### PR TITLE
REPO-2828: add 'description' for shared link info

### DIFF
--- a/src/main/java/org/alfresco/repo/quickshare/QuickShareServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/quickshare/QuickShareServiceImpl.java
@@ -570,6 +570,7 @@ public class QuickShareServiceImpl implements QuickShareService,
         metadata.put("nodeRef", nodeRef.toString());
         metadata.put("name", nodeProps.get(ContentModel.PROP_NAME));
         metadata.put("title", nodeProps.get(ContentModel.PROP_TITLE));
+        metadata.put("description", nodeProps.get(ContentModel.PROP_DESCRIPTION));
         
         if (contentData != null)
         {


### PR DESCRIPTION
The metadata regarding a shared document must include the `cm:description` property.

This minor change needs releasing in the repository jar so that `alfresco-remote-api` may have its pom.xml updated to use the new version and so have the description property available in the quick share link REST API.

I would have added a test case, but there didn’t seem anything appropriate to add it to (and creating a whole test for a single property addition didn’t seem useful right now)

Of course there are REST API tests coming up that fail without this repo addition, so it is tested there.

Build:
https://bamboo.alfresco.com/bamboo/browse/PLAT-REP47

