### PR TITLE
REPO-1323: Rhino upgrade to 1.7.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
         <dependency>
             <groupId>org.mozilla</groupId>
             <artifactId>rhino</artifactId>
-            <version>1.7R4-alfresco-patched</version>
+            <version>1.7.9</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>6.38-SNAPSHOT</version>
+    <version>6.38-RhinoUpgrade</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -15,7 +15,7 @@
         <connection>scm:git:git@github.com:Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:git@github.com:Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>HEAD</tag>
+        <tag>alfresco-repository-6.38-RhinoUpgrade</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>6.38-RhinoUpgrade</version>
+    <version>6.38-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -15,7 +15,7 @@
         <connection>scm:git:git@github.com:Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:git@github.com:Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>alfresco-repository-6.38-RhinoUpgrade</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
I upgraded Rhino to **1.7.9**, which is the most recent release - https://github.com/mozilla/rhino/releases/tag/Rhino1_7_9_Release (March 15, 2018).

There isn't any diff file in the code, to identify what was patched in the version `1.7R4-alfresco-patched`, so I did a compare between the zip that is suppose to be the source zip for the patched version and the source for the 1.7R4 release, and the only difference I found was in `org.mozilla.javascript.ScriptRuntime.warnAboutNonJSObject`, where the actual logging of the warning is removed.
In the 1.7.9 version, this logging is based on the value of a flag and is omitted by default (https://github.com/mozilla/rhino/blob/Rhino1_7_9_Release/src/org/mozilla/javascript/ScriptRuntime.java#L4312), so no need to patch the latest version.