### PR TITLE
REPO-3013 Fix security config for PermissionService

### DIFF
--- a/src/main/resources/alfresco/public-services-security-context.xml
+++ b/src/main/resources/alfresco/public-services-security-context.xml
@@ -768,6 +768,7 @@
                 org.alfresco.service.cmr.security.PermissionService.getAllSetPermissions=ACL_NODE.0.sys:base.ReadPermissions
                 org.alfresco.service.cmr.security.PermissionService.getSettablePermissions=ACL_ALLOW
                 org.alfresco.service.cmr.security.PermissionService.hasPermission=ACL_ALLOW
+                org.alfresco.service.cmr.security.PermissionService.hasReadPermission=ACL_ALLOW
                 org.alfresco.service.cmr.security.PermissionService.getReaders=ACL_METHOD.ROLE_ADMINISTRATOR
                 org.alfresco.service.cmr.security.PermissionService.deletePermissions=ACL_NODE.0.sys:base.ChangePermissions
                 org.alfresco.service.cmr.security.PermissionService.deletePermission=ACL_NODE.0.sys:base.ChangePermissions
@@ -775,6 +776,7 @@
                 org.alfresco.service.cmr.security.PermissionService.setInheritParentPermissions=ACL_NODE.0.sys:base.ChangePermissions
                 org.alfresco.service.cmr.security.PermissionService.getInheritParentPermissions=ACL_ALLOW
                 org.alfresco.service.cmr.security.PermissionService.clearPermission=ACL_NODE.0.sys:base.ChangePermissions
+                org.alfresco.service.cmr.security.PermissionService.getAuthorisations=ACL_DENY
                 org.alfresco.service.cmr.security.PermissionService.*=ACL_DENY
             </value>
         </property>

--- a/src/test/java/org/alfresco/repo/security/permissions/impl/PermissionServiceTest.java
+++ b/src/test/java/org/alfresco/repo/security/permissions/impl/PermissionServiceTest.java
@@ -92,10 +92,62 @@ public class PermissionServiceTest extends AbstractPermissionTest
 
     public void testPublicAccessService()
     {
+        AuthenticationUtil.clearCurrentSecurityContext();
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getOwnerAuthority") ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAllAuthorities") ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAllPermission") ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getSettablePermissions", rootNodeRef) ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "hasPermission", rootNodeRef, PermissionService.READ_PERMISSIONS) ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "hasReadPermission", rootNodeRef) ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getInheritParentPermissions", rootNodeRef) ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAuthorisations") ==  AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getPermissions", rootNodeRef) ==  AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAllSetPermissions", rootNodeRef) ==  AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAllPermission") ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "deletePermissions", rootNodeRef) ==  AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "deletePermission", rootNodeRef, "andy", PermissionService.READ_PERMISSIONS) ==  AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "setPermission", rootNodeRef, "andy", PermissionService.READ_PERMISSIONS, true) ==  AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "setInheritParentPermissions", rootNodeRef, true) ==  AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "clearPermission", rootNodeRef, "andy") ==  AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAuthorisations") ==  AccessStatus.DENIED);
+
         runAs("admin");
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getOwnerAuthority") ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAllAuthorities") ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAllPermission") ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getSettablePermissions", rootNodeRef) ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "hasPermission", rootNodeRef, PermissionService.READ_PERMISSIONS) ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "hasReadPermission", rootNodeRef) ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getReaders", nodeService.getNodeAclId(rootNodeRef)) == AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getPermissions", rootNodeRef) ==  AccessStatus.ALLOWED);
         assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAllSetPermissions", rootNodeRef) ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAllPermission") ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "deletePermissions", rootNodeRef) ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "deletePermission", rootNodeRef, "andy", PermissionService.READ_PERMISSIONS) ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "setPermission", rootNodeRef, "andy", PermissionService.READ_PERMISSIONS, true) ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "setInheritParentPermissions", rootNodeRef, true) ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "clearPermission", rootNodeRef, "andy") ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAuthorisations") ==  AccessStatus.DENIED);
+
         assertTrue(publicServiceAccessService.hasAccess("SiteService", "createSite", "", "", "", "", true) == AccessStatus.ALLOWED);
-      
+
+        runAs("andy");
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getOwnerAuthority") ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAllAuthorities") ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAllPermission") ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getSettablePermissions", rootNodeRef) ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "hasPermission", rootNodeRef, PermissionService.READ_PERMISSIONS) ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "hasReadPermission", rootNodeRef) ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getReaders", nodeService.getNodeAclId(rootNodeRef)) == AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getPermissions", rootNodeRef) ==  AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAllSetPermissions", rootNodeRef) ==  AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAllPermission") ==  AccessStatus.ALLOWED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "deletePermissions", rootNodeRef) ==  AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "deletePermission", rootNodeRef, "andy", PermissionService.READ_PERMISSIONS) ==  AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "setPermission", rootNodeRef, "andy", PermissionService.READ_PERMISSIONS, true) ==  AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "setInheritParentPermissions", rootNodeRef, true) ==  AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "clearPermission", rootNodeRef, "andy") ==  AccessStatus.DENIED);
+        assertTrue(publicServiceAccessService.hasAccess("PermissionService", "getAuthorisations") ==  AccessStatus.DENIED);
     }
     
     public void testAnyDenyDeniesAndRead()


### PR DESCRIPTION
The PermissionService had security config for two methods missing:
* hasReadPermission
* getAuthorisations

getAuthorisations was duplicated as ACL_DENY as it is a system only performance method.