### PR TITLE
REPO-3109: Brute force protection can be bypassed by changing username case

### DIFF
--- a/src/main/java/org/alfresco/repo/security/authentication/AuthenticationServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/security/authentication/AuthenticationServiceImpl.java
@@ -109,6 +109,18 @@ public class AuthenticationServiceImpl extends AbstractAuthenticationService imp
                 || ((ActivateableBean) this.authenticationComponent).isActive();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    private boolean getUserNamesAreCaseSensitive()
+    {
+        if (personService != null)
+        {
+            return personService.getUserNamesAreCaseSensitive();
+        }
+        return false;
+    }
+
     public void authenticate(String userName, char[] password) throws AuthenticationException
     {
         try
@@ -204,6 +216,10 @@ public class AuthenticationServiceImpl extends AbstractAuthenticationService imp
      */
     public String getProtectedUserKey(String userName)
     {
+        if (!getUserNamesAreCaseSensitive())
+        {
+            userName = userName.toLowerCase();
+        }
         return serviceInstanceId + "@@" + userName;
     }
 


### PR DESCRIPTION

 The protection respects the setting of user.name.caseSensitive property (default is false).