### PR TITLE
MNT-17706: Bulk Import: Error message does not give hints about the f…

### DIFF
--- a/src/main/java/org/alfresco/repo/bulkimport/metadataloaders/AbstractMapBasedMetadataLoader.java
+++ b/src/main/java/org/alfresco/repo/bulkimport/metadataloaders/AbstractMapBasedMetadataLoader.java
@@ -101,14 +101,27 @@ abstract class AbstractMapBasedMetadataLoader implements MetadataLoader
      */
     abstract protected Map<String,Serializable> loadMetadataFromFile(final Path metadataFile);
 
-
     @Override
     public final void loadMetadata(final ContentAndMetadata contentAndMetadata, Metadata metadata)
     {
         if (contentAndMetadata.metadataFileExists())
         {
             final Path metadataFile = contentAndMetadata.getMetadataFile();
+            final String metadataFilePath = FileUtils.getFileName(metadataFile);
+            try
+            {
+                loadMetadataInternal(metadata, metadataFile, metadataFilePath);
+            }
+            catch (Exception e)
+            {
+                log.error("Error encountered when reading metadata file '" + metadataFilePath + "'.");
+                throw new RuntimeException("Exception from reading file: '" + metadataFilePath + "'.", e);
+            }
+        }
+    }
 
+    private void loadMetadataInternal(Metadata metadata, Path metadataFile, String metadataFilePath)
+    {
             if (Files.isReadable(metadataFile))
             {
                 Map<String,Serializable> metadataProperties = loadMetadataFromFile(metadataFile);
@@ -154,16 +167,15 @@ abstract class AbstractMapBasedMetadataLoader implements MetadataLoader
                     	}
                     	else
                     	{
-                    	    if (log.isWarnEnabled()) log.warn("Property " + String.valueOf(name) + " doesn't exist in the Data Dictionary.  Ignoring it.");
+                    	    if (log.isWarnEnabled()) log.warn("Property " + String.valueOf(name) + " from '" + metadataFilePath + "' doesn't exist in the Data Dictionary.  Ignoring it.");
                     	}
                     }
                 }
             }
             else
             {
-                if (log.isWarnEnabled()) log.warn("Metadata file '" + FileUtils.getFileName(metadataFile) + "' is not readable.");
+                if (log.isWarnEnabled()) log.warn("Metadata file '" + metadataFilePath + "' is not readable.");
             }
-        }
     }
 
 }

