### PR TITLE
REPO-3524: remove the old 2.7 version of antlr jar as it was used for…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -490,12 +490,6 @@
             <artifactId>htmlparser</artifactId>
             <version>2.1</version>
         </dependency>
-        <!-- Old version of AntLR is still required as a dependency of Hibernate -->
-        <dependency>
-            <groupId>antlr</groupId>
-            <artifactId>antlr</artifactId>
-            <version>2.7.7</version>
-        </dependency>
         <!-- Apache POI -->
         <dependency>
             <groupId>org.apache.poi</groupId>


### PR DESCRIPTION
as it was used for hibernate, but we don't have hibernate anymore