### PR TITLE
REPO-3255: Service Pack: MNT-19181 and MNT-19129: Authentication regressions

### DIFF
--- a/src/main/java/org/alfresco/repo/security/authentication/AuthenticationServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/security/authentication/AuthenticationServiceImpl.java
@@ -71,6 +71,11 @@ public class AuthenticationServiceImpl extends AbstractAuthenticationService imp
         this.protectionEnabled = protectionEnabled;
     }
 
+    public boolean isProtectionEnabled()
+    {
+        return protectionEnabled;
+    }
+
     public void setProtectionLimit(int protectionLimit)
     {
         this.protectionLimit = protectionLimit;

--- a/src/main/resources/alfresco/subsystems/Authentication/common-ldap-context.xml
+++ b/src/main/resources/alfresco/subsystems/Authentication/common-ldap-context.xml
@@ -94,7 +94,9 @@
          <ref bean="sysAdminParams" />
       </property>
       <property name="personService">
-         <ref bean="PersonService" />
+          <!-- use the unsecure "personService" because we need to know if  -->
+          <!-- personService.getUserNamesAreCaseSensitive(), without having the user authenticated yet -->
+         <ref bean="personService" />
       </property>
       <property name="protectedUsersCache">
          <ref bean="protectedUsersCache" />

--- a/src/main/resources/alfresco/subsystems/Authentication/external/external-authentication-context.xml
+++ b/src/main/resources/alfresco/subsystems/Authentication/external/external-authentication-context.xml
@@ -55,7 +55,9 @@
          <ref bean="protectedUsersCache" />
       </property>
       <property name="protectionEnabled">
-         <value>${authentication.protection.enabled}</value>
+         <!-- for external authentication ignore ${authentication.protection.enabled} -->
+         <!-- the external users are already authenticated by something else -->
+         <value>false</value>
       </property>
       <property name="protectionLimit">
          <value>${authentication.protection.limit}</value>

--- a/src/test/java/org/alfresco/repo/security/authentication/external/LocalAuthenticationServiceTest.java
+++ b/src/test/java/org/alfresco/repo/security/authentication/external/LocalAuthenticationServiceTest.java
@@ -28,6 +28,7 @@ package org.alfresco.repo.security.authentication.external;
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.management.subsystems.ChildApplicationContextFactory;
 import org.alfresco.repo.management.subsystems.DefaultChildApplicationContextManager;
+import org.alfresco.repo.security.authentication.AuthenticationServiceImpl;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.service.cmr.security.AuthenticationService;
 import org.alfresco.service.cmr.security.PersonService;
@@ -106,5 +107,7 @@ public class LocalAuthenticationServiceTest
         personService.setPersonProperties(username, properties);
         assertFalse("The isEnabed flag should be set to false for the disabled user",
                 localAuthenticationService.getAuthenticationEnabled(username));
+        assertFalse("External authentication should not protect against brute force attacks",
+            ((AuthenticationServiceImpl) localAuthenticationService).isProtectionEnabled());
     }
 }


### PR DESCRIPTION
ignore authentication protection for ext auth, and use the unsercure personService bean to be able to check if the system uses case sensitive usernames