### PR TITLE
Fix/mnt 18404 image magick fails on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ target
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 
 hs_err_pid*
+alf_data
+/src/main/resources/alfresco-global.properties
+/src/main/resources/alfresco/extension/custom-log4j.properties

--- a/src/main/resources/alfresco-global.properties.sample
+++ b/src/main/resources/alfresco-global.properties.sample
@@ -29,7 +29,6 @@
 #
 #img.coders=${img.root}/modules/coders
 #img.config=${img.root}/config
-#img.gslib=${img.root}/lib
 
 #
 # Property to control whether schema updates are performed automatically.

--- a/src/main/resources/alfresco/subsystems/thirdparty/default/alfresco-pdf-renderer-transform-context.xml
+++ b/src/main/resources/alfresco/subsystems/thirdparty/default/alfresco-pdf-renderer-transform-context.xml
@@ -20,7 +20,7 @@
                   </entry>
                </map>
             </property>
-            <property name="processProperties" ref="#{systemProperties['os.name'].contains('Windows') ? 'processPropertiesWindows' : 'processPropertiesUnix'}" />
+            <property name="processProperties" ref="#{systemProperties['os.name'].contains('Windows') ? 'transformer.worker.subsys.alfresco-pdf-renderer.processPropertiesWindows' : 'transformer.worker.subsys.alfresco-pdf-renderer.processPropertiesUnix'}" />
             <property name="defaultProperties">
                <props>
                   <prop key="options"></prop>
@@ -47,7 +47,7 @@
       </property>
    </bean>
 
-   <bean id="processPropertiesWindows" class="org.springframework.beans.factory.config.MapFactoryBean">
+   <bean id="transformer.worker.subsys.alfresco-pdf-renderer.processPropertiesWindows" class="org.springframework.beans.factory.config.MapFactoryBean">
       <property name="sourceMap"> 
          <map>
             <entry key="ALFRESCO-PDF-RENDERER_HOME">
@@ -57,7 +57,7 @@
       </property>
    </bean>
 
-   <bean id="processPropertiesUnix" class="org.springframework.beans.factory.config.MapFactoryBean">
+   <bean id="transformer.worker.subsys.alfresco-pdf-renderer.processPropertiesUnix" class="org.springframework.beans.factory.config.MapFactoryBean">
       <property name="sourceMap">
          <map>
             <entry key="ALFRESCO-PDF-RENDERER_HOME">

--- a/src/main/resources/alfresco/subsystems/thirdparty/default/imagemagick-transform-context.xml
+++ b/src/main/resources/alfresco/subsystems/thirdparty/default/imagemagick-transform-context.xml
@@ -22,7 +22,7 @@
                   </entry>
                </map>
             </property>
-            <property name="processProperties" ref="#{systemProperties['os.name'].contains('Windows') ? 'processPropertiesWindows' : 'processPropertiesUnix'}" />
+            <property name="processProperties" ref="#{systemProperties['os.name'].contains('Windows') ? 'transformer.worker.ImageMagick.processPropertiesWindows' : 'transformer.worker.ImageMagick.processPropertiesUnix'}" />
             <property name="defaultProperties">
                <props>
                   <prop key="options"></prop>
@@ -50,7 +50,7 @@
       </property>
    </bean>
 
-   <bean id="processPropertiesWindows" class="org.springframework.beans.factory.config.MapFactoryBean">
+   <bean id="transformer.worker.ImageMagick.processPropertiesWindows" class="org.springframework.beans.factory.config.MapFactoryBean">
       <property name="sourceMap"> 
          <map>
             <entry key="MAGICK_HOME">
@@ -62,9 +62,6 @@
             <entry key="MAGICK_CONFIGURE_PATH">
                <value>${img.config}</value>
             </entry>
-            <entry key="GS_LIB">
-               <value>${img.gslib}</value>
-            </entry>
             <entry key="DYLD_FALLBACK_LIBRARY_PATH">
                <value>${img.dyn}</value>
             </entry>
@@ -75,7 +72,7 @@
       </property>
    </bean>
 
-   <bean id="processPropertiesUnix" class="org.springframework.beans.factory.config.MapFactoryBean">
+   <bean id="transformer.worker.ImageMagick.processPropertiesUnix" class="org.springframework.beans.factory.config.MapFactoryBean">
       <property name="sourceMap">
          <map>
             <entry key="MAGICK_HOME">

--- a/src/main/resources/alfresco/subsystems/thirdparty/default/imagemagick-transform.properties
+++ b/src/main/resources/alfresco/subsystems/thirdparty/default/imagemagick-transform.properties
@@ -4,4 +4,3 @@ img.dyn=${img.root}/lib
 img.exe=${img.root}/bin/convert
 img.coders=${img.root}/modules/coders
 img.config=${img.root}/config
-img.gslib=

--- a/src/test/java/org/alfresco/repo/content/transform/magick/ImageMagickContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/magick/ImageMagickContentTransformerTest.java
@@ -120,12 +120,24 @@ public class ImageMagickContentTransformerTest extends AbstractContentTransforme
         }
     }
     
+    public void testGifToPng() throws Exception
+    {
+        ImageTransformationOptions options = new ImageTransformationOptions();
+        transform(MimetypeMap.MIMETYPE_IMAGE_GIF, MimetypeMap.MIMETYPE_IMAGE_PNG, options);
+    }
+        
+    public void testJpegToPng() throws Exception
+    {
+        ImageTransformationOptions options = new ImageTransformationOptions();
+        transform(MimetypeMap.MIMETYPE_IMAGE_JPEG, MimetypeMap.MIMETYPE_IMAGE_PNG, options);
+    }
+
     public void testPageSourceOptions() throws Exception
     {
         // Test empty source options
         ImageTransformationOptions options = new ImageTransformationOptions();
         this.transform(MimetypeMap.MIMETYPE_PDF, MimetypeMap.MIMETYPE_IMAGE_PNG, options);
-        
+
         // Test first page
         options = new ImageTransformationOptions();
         List<TransformationSourceOptions> sourceOptionsList = new ArrayList<TransformationSourceOptions>();


### PR DESCRIPTION
Contains fix for bug and removal of img.gslib that was not fully removed as part of the REPO-2054.