### PR TITLE
REPO-3447: Remove c3p0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -651,6 +651,12 @@
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
             <version>2.3.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.mchange</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Activiti -->
         <!-- Updated commons-email to 1.5 -->


### PR DESCRIPTION
Quartz uses c3p0 jdbc pool for it's distributed job storage since version 2.x
This commit will exclude c3p0 lib as distributed job storage is not used.