### PR TITLE
REPO-2896: Redundant "baseMetadataExtracter" bean definition in conte…

### DIFF
--- a/src/main/resources/alfresco/content-services-context.xml
+++ b/src/main/resources/alfresco/content-services-context.xml
@@ -256,7 +256,6 @@
    
    <!-- Abstract bean definition defining base definition for all metadata extracters -->
    <bean id="baseMetadataExtracter"
-         class="org.alfresco.repo.content.metadata.AbstractMetadataExtracter"
          abstract="true"
          init-method="register">
       <property name="registry">


### PR DESCRIPTION
…nt-services-context.xml

* Remove class attribute from baseMetadataExtracter bean definition