### PR TITLE
Feature/repo 3112

### DIFF
--- a/src/main/java/org/alfresco/repo/security/permissions/impl/PermissionServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/security/permissions/impl/PermissionServiceImpl.java
@@ -1033,7 +1033,7 @@ public class PermissionServiceImpl extends AbstractLifecycleBean implements Perm
         permissionsDaoComponent.deletePermission(tenantService.getName(nodeRef), authority, perm);
         accessCache.clear();
         
-        invokeUpdateLocalPermissionsPolicy(nodeRef, authority, perm.getName(), false);
+        invokeUpdateLocalPermissionsPolicy(nodeRef, authority, (perm != null? perm.getName():null), false);
     }
     
     private void invokeUpdateLocalPermissionsPolicy(NodeRef nodeRef, String authority, String permission, boolean grantPermission)

--- a/src/test/java/org/alfresco/repo/security/permissions/impl/AbstractPermissionTest.java
+++ b/src/test/java/org/alfresco/repo/security/permissions/impl/AbstractPermissionTest.java
@@ -56,6 +56,7 @@ import org.alfresco.service.cmr.security.AuthorityService;
 import org.alfresco.service.cmr.security.MutableAuthenticationService;
 import org.alfresco.service.cmr.security.PersonService;
 import org.alfresco.service.cmr.security.PublicServiceAccessService;
+import org.alfresco.service.cmr.site.SiteService;
 import org.alfresco.service.namespace.NamespacePrefixResolver;
 import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
@@ -69,6 +70,8 @@ public class AbstractPermissionTest extends TestCase
     protected static final String USER2_LEMUR = "lemur";
 
     protected static final String USER1_ANDY = "andy";
+    
+    protected static final String USER3_PAUL ="paul";
 
     protected static ApplicationContext applicationContext = ApplicationContextHelper.getApplicationContext();
     
@@ -122,6 +125,8 @@ public class AbstractPermissionTest extends TestCase
 
     protected PolicyComponent policyComponent;
     
+    protected SiteService siteService;
+    
     public AbstractPermissionTest()
     {
         super();
@@ -151,6 +156,7 @@ public class AbstractPermissionTest extends TestCase
         personService = (PersonService) applicationContext.getBean("personService");
         authorityService = (AuthorityService) applicationContext.getBean("authorityService");
         authorityDAO = (AuthorityDAO) applicationContext.getBean("authorityDAO");
+        siteService = (SiteService) applicationContext.getBean("SiteService"); // Big 'S'
         
         authenticationComponent.setCurrentUser(authenticationComponent.getSystemUserName());
         authenticationDAO = (MutableAuthenticationDao) applicationContext.getBean("authenticationDao");
@@ -195,6 +201,12 @@ public class AbstractPermissionTest extends TestCase
             authenticationService.deleteAuthentication(USER2_LEMUR);
         }
         authenticationService.createAuthentication(USER2_LEMUR, USER2_LEMUR.toCharArray());
+        
+        if(authenticationDAO.userExists(USER3_PAUL))
+        {
+            authenticationService.deleteAuthentication(USER3_PAUL);
+        }
+        authenticationService.createAuthentication(USER3_PAUL, USER3_PAUL.toCharArray());
         
         if(authenticationDAO.userExists(AuthenticationUtil.getAdminUserName()))
         {

--- a/src/test/java/org/alfresco/repo/security/permissions/impl/PermissionServiceTest.java
+++ b/src/test/java/org/alfresco/repo/security/permissions/impl/PermissionServiceTest.java
@@ -4085,19 +4085,19 @@ public class PermissionServiceTest extends AbstractPermissionTest
             permissionService.setPermission(siteInfo.getNodeRef(), USER1_ANDY, PermissionService.WRITE, true);
             permissionService.setPermission(siteInfo.getNodeRef(), USER1_ANDY, PermissionService.CHANGE_PERMISSIONS, true);
 
-            // case1 delete a specific permission
+            //case1 delete a specific permission
             permissionService.deletePermission(siteInfo.getNodeRef(), USER1_ANDY, PermissionService.CONTRIBUTOR);
             verify(onRevokeLocalPermission).onRevokeLocalPermission(siteInfo.getNodeRef(), USER1_ANDY,
                             PermissionService.CONTRIBUTOR);
 
-            // case2 delete all permissions for an authority
+            //case2 delete all permissions for an authority
             permissionService.deletePermission(siteInfo.getNodeRef(), USER1_ANDY, null);
             verify(onRevokeLocalPermission).onRevokeLocalPermission(siteInfo.getNodeRef(), USER1_ANDY, null);
 
             permissionService.setPermission(siteInfo.getNodeRef(), USER1_ANDY, PermissionService.CONTRIBUTOR, true);
             permissionService.setPermission(siteInfo.getNodeRef(), USER3_PAUL, PermissionService.CONTRIBUTOR, true);
-            // case3 entries for all authorities that have a specific permission (if
-            // the authority is null)
+           
+            //case3 entries for all authorities that have a specific permission
             permissionService.deletePermission(siteInfo.getNodeRef(), null, PermissionService.CONTRIBUTOR);
             verify(onRevokeLocalPermission).onRevokeLocalPermission(siteInfo.getNodeRef(), null,
                             PermissionService.CONTRIBUTOR);
@@ -4106,8 +4106,8 @@ public class PermissionServiceTest extends AbstractPermissionTest
             permissionService.setPermission(siteInfo.getNodeRef(), USER1_ANDY, PermissionService.WRITE, true);
             permissionService.setPermission(siteInfo.getNodeRef(), USER1_ANDY, PermissionService.CHANGE_PERMISSIONS, true);
             permissionService.setPermission(siteInfo.getNodeRef(), USER3_PAUL, PermissionService.CONTRIBUTOR, true);
-            // case4 all permissions set for the node (if both the permission and
-            // authority are null).
+           
+            //case4 delete all permissions set for the node
             permissionService.deletePermission(siteInfo.getNodeRef(), null, null);
             verify(onRevokeLocalPermission).onRevokeLocalPermission(siteInfo.getNodeRef(), null, null);
 


### PR DESCRIPTION
REPO 3112 : PermissionService throws NullpointerException when trying to delete all permission on a node