### PR TITLE
REPO-3465  Add CSRF filter config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>6.47-SNAPSHOT</version>
+    <version>csrf-rc1</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -15,7 +15,7 @@
         <connection>scm:git:git@github.com:Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:git@github.com:Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>HEAD</tag>
+        <tag>alfresco-repository-csrf-rc1</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency.httpcomponents.version>4.5.2</dependency.httpcomponents.version>
         <dependency.truezip.version>7.7.9</dependency.truezip.version>
         <dependency.poi.version>3.17</dependency.poi.version>
-        <dependency.webscripts.version>6.16</dependency.webscripts.version>
+        <dependency.webscripts.version>csrf-rc1</dependency.webscripts.version>
         <dependency.opencmis.version>1.0.0</dependency.opencmis.version>
         <dependency.activiti-engine.version>5.22.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.22.0</dependency.activiti.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency.httpcomponents.version>4.5.2</dependency.httpcomponents.version>
         <dependency.truezip.version>7.7.9</dependency.truezip.version>
         <dependency.poi.version>3.17</dependency.poi.version>
-        <dependency.webscripts.version>csrf-rc1</dependency.webscripts.version>
+        <dependency.webscripts.version>6.17</dependency.webscripts.version>
         <dependency.opencmis.version>1.0.0</dependency.opencmis.version>
         <dependency.activiti-engine.version>5.22.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.22.0</dependency.activiti.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>csrf-rc1</version>
+    <version>6.47-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -15,7 +15,7 @@
         <connection>scm:git:git@github.com:Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:git@github.com:Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>alfresco-repository-csrf-rc1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/src/main/resources/alfresco/repository.properties
+++ b/src/main/resources/alfresco/repository.properties
@@ -1206,3 +1206,9 @@ heartbeat.enabled=true
 heartbeat.sender.cronExpression=
 # When testMode is set to true all collectors will be scheduled using test cron expression "0 0/1 * * * ?"
 heartbeat.collectors.testMode=false
+
+# CSRF filter overrides
+csrf.filter.referer=
+csrf.filter.referer.always=false
+csrf.filter.origin=
+csrf.filter.origin.always=false


### PR DESCRIPTION
CSRF filter is now configured by these props:
csrf.filter.referer=
csrf.filter.referer.always=false
csrf.filter.origin=
csrf.filter.origin.always=false

Referer and origin here is a regexp and should look like:
http://mydomain:80/*.