### PR TITLE
REPO-1886 / ALF-21822: NodeServiceXPath: Unsupported operation list.clear()

### DIFF
--- a/src/main/java/org/alfresco/repo/search/NodeServiceXPath.java
+++ b/src/main/java/org/alfresco/repo/search/NodeServiceXPath.java
@@ -195,7 +195,7 @@ public class NodeServiceXPath extends BaseXPath
         Set<Object> set = new HashSet<Object>(resultsWithDuplicates);
         
         // return new list without duplicates
-        List<Object> results = new ArrayList<Object>();
+        List<Object> results = new ArrayList<>();
         results.addAll(set);
         
         // done

--- a/src/main/java/org/alfresco/repo/search/NodeServiceXPath.java
+++ b/src/main/java/org/alfresco/repo/search/NodeServiceXPath.java
@@ -194,9 +194,8 @@ public class NodeServiceXPath extends BaseXPath
         
         Set<Object> set = new HashSet<Object>(resultsWithDuplicates);
         
-        // now return as a list again
-        List<Object> results = resultsWithDuplicates;
-        results.clear();
+        // return new list without duplicates
+        List<Object> results = new ArrayList<Object>();
         results.addAll(set);
         
         // done


### PR DESCRIPTION
Fix for REPO-1886 / ALF-21822: create new list instead of using the old list. 
For some reason it seems that the retrieved list may be used in other operations, so instead of mutating this one to remove duplicates, a new list is created and returned without duplicates. Couldn't reproduce the issue using acp import as suggested in ALF-21822