### PR TITLE
MNT-16433: Add ftp.externalAddress property

### DIFF
--- a/src/main/java/org/alfresco/filesys/config/FTPConfigBean.java
+++ b/src/main/java/org/alfresco/filesys/config/FTPConfigBean.java
@@ -69,7 +69,11 @@ public class FTPConfigBean
     
     private int dataPortFrom;
     private int dataPortTo;
-    
+
+    // Externally seen IP address
+
+    private String externalAddress;
+
     // FTPS configuration
     //
     // Keystore/truststore details
@@ -332,7 +336,25 @@ public class FTPConfigBean
     public void setDataPortTo(int toPort) {
     	dataPortTo = toPort;
     }
-    
+
+    /**
+     * Return the IP Address to use in NAT setup
+     *
+     * @return String
+     */
+    public String getExternalAddress() {
+        return externalAddress;
+    }
+
+    /**
+     * Set the IP Address to use in NAT setup
+     *
+     * @param externalAddress String
+     */
+    public void setExternalAddress(String externalAddress) {
+        this.externalAddress = externalAddress;
+    }
+
     /**
      * Return the key store path
      * 

--- a/src/main/java/org/alfresco/filesys/config/ServerConfigurationBean.java
+++ b/src/main/java/org/alfresco/filesys/config/ServerConfigurationBean.java
@@ -1409,6 +1409,15 @@ public class ServerConfigurationBean extends AbstractServerConfigurationBean imp
 	    			logger.info("FTP server data ports restricted to range " + rangeFrom + ":" + rangeTo);
             	}
             }
+
+            // Check for an external address
+
+            String ExtAddr = ftpConfigBean.getExternalAddress();
+            if (ExtAddr != null && ExtAddr.length() > 0) {
+
+               ftpConfig.setFTPExternalAddress(ExtAddr);
+            }
+
             
     		// FTPS parameter parsing
     		//

--- a/src/main/resources/alfresco/subsystems/fileServers/default/file-servers-context.xml
+++ b/src/main/resources/alfresco/subsystems/fileServers/default/file-servers-context.xml
@@ -226,7 +226,11 @@
 	  <property name="dataPortTo">
 		  <value>${ftp.dataPortTo}</value>
 	  </property>
-	   
+
+      <property name="externalAddress">
+          <value>${ftp.externalAddress}</value>
+      </property>
+
 	 <!-- FTPS support -->
 	 <property name="keyStorePath">
 		 <value>${ftp.keyStore}</value>

--- a/src/main/resources/alfresco/subsystems/fileServers/default/file-servers.properties
+++ b/src/main/resources/alfresco/subsystems/fileServers/default/file-servers.properties
@@ -86,6 +86,9 @@ ftp.bindto=
 ftp.dataPortFrom=0
 ftp.dataPortTo=0
 
+# FTP external address, the IP address as seen by FTP clients (in case of NAT)
+ftp.externalAddress=
+
 # FTPS support (enabled when the keystore and truststore are set)
 ftp.keyStore=
 ftp.keyStoreType=JKS


### PR DESCRIPTION
Adds a property to collect the value to pass on to JLAN to use as the
FTPExternalAddress parameter.

> This PR is for MNT-16433 which first requires jlan patch. 
the pom file need to reference a jlan artifact which has the corresponding code. Please see https://git.alfresco.com/Repository/jlan/merge_requests/3