### PR TITLE
REPO-3040 Make TransferVersionCheckerImpl less restrictive

### DIFF
--- a/src/main/java/org/alfresco/repo/transfer/TransferVersionCheckerImpl.java
+++ b/src/main/java/org/alfresco/repo/transfer/TransferVersionCheckerImpl.java
@@ -32,7 +32,7 @@ import org.apache.commons.logging.LogFactory;
 /**
  * This is an implementation of TransferVersionChecker.
  * 
- * It allows transfer to the same edition/major/minor but ignores revision.
+ * It allows transfer to the same major version.
  */
 public class TransferVersionCheckerImpl implements TransferVersionChecker
 {
@@ -42,26 +42,16 @@ public class TransferVersionCheckerImpl implements TransferVersionChecker
     {
         logger.debug("checkTransferVersions from:" + from + ", to:" + to);
         
-        if(from == null || to == null || to.getEdition() == null || to.getVersionMajor() == null || to.getVersionMinor() == null)
+        if(from == null || to == null || to.getVersionMajor() == null)
         {
             return false;
         }
-        
-        if(!from.getEdition().equalsIgnoreCase(to.getEdition()))
-        {
-            return false;
-        }
-        
+
         if(!from.getVersionMajor().equalsIgnoreCase(to.getVersionMajor()))
         {
             return false;
         }
-        
-        if(!from.getVersionMinor().equalsIgnoreCase(to.getVersionMinor()))
-        {
-            return false;
-        }
-        
+
         // ignore revisions
         
         return true;

--- a/src/main/java/org/alfresco/repo/transfer/TransferVersionCheckerImpl.java
+++ b/src/main/java/org/alfresco/repo/transfer/TransferVersionCheckerImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2017 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -42,7 +42,7 @@ public class TransferVersionCheckerImpl implements TransferVersionChecker
     {
         logger.debug("checkTransferVersions from:" + from + ", to:" + to);
         
-        if(from == null || to == null || to.getVersionMajor() == null)
+        if(from == null || to == null || from.getVersionMajor() == null || to.getVersionMajor() == null)
         {
             return false;
         }

--- a/src/test/java/org/alfresco/AllUnitTestsSuite.java
+++ b/src/test/java/org/alfresco/AllUnitTestsSuite.java
@@ -74,6 +74,7 @@ import org.junit.runners.Suite;
     org.alfresco.repo.transfer.ContentChunkerImplTest.class,
     org.alfresco.repo.transfer.HttpClientTransmitterImplTest.class,
     org.alfresco.repo.transfer.manifest.TransferManifestTest.class,
+    org.alfresco.repo.transfer.TransferVersionCheckerImplTest.class,
     org.alfresco.repo.urlshortening.BitlyUrlShortenerTest.class,
     org.alfresco.service.cmr.calendar.CalendarRecurrenceHelperTest.class,
     org.alfresco.service.cmr.calendar.CalendarTimezoneHelperTest.class,

--- a/src/test/java/org/alfresco/AppContext04TestSuite.java
+++ b/src/test/java/org/alfresco/AppContext04TestSuite.java
@@ -81,7 +81,6 @@ import org.junit.runners.Suite;
     org.alfresco.repo.transfer.TransferServiceCallbackTest.class,
     org.alfresco.repo.transfer.TransferServiceImplTest.class,
     org.alfresco.repo.transfer.TransferServiceToBeRefactoredTest.class,
-    org.alfresco.repo.transfer.TransferVersionCheckerImplTest.class,
     org.alfresco.repo.transfer.manifest.ManifestIntegrationTest.class,
     org.alfresco.repo.transfer.script.ScriptTransferServiceTest.class,
     org.alfresco.util.schemacomp.DbToXMLTest.class,

--- a/src/test/java/org/alfresco/repo/transfer/TransferVersionCheckerImplTest.java
+++ b/src/test/java/org/alfresco/repo/transfer/TransferVersionCheckerImplTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2017 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -26,20 +26,21 @@
 package org.alfresco.repo.transfer;
 
 import org.alfresco.service.cmr.transfer.TransferVersion;
-import org.alfresco.test_category.BaseSpringTestsCategory;
-import org.alfresco.util.BaseAlfrescoSpringTest;
-import org.junit.experimental.categories.Category;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit test for TransferVersionChecker
  * @author mrogers
  */
-@Category(BaseSpringTestsCategory.class)
-public class TransferVersionCheckerImplTest extends BaseAlfrescoSpringTest 
+public class TransferVersionCheckerImplTest
 {
     /**
      * Test TransferVersionCheckerImpl
      */
+    @Test
     public void testTransferVersionCheckerImpl()
     {
         
@@ -61,11 +62,10 @@ public class TransferVersionCheckerImplTest extends BaseAlfrescoSpringTest
         assertTrue("not equals", checker.checkTransferVersions(e, new TransferVersionImpl("3", "3", "1", EDITION)));
         assertTrue("not equals", checker.checkTransferVersions(e, new TransferVersionImpl("3", "3", "2", EDITION)));
         
-        // These should not match
-        assertFalse("not equals minor different", checker.checkTransferVersions(e, new TransferVersionImpl("3", "4", "0", EDITION)));     
-        assertFalse("not equals major different", checker.checkTransferVersions(e, new TransferVersionImpl("4", "3", "0", EDITION)));     
-        assertFalse("not equals edition different", checker.checkTransferVersions(e, new TransferVersionImpl("3", "3", "0", "Whatever")));     
-        assertFalse("not equals edition null ", checker.checkTransferVersions(e, new TransferVersionImpl("3", "3", "0", null)));                        
+        assertTrue("Checker should not flag minor difference", checker.checkTransferVersions(e, new TransferVersionImpl("3", "4", "0", EDITION)));
+        assertFalse("Checker should flag major difference", checker.checkTransferVersions(e, new TransferVersionImpl("4", "3", "0", EDITION)));
+        assertTrue("Checker should not flag edition difference", checker.checkTransferVersions(e, new TransferVersionImpl("3", "3", "0", "Whatever")));
+        assertTrue("Checker should not flag edition absence", checker.checkTransferVersions(e, new TransferVersionImpl("3", "3", "0", null)));
     }
 
 }


### PR DESCRIPTION
As FTR is now a separate project it is not feasible to check the minor version and edition during transfer.
Now only major version is checked (6 in this case). 