### PR TITLE
REPO-2963 : Tests causing a cascade of failures in AllDBTestsTestSuit…

### DIFF
--- a/src/test/java/org/alfresco/AllDBTestsTestSuite.java
+++ b/src/test/java/org/alfresco/AllDBTestsTestSuite.java
@@ -38,7 +38,6 @@ import org.junit.runners.Suite;
 @Categories.IncludeCategory(DBTests.class)
 @Categories.ExcludeCategory(NonBuildTests.class)
 @Suite.SuiteClasses({
-
 	// From AllUnitTestsSuite
     org.alfresco.repo.dictionary.RepoDictionaryDAOTest.class,
 
@@ -76,6 +75,9 @@ import org.junit.runners.Suite;
 
 	// From MiscContextTestSuite
     org.alfresco.repo.domain.query.CannedQueryDAOTest.class,
+
+    // REPO-2963 : Tests causing a cascade of failures in AllDBTestsTestSuite on PostgreSQL/MySQL	
+    // Moved at the bottom of the suite because DbNodeServiceImplTest.testNodeCleanupRegistry() takes a long time on a clean DB.
     org.alfresco.repo.node.db.DbNodeServiceImplTest.class,
 })
 public class AllDBTestsTestSuite

--- a/src/test/java/org/alfresco/AllDBTestsTestSuite.java
+++ b/src/test/java/org/alfresco/AllDBTestsTestSuite.java
@@ -39,8 +39,6 @@ import org.junit.runners.Suite;
 @Categories.ExcludeCategory(NonBuildTests.class)
 @Suite.SuiteClasses({
 
-    org.alfresco.repo.node.db.DbNodeServiceImplTest.class,
-
 	// From AllUnitTestsSuite
     org.alfresco.repo.dictionary.RepoDictionaryDAOTest.class,
 
@@ -78,6 +76,7 @@ import org.junit.runners.Suite;
 
 	// From MiscContextTestSuite
     org.alfresco.repo.domain.query.CannedQueryDAOTest.class,
+    org.alfresco.repo.node.db.DbNodeServiceImplTest.class,
 })
 public class AllDBTestsTestSuite
 {

--- a/src/test/java/org/alfresco/AllDBTestsTestSuite.java
+++ b/src/test/java/org/alfresco/AllDBTestsTestSuite.java
@@ -39,12 +39,13 @@ import org.junit.runners.Suite;
 @Categories.ExcludeCategory(NonBuildTests.class)
 @Suite.SuiteClasses({
 
+    org.alfresco.repo.node.db.DbNodeServiceImplTest.class,
+
 	// From AllUnitTestsSuite
     org.alfresco.repo.dictionary.RepoDictionaryDAOTest.class,
 
 	// From AppContext03TestSuite
     org.alfresco.repo.lock.JobLockServiceTest.class,
-    org.alfresco.repo.node.db.DbNodeServiceImplTest.class,
     org.alfresco.repo.node.db.DbNodeServiceImplPropagationTest.class,
 
 //	// From AppContext04TestSuite

--- a/src/test/java/org/alfresco/repo/node/db/DbNodeServiceImplPropagationTest.java
+++ b/src/test/java/org/alfresco/repo/node/db/DbNodeServiceImplPropagationTest.java
@@ -115,14 +115,6 @@ public class DbNodeServiceImplPropagationTest extends BaseSpringTest
         }
         super.onTearDownInTransaction();
     }
-    
-    // REPO-2963 Initially just pass tests on selected DBs
-    protected boolean skipTestRepo2963()
-    {
-        return true; // Always skip the test
-//        String name = dialect.getClass().getName();
-//        return name.contains("PostgreSQL") || name.contains("MySQL");
-    }
 
     /**
      * Loads the test model required for building the node graphs
@@ -155,12 +147,6 @@ public class DbNodeServiceImplPropagationTest extends BaseSpringTest
     @SuppressWarnings("deprecation")
     public void testAuditablePropagation() throws Exception
     {
-        // See REPO-2963
-        if (skipTestRepo2963())
-        {
-            return;
-        }
-
         String fullyAuthenticatedUser = AuthenticationUtil.getFullyAuthenticatedUser();
 
         final QName TYPE_NOT_AUDITABLE = ContentModel.TYPE_CONTAINER;
@@ -301,7 +287,7 @@ public class DbNodeServiceImplPropagationTest extends BaseSpringTest
         assertEquals(fullyAuthenticatedUser, nodeService.getProperty(n2Ref, ContentModel.PROP_MODIFIER));
         assertEquals(fullyAuthenticatedUser, nodeService.getProperty(ac1, ContentModel.PROP_MODIFIER));
         assertEquals(fullyAuthenticatedUser, nodeService.getProperty(ac2, ContentModel.PROP_MODIFIER));
-        
+
         // Updates won't apply if the parent is newer than the child
         Date now = new Date();
         long futureShift = 4000l;
@@ -356,8 +342,9 @@ public class DbNodeServiceImplPropagationTest extends BaseSpringTest
         
         setComplete();
         endTransaction();
-        
+
         startNewTransaction();
+        txn.commit();
 
     }
     

--- a/src/test/java/org/alfresco/repo/node/db/DbNodeServiceImplTest.java
+++ b/src/test/java/org/alfresco/repo/node/db/DbNodeServiceImplTest.java
@@ -66,8 +66,10 @@ import org.alfresco.util.Pair;
 import org.alfresco.util.testing.category.DBTests;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.MySQLInnoDBDialect;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runners.MethodSorters;
 import org.quartz.Scheduler;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -81,6 +83,7 @@ import org.springframework.scheduling.quartz.JobDetailBean;
  */
 @SuppressWarnings("unused")
 @Category({OwnJVMTestsCategory.class, DBTests.class})
+//@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class DbNodeServiceImplTest extends BaseNodeServiceTest
 {
     private TransactionService txnService;
@@ -121,10 +124,6 @@ public class DbNodeServiceImplTest extends BaseNodeServiceTest
     @SuppressWarnings("deprecation")
     public void testNodeCleanupRegistry() throws Exception
     {
-        if (true)
-        {
-        return ;
-        }
         long cleanupRegistryTime=0;
         System.out.println("testNodeCleanupRegistry has just started, let the magic begin:");
         long startTime = System.currentTimeMillis();

--- a/src/test/java/org/alfresco/repo/node/db/DbNodeServiceImplTest.java
+++ b/src/test/java/org/alfresco/repo/node/db/DbNodeServiceImplTest.java
@@ -83,7 +83,6 @@ import org.springframework.scheduling.quartz.JobDetailBean;
  */
 @SuppressWarnings("unused")
 @Category({OwnJVMTestsCategory.class, DBTests.class})
-//@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class DbNodeServiceImplTest extends BaseNodeServiceTest
 {
     private TransactionService txnService;
@@ -124,48 +123,11 @@ public class DbNodeServiceImplTest extends BaseNodeServiceTest
     @SuppressWarnings("deprecation")
     public void testNodeCleanupRegistry() throws Exception
     {
-        long cleanupRegistryTime=0;
-        System.out.println("testNodeCleanupRegistry has just started, let the magic begin:");
-        long startTime = System.currentTimeMillis();
-        Scheduler scheduler = (Scheduler)applicationContext.getBean("schedulerFactory");
-
-        try
-        {
-        JobDetailBean contentStoreCleanerJobDetail = (JobDetailBean)applicationContext.getBean("contentStoreCleanerJobDetail");
-        scheduler.pauseJob(contentStoreCleanerJobDetail.getName(), contentStoreCleanerJobDetail.getGroup());
-
-        ChildApplicationContextFactory activitiesFeed = (ChildApplicationContextFactory)applicationContext.getBean("ActivitiesFeed");
-        ApplicationContext activitiesFeedCtx = activitiesFeed.getApplicationContext();
-        JobDetailBean feedGeneratorJobDetail = (JobDetailBean)activitiesFeedCtx.getBean("feedGeneratorJobDetail");
-        JobDetailBean postLookupJobDetail = (JobDetailBean)activitiesFeedCtx.getBean("postLookupJobDetail");
-        JobDetailBean feedCleanerJobDetail = (JobDetailBean)activitiesFeedCtx.getBean("feedCleanerJobDetail");
-        JobDetailBean postCleanerJobDetail = (JobDetailBean)activitiesFeedCtx.getBean("postCleanerJobDetail");
-        JobDetailBean feedNotifierJobDetail = (JobDetailBean)activitiesFeedCtx.getBean("feedNotifierJobDetail");
-
-        // Pause activities jobs so that we aren't competing with their scheduled versions
-        scheduler.pauseJob(feedGeneratorJobDetail.getName(), feedGeneratorJobDetail.getGroup());
-        scheduler.pauseJob(postLookupJobDetail.getName(), postLookupJobDetail.getGroup());
-        scheduler.pauseJob(feedCleanerJobDetail.getName(), feedCleanerJobDetail.getGroup());
-        scheduler.pauseJob(postCleanerJobDetail.getName(), postCleanerJobDetail.getGroup());
-        scheduler.pauseJob(feedNotifierJobDetail.getName(), feedNotifierJobDetail.getGroup());
-
-        long pauseTime = System.currentTimeMillis();
-        System.out.println("Time elapsed for pause jobs:"+(pauseTime-startTime));
+        // REPO-2963: this test takes a long time in order to pass on a clean DB.
         setComplete();
         endTransaction();
-        long endTransactionTime=System.currentTimeMillis();
-        System.out.println("Time elapsed for commiting transaction:"+(endTransactionTime-pauseTime));
         NodeCleanupRegistry cleanupRegistry = (NodeCleanupRegistry) applicationContext.getBean("nodeCleanupRegistry");
         cleanupRegistry.doClean();
-        cleanupRegistryTime = System.currentTimeMillis();
-        System.out.println("Time elapsed for the cleanupRegistry to do his magic:"+(cleanupRegistryTime-endTransactionTime));
-        
-        }
-        finally{
-        scheduler.resumeAll();
-        long resumeTime = System.currentTimeMillis();
-        System.out.println("Time elapsed for resuming jobs:"+(resumeTime-cleanupRegistryTime));
-        }
     }
 
     /**

--- a/src/test/java/org/alfresco/repo/node/db/DbNodeServiceImplTest.java
+++ b/src/test/java/org/alfresco/repo/node/db/DbNodeServiceImplTest.java
@@ -121,6 +121,9 @@ public class DbNodeServiceImplTest extends BaseNodeServiceTest
     @SuppressWarnings("deprecation")
     public void testNodeCleanupRegistry() throws Exception
     {
+        long cleanupRegistryTime=0;
+        System.out.println("testNodeCleanupRegistry has just started, let the magic begin:");
+        long startTime = System.currentTimeMillis();
         Scheduler scheduler = (Scheduler)applicationContext.getBean("schedulerFactory");
 
         try
@@ -143,13 +146,22 @@ public class DbNodeServiceImplTest extends BaseNodeServiceTest
         scheduler.pauseJob(postCleanerJobDetail.getName(), postCleanerJobDetail.getGroup());
         scheduler.pauseJob(feedNotifierJobDetail.getName(), feedNotifierJobDetail.getGroup());
 
+        long pauseTime = System.currentTimeMillis();
+        System.out.println("Time elapsed for pause jobs:"+(pauseTime-startTime));
         setComplete();
         endTransaction();
+        long endTransactionTime=System.currentTimeMillis();
+        System.out.println("Time elapsed for commiting transaction:"+(endTransactionTime-pauseTime));
         NodeCleanupRegistry cleanupRegistry = (NodeCleanupRegistry) applicationContext.getBean("nodeCleanupRegistry");
         cleanupRegistry.doClean();
+        cleanupRegistryTime = System.currentTimeMillis();
+        System.out.println("Time elapsed for the cleanupRegistry to do his magic:"+(cleanupRegistryTime-endTransactionTime));
+        
         }
         finally{
         scheduler.resumeAll();
+        long resumeTime = System.currentTimeMillis();
+        System.out.println("Time elapsed for resuming jobs:"+(resumeTime-cleanupRegistryTime));
         }
     }
 

--- a/src/test/java/org/alfresco/repo/node/db/DbNodeServiceImplTest.java
+++ b/src/test/java/org/alfresco/repo/node/db/DbNodeServiceImplTest.java
@@ -42,7 +42,6 @@ import org.alfresco.repo.domain.node.NodeDAO;
 import org.alfresco.repo.domain.node.NodeDAO.ChildAssocRefQueryCallback;
 import org.alfresco.repo.domain.node.Transaction;
 import org.alfresco.repo.domain.schema.SchemaBootstrap;
-import org.alfresco.repo.management.subsystems.ChildApplicationContextFactory;
 import org.alfresco.repo.node.BaseNodeServiceTest;
 import org.alfresco.repo.node.cleanup.NodeCleanupRegistry;
 import org.alfresco.repo.node.db.NodeStringLengthWorker.NodeStringLengthWorkResult;
@@ -66,15 +65,10 @@ import org.alfresco.util.Pair;
 import org.alfresco.util.testing.category.DBTests;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.MySQLInnoDBDialect;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.runners.MethodSorters;
-import org.quartz.Scheduler;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.extensions.surf.util.I18NUtil;
-import org.springframework.scheduling.quartz.JobDetailBean;
 
 /**
  * @see org.alfresco.repo.node.db.DbNodeServiceImpl

--- a/src/test/java/org/alfresco/repo/node/db/DbNodeServiceImplTest.java
+++ b/src/test/java/org/alfresco/repo/node/db/DbNodeServiceImplTest.java
@@ -121,6 +121,10 @@ public class DbNodeServiceImplTest extends BaseNodeServiceTest
     @SuppressWarnings("deprecation")
     public void testNodeCleanupRegistry() throws Exception
     {
+        if (true)
+        {
+        return ;
+        }
         long cleanupRegistryTime=0;
         System.out.println("testNodeCleanupRegistry has just started, let the magic begin:");
         long startTime = System.currentTimeMillis();


### PR DESCRIPTION
…e on PostgreSQL/MySQL

   Remove skipTestRepo2963() call from DbNodeServiceImplTest and DbNodeServiceImplPropagationTest
   Add txn.commit() in order to commit the UserTransaction from DbNodeServiceImplPropagationTest.testAuditablePropagation() this leftover made other tests fail.
   Use scheduler to pauseAll() for DbNodeServiceImplTest.testNodeCleanupRegistry() as it created a deadlock on mysql.