--- a/src/main/java/org/alfresco/repo/bulkimport/metadataloaders/AbstractMapBasedMetadataLoader.java
+++ b/src/main/java/org/alfresco/repo/bulkimport/metadataloaders/AbstractMapBasedMetadataLoader.java
@@ -123,60 +123,64 @@ abstract class AbstractMapBasedMetadataLoader implements MetadataLoader
     private void loadMetadataInternal(Metadata metadata, final Path metadataFile)
     {
         final String metadataFilePath = FileUtils.getFileName(metadataFile);
-            if (Files.isReadable(metadataFile))
+        if (Files.isReadable(metadataFile))
+        {
+            Map<String, Serializable> metadataProperties = loadMetadataFromFile(metadataFile);
+
+            for (String key : metadataProperties.keySet())
             {
-                Map<String,Serializable> metadataProperties = loadMetadataFromFile(metadataFile);
-                
-                for (String key : metadataProperties.keySet())
+                if (PROPERTY_NAME_TYPE.equals(key))
                 {
-                    if (PROPERTY_NAME_TYPE.equals(key))
+                    String typeName = (String) metadataProperties.get(key);
+                    QName type = QName.createQName(typeName, namespaceService);
+
+                    metadata.setType(type);
+                }
+                else if (PROPERTY_NAME_ASPECTS.equals(key))
+                {
+                    String[] aspectNames = ((String) metadataProperties.get(key)).split(",");
+
+                    for (final String aspectName : aspectNames)
                     {
-                        String typeName = (String)metadataProperties.get(key);
-                        QName  type     = QName.createQName(typeName, namespaceService);
-                        
-                        metadata.setType(type);
+                        QName aspect = QName.createQName(aspectName.trim(), namespaceService);
+                        metadata.addAspect(aspect);
                     }
-                    else if (PROPERTY_NAME_ASPECTS.equals(key))
+                }
+                else // Any other key => property
+                {
+                    // ####TODO: figure out how to handle properties of type cm:content - they need to be streamed in via a Writer
+                    QName name = QName.createQName(key, namespaceService);
+                    PropertyDefinition propertyDefinition = dictionaryService.getProperty(name);// TODO: measure performance impact of this API call!!
+
+                    if (propertyDefinition != null)
                     {
-                        String[] aspectNames = ((String)metadataProperties.get(key)).split(",");
-                        
-                        for (final String aspectName : aspectNames)
+                        if (propertyDefinition.isMultiValued())
                         {
-                            QName aspect = QName.createQName(aspectName.trim(), namespaceService);
-                            metadata.addAspect(aspect);
+                            // Multi-valued property
+                            ArrayList<Serializable> values = new ArrayList<Serializable>(
+                                    Arrays.asList(((String) metadataProperties.get(key)).split(multiValuedSeparator)));
+                            metadata.addProperty(name, values);
+                        }
+                        else
+                        {
+                            // Single value property
+                            metadata.addProperty(name, metadataProperties.get(key));
                         }
                     }
-                    else  // Any other key => property
+                    else
                     {
-                        //####TODO: figure out how to handle properties of type cm:content - they need to be streamed in via a Writer 
-                    	QName              name               = QName.createQName(key, namespaceService);
-                    	PropertyDefinition propertyDefinition = dictionaryService.getProperty(name);  // TODO: measure performance impact of this API call!!
-                    	
-                    	if (propertyDefinition != null)
-                    	{
-                        	if (propertyDefinition.isMultiValued())
-                        	{
-                                // Multi-valued property
-                        		ArrayList<Serializable> values = new ArrayList<Serializable>(Arrays.asList(((String)metadataProperties.get(key)).split(multiValuedSeparator)));
-                        	    metadata.addProperty(name, values);
-                        	}
-                        	else
-                        	{
-                        	    // Single value property
-                        		metadata.addProperty(name, metadataProperties.get(key));
-                        	}
-                    	}
-                    	else
-                    	{
-                    	    if (log.isWarnEnabled()) log.warn("Property " + String.valueOf(name) + " from '" + metadataFilePath + "' doesn't exist in the Data Dictionary.  Ignoring it.");
-                    	}
+                        if (log.isWarnEnabled())
+                            log.warn("Property " + String.valueOf(name) + " from '" + metadataFilePath
+                                    + "' doesn't exist in the Data Dictionary.  Ignoring it.");
                     }
                 }
             }
-            else
-            {
-                if (log.isWarnEnabled()) log.warn("Metadata file '" + metadataFilePath + "' is not readable.");
-            }
+        }
+        else
+        {
+            if (log.isWarnEnabled())
+                log.warn("Metadata file '" + metadataFilePath + "' is not readable.");
+        }
     }
 
 }

--- a/src/main/java/org/alfresco/repo/bulkimport/metadataloaders/AbstractMapBasedMetadataLoader.java
+++ b/src/main/java/org/alfresco/repo/bulkimport/metadataloaders/AbstractMapBasedMetadataLoader.java
@@ -107,10 +107,10 @@ abstract class AbstractMapBasedMetadataLoader implements MetadataLoader
         if (contentAndMetadata.metadataFileExists())
         {
             final Path metadataFile = contentAndMetadata.getMetadataFile();
-            final String metadataFilePath = FileUtils.getFileName(metadataFile);
+            String metadataFilePath = FileUtils.getFileName(metadataFile);
             try
             {
-                loadMetadataInternal(metadata, metadataFile, metadataFilePath);
+                loadMetadataInternal(metadata, metadataFile);
             }
             catch (Exception e)
             {
@@ -120,8 +120,9 @@ abstract class AbstractMapBasedMetadataLoader implements MetadataLoader
         }
     }
 
-    private void loadMetadataInternal(Metadata metadata, Path metadataFile, String metadataFilePath)
+    private void loadMetadataInternal(Metadata metadata, final Path metadataFile)
     {
+        final String metadataFilePath = FileUtils.getFileName(metadataFile);
             if (Files.isReadable(metadataFile))
             {
                 Map<String,Serializable> metadataProperties = loadMetadataFromFile(metadataFile);


### PR DESCRIPTION
 Bulk Import: Error message does not give hints about the file triggering the error

Catch the exception and throw new one that appends the metadata file path and the cause. In case of an exception, the file path will be displayed in alfresco.log and in bulk import status page.