### PR TITLE
REPO-3107/MNT-18764: workflow admin security bypass

### DIFF
--- a/src/main/java/org/alfresco/repo/workflow/WorkflowDefinitionType.java
+++ b/src/main/java/org/alfresco/repo/workflow/WorkflowDefinitionType.java
@@ -25,9 +25,6 @@
  */
 package org.alfresco.repo.workflow;
 
-import java.io.Serializable;
-import java.util.Map;
-
 import org.alfresco.repo.content.ContentServicePolicies;
 import org.alfresco.repo.node.NodeServicePolicies;
 import org.alfresco.repo.policy.JavaBehaviour;
@@ -35,6 +32,9 @@ import org.alfresco.repo.policy.PolicyComponent;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
+
+import java.io.Serializable;
+import java.util.Map;
 
 /**
  * Workflow Definition type behaviour.
@@ -70,7 +70,7 @@ public class WorkflowDefinitionType implements ContentServicePolicies.OnContentU
     {
         this.workflowDeployer = workflowDeployer;
     }
-    
+
     /**
      * The initialise method     
      */

--- a/src/test/java/org/alfresco/repo/workflow/activiti/ActivitiWorkflowServiceIntegrationTest.java
+++ b/src/test/java/org/alfresco/repo/workflow/activiti/ActivitiWorkflowServiceIntegrationTest.java
@@ -700,6 +700,28 @@ public class ActivitiWorkflowServiceIntegrationTest extends AbstractWorkflowServ
         assertNull("Workflow should not be deployed", workflowDef);
     }
     
