### PR TITLE
REPO-2253/ALF-21854 Fix action parameter locale lookup

### DIFF
--- a/src/main/java/org/alfresco/repo/action/ParameterizedItemDefinitionImpl.java
+++ b/src/main/java/org/alfresco/repo/action/ParameterizedItemDefinitionImpl.java
@@ -295,7 +295,9 @@ public abstract class ParameterizedItemDefinitionImpl implements ParameterizedIt
 
         if (null != paramDefinitionsByName)
         {
-            Map<String, ParameterDefinition> localizedDefinitionsByName = paramDefinitionsByName.get(I18NUtil.getLocale());
+            Set<Locale> locales = paramDefinitionsByName.keySet();
+            Locale match = I18NUtil.getNearestLocale(I18NUtil.getLocale(), locales);
+            Map<String, ParameterDefinition> localizedDefinitionsByName = paramDefinitionsByName.get(match);
 
             if (null == localizedDefinitionsByName)
             {

--- a/src/main/java/org/alfresco/repo/action/ParameterizedItemDefinitionImpl.java
+++ b/src/main/java/org/alfresco/repo/action/ParameterizedItemDefinitionImpl.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.extensions.surf.util.I18NUtil;
 import org.alfresco.service.cmr.action.ParameterDefinition;
@@ -263,11 +264,7 @@ public abstract class ParameterizedItemDefinitionImpl implements ParameterizedIt
      */
     public boolean hasParameterDefinitions()
     {
-        List<ParameterDefinition> localizedDefinitions = parameterDefinitions.get(I18NUtil.getLocale());
-        if (null == localizedDefinitions)
-        {
-            localizedDefinitions = parameterDefinitions.get(Locale.ROOT);
-        }
+        List<ParameterDefinition> localizedDefinitions = getParameterDefinitions();
 
         return (null != localizedDefinitions) && !localizedDefinitions.isEmpty();
     }
@@ -277,7 +274,9 @@ public abstract class ParameterizedItemDefinitionImpl implements ParameterizedIt
      */
     public List<ParameterDefinition> getParameterDefinitions()
     {
-        List<ParameterDefinition> result = parameterDefinitions.get(I18NUtil.getLocale());
+        Set<Locale> locales = parameterDefinitions.keySet();
+        Locale match = I18NUtil.getNearestLocale(I18NUtil.getLocale(), locales);
+        List<ParameterDefinition> result = parameterDefinitions.get(match);
 
         if (null == result)
         {

--- a/src/test/java/org/alfresco/repo/i18n/MessageServiceImplTest.java
+++ b/src/test/java/org/alfresco/repo/i18n/MessageServiceImplTest.java
@@ -364,6 +364,7 @@ public class MessageServiceImplTest extends TestCase implements MessageDeployer
         options.add(Locale.CHINESE);                // zh
         options.add(Locale.TRADITIONAL_CHINESE);    // zh_TW
         options.add(Locale.SIMPLIFIED_CHINESE);     // zh_CN
+        options.add(Locale.GERMAN);                 // de
         // add some variants
         Locale fr_FR_1 = new Locale("fr", "FR", "1");
         Locale zh_CN_1 = new Locale("zh", "CN", "1");
@@ -387,6 +388,10 @@ public class MessageServiceImplTest extends TestCase implements MessageDeployer
         assertEquals(zh_CN_2, messageService.getNearestLocale(zh_CN_2, options));
         assertTrue(chineseMatches.contains(messageService.getNearestLocale(zh_CN_3, options)));         // must match the last variant - but set can have any order an IBM JDK differs!
         assertEquals(Locale.FRANCE, messageService.getNearestLocale(fr_FR_1, options)); // same here
+        
+        // fallback to language if the country isn't defined
+        assertFalse(options.contains(Locale.GERMANY)); // test pre-condition
+        assertEquals(Locale.GERMAN, messageService.getNearestLocale(Locale.GERMANY, options));
         
         // now test the match for just anything
         Locale na_na_na = new Locale("", "", "");


### PR DESCRIPTION
REPO-2253: Community: ALF-21854 Action parameter lookup for "de_DE" falls back to "root" locale instead of "de"

This fixes the locale fallback problem for action definitions, such that if a parameter definition exists for German ("de") and the client asks for it with the locale Germany ("de-DE") then the labels will be returned in German, rather than English, even though there is no specific language bundle for the de-DE locale.