### PR TITLE
REPO-2575: added property loader pattern for non-enterprise projects

### DIFF
--- a/src/main/resources/alfresco/core-services-context.xml
+++ b/src/main/resources/alfresco/core-services-context.xml
@@ -27,7 +27,7 @@
                 <value>classpath:alfresco/domain/transaction.properties</value>
                 <value>classpath:alfresco/caches.properties</value>
                 <!-- Defaults for "decomposed" non-enterprise projects, e.g. alfresco-remote-api -->
-                <value>classpath*:alfresco/project.properties</value>
+                <value>classpath*:alfresco/project-*.properties</value>
                 <!-- Enterprise defaults -->
                 <!--  Overrides supplied if this is an enterprise install (none exist for community) -->
                 <value>classpath*:alfresco/enterprise/caches.properties</value>

--- a/src/main/resources/alfresco/core-services-context.xml
+++ b/src/main/resources/alfresco/core-services-context.xml
@@ -26,6 +26,8 @@
                 <value>classpath:alfresco/repository.properties</value>
                 <value>classpath:alfresco/domain/transaction.properties</value>
                 <value>classpath:alfresco/caches.properties</value>
+                <!-- Defaults for "decomposed" non-enterprise projects, e.g. alfresco-remote-api -->
+                <value>classpath*:alfresco/project.properties</value>
                 <!-- Enterprise defaults -->
                 <!--  Overrides supplied if this is an enterprise install (none exist for community) -->
                 <value>classpath*:alfresco/enterprise/caches.properties</value>


### PR DESCRIPTION
Now that we have "decomposed" various parts of the mega-monolith repository
into smaller projects such as alfresco-remote-api, we need a mechanism for
adding new system properties within the project that requires them.

For example, to add a new boolean/toggle for the WWW-Authenticate behaviour
in the remote API project, we don't want that setting to go in
alfresco-repository - we want it to live in alfresco-remote-api. So this
extra pattern (classpath*:alfresco/project.properties) is being added to
load these project specific properties.