+    public void testNonAdminCannotDeployWorkflowBySwitchingNodeTypeEvenInCorrectLocation()
+    {
+        // Test precondition
+        assertNull(workflowService.getDefinitionByName("activiti$testProcess"));
+        
+        AuthenticationUtil.setFullyAuthenticatedUser(USER1);
+        NodeRef workflowParent = findWorkflowParent();
+        
+        try
+        {
+            createContentAndSwitchToWorkflow(
+                    "activiti$testProcess",
+                    "alfresco/workflow/test-security.bpmn20.xml",
+                    workflowParent);
+            fail("User should not be able to create a node in the 'correct location'.");
+        }
+        catch (AccessDeniedException e)
+        {
+            // Good!
+        }
+    }
+    
     public void testAdminCanDeployBySwitchingContentTypeToWorkflow()
     {
         // This test should pass, as the workflow is in the correct location

--- a/src/test/resources/alfresco/workflow/test-security.bpmn20.xml
+++ b/src/test/resources/alfresco/workflow/test-security.bpmn20.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:activiti="http://activiti.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema"
+             expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://alfresco.org">
+
+    <process isExecutable="true" id="testProcess" name="Testing security etc.">
+
+        <startEvent id="start"
+                    activiti:formKey="wf:submitGroupReviewTask" />
+
+        <sequenceFlow id='flow1'
+                      sourceRef='start'
+                      targetRef='reviewTask' />
+
+        <userTask id="reviewTask" name="Review Task"
+                  activiti:formKey="wf:activitiReviewTask">
+            <extensionElements>
+                <activiti:taskListener event="create" class="org.alfresco.repo.workflow.activiti.tasklistener.ScriptTaskListener">
+                    <activiti:field name="script">
+                        <activiti:string>
+                            if (typeof bpm_workflowDueDate != 'undefined') task.dueDate = bpm_workflowDueDate
+                            if (typeof bpm_workflowPriority != 'undefined') task.priority = bpm_workflowPriority;
+                        </activiti:string>
+                    </activiti:field>
+                </activiti:taskListener>
+                <activiti:taskListener event="complete" class="org.alfresco.repo.workflow.activiti.tasklistener.ScriptTaskListener">
+                    <activiti:field name="script">
+                        <activiti:string>
+                            execution.setVariable('wf_reviewOutcome', task.getVariable('wf_reviewOutcome'));
+                        </activiti:string>
+                    </activiti:field>
+                </activiti:taskListener>
+
+            </extensionElements>
+            <potentialOwner>
+                <resourceAssignmentExpression>
+                    <formalExpression>${bpm_groupAssignee.properties.authorityName}</formalExpression>
+                </resourceAssignmentExpression>
+            </potentialOwner>
+        </userTask>
+
+        <sequenceFlow id='flow2'
+                      sourceRef='reviewTask'
+                      targetRef='reviewDecision' />
+
+        <exclusiveGateway  id="reviewDecision" name="Review Decision" />
+
+        <sequenceFlow id='flow3' sourceRef='reviewDecision' targetRef='approved' >
+            <conditionExpression xsi:type="tFormalExpression">${wf_reviewOutcome == 'Approve'}</conditionExpression>
+        </sequenceFlow>
+
+        <sequenceFlow id='flow4'
+                      sourceRef='reviewDecision'
+                      targetRef='rejected' />
+
+        <userTask id="approved" name="Document Approved"
+                  activiti:formKey="wf:approvedTask" >
+            <documentation>
+                The document was reviewed and approved.
+            </documentation>
+            <extensionElements>
+                <activiti:taskListener event="create" class="org.alfresco.repo.workflow.activiti.tasklistener.ScriptTaskListener">
+                    <activiti:field name="script">
+                        <activiti:string>
+                            if (typeof bpm_workflowDueDate != 'undefined') task.dueDate = bpm_workflowDueDate
+                            if (typeof bpm_workflowPriority != 'undefined') task.priority = bpm_workflowPriority;
+                        </activiti:string>
+                    </activiti:field>
+                </activiti:taskListener>
+                <activiti:taskListener event="complete" class="org.alfresco.repo.workflow.activiti.tasklistener.ScriptTaskListener">
+                    <activiti:field name="script">
+                        <activiti:string>
+                            execution.setVariable('bpm_assignee', person);
+                        </activiti:string>
+                    </activiti:field>
+                </activiti:taskListener>
+            </extensionElements>
+            <humanPerformer>
+                <resourceAssignmentExpression>
+                    <formalExpression>${initiator.exists() ? initiator.properties.userName : 'admin'}</formalExpression>
+                </resourceAssignmentExpression>
+            </humanPerformer>
+        </userTask>
+
+        <userTask id="rejected" name="Document Rejected"
+                  activiti:formKey="wf:rejectedTask" >
+            <documentation>
+                The document was reviewed and rejected.
+            </documentation>
+            <extensionElements>
+                <activiti:taskListener event="create" class="org.alfresco.repo.workflow.activiti.tasklistener.ScriptTaskListener">
+                    <activiti:field name="script">
+                        <activiti:string>
+                            if (typeof bpm_workflowDueDate != 'undefined') task.dueDate = bpm_workflowDueDate
+                            if (typeof bpm_workflowPriority != 'undefined') task.priority = bpm_workflowPriority;
+                        </activiti:string>
+                    </activiti:field>
+                </activiti:taskListener>
+                <activiti:taskListener event="complete" class="org.alfresco.repo.workflow.activiti.tasklistener.ScriptTaskListener">
+                    <activiti:field name="script">
+                        <activiti:string>
+                            execution.setVariable('bpm_assignee', person);
+                        </activiti:string>
+                    </activiti:field>
+                </activiti:taskListener>
+            </extensionElements>
+            <humanPerformer>
+                <resourceAssignmentExpression>
+                    <formalExpression>${initiator.exists() ? initiator.properties.userName : 'admin'}</formalExpression>
+                </resourceAssignmentExpression>
+            </humanPerformer>
+        </userTask>
+
+        <sequenceFlow id='flow5' sourceRef='approved'
+                      targetRef='end' />
+
+        <sequenceFlow id='flow6' sourceRef='rejected'
+                      targetRef='end' />
+
+        <endEvent id="end" />
+
+    </process>
+
+    <!-- Graphical representaion of diagram -->
+    <bpmndi:BPMNDiagram id="BPMNDiagram_activitiReviewPooled">
+        <bpmndi:BPMNPlane bpmnElement="activitiReviewPooled"
+                          id="BPMNPlane_activitiReviewPooled">
+            <bpmndi:BPMNShape bpmnElement="start"
+                              id="BPMNShape_start">
+                <omgdc:Bounds height="35" width="35" x="30" y="200"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="reviewTask"
+                              id="BPMNShape_reviewTask">
+                <omgdc:Bounds height="55" width="105" x="125"
+                              y="190"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="reviewDecision"
+                              id="BPMNShape_reviewDecision">
+                <omgdc:Bounds height="40" width="40" x="290" y="197"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="approved"
+                              id="BPMNShape_approved">
+                <omgdc:Bounds height="55" width="105" x="390"
+                              y="97"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="rejected"
+                              id="BPMNShape_rejected">
+                <omgdc:Bounds height="55" width="105" x="390"
+                              y="297"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="end" id="BPMNShape_end">
+                <omgdc:Bounds height="35" width="35" x="555" y="307"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+                <omgdi:waypoint x="65" y="217"></omgdi:waypoint>
+                <omgdi:waypoint x="125" y="217"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="flow2" id="BPMNEdge_flow2">
+                <omgdi:waypoint x="230" y="217"></omgdi:waypoint>
+                <omgdi:waypoint x="290" y="217"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="flow3" id="BPMNEdge_flow3">
+                <omgdi:waypoint x="310" y="197"></omgdi:waypoint>
+                <omgdi:waypoint x="310" y="124"></omgdi:waypoint>
+                <omgdi:waypoint x="390" y="124"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="flow4" id="BPMNEdge_flow4">
+                <omgdi:waypoint x="310" y="237"></omgdi:waypoint>
+                <omgdi:waypoint x="310" y="324"></omgdi:waypoint>
+                <omgdi:waypoint x="390" y="324"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="flow5" id="BPMNEdge_flow5">
+                <omgdi:waypoint x="495" y="124"></omgdi:waypoint>
+                <omgdi:waypoint x="572" y="124"></omgdi:waypoint>
+                <omgdi:waypoint x="572" y="307"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="flow6" id="BPMNEdge_flow6">
+                <omgdi:waypoint x="495" y="324"></omgdi:waypoint>
+                <omgdi:waypoint x="555" y="324"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+
+</definitions>


### PR DESCRIPTION
This fix stops a non-admin user from being able to create a content node, then turn it into a workflow and deploy it. It also tightens up the requirement that workflows deployed in this way are only accepted in the correct place.