### PR TITLE
REPO-3747 Trials: Changes to license generation and docs

### DIFF
--- a/src/main/java/org/alfresco/repo/descriptor/DescriptorStartupLog.java
+++ b/src/main/java/org/alfresco/repo/descriptor/DescriptorStartupLog.java
@@ -132,10 +132,11 @@ public class DescriptorStartupLog extends AbstractLifecycleBean
             }
             
             Date validUntil = license.getValidUntil();
-            
+
+            Integer days = null;
             if (validUntil != null)
             {
-                Integer days = license.getDays();
+                days = license.getDays();
                 Integer remainingDays = license.getRemainingDays();
                 
                 msg += " limited to " + days + " days expiring " + validUntil + " (" + remainingDays + " days remaining).";
@@ -159,7 +160,14 @@ public class DescriptorStartupLog extends AbstractLifecycleBean
             /*
              * This is an important information logging since it logs the license
              */
+            String line = msg.replaceAll(".", "-");
+            logger.info(line);
             logger.info(msg);
+            if ("Trial User".equals(holder) && days != null && days == 2)
+            {
+                logger.info("To extend the trial period visit: https://www.alfresco.com/platform/content-services-ecm/trial/docker");
+            }
+            logger.info(line);
         }
         
         // Log Repository Descriptors

--- a/src/main/java/org/alfresco/repo/descriptor/DescriptorStartupLog.java
+++ b/src/main/java/org/alfresco/repo/descriptor/DescriptorStartupLog.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2018 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 

--- a/src/main/java/org/alfresco/repo/descriptor/DescriptorStartupLog.java
+++ b/src/main/java/org/alfresco/repo/descriptor/DescriptorStartupLog.java
@@ -165,7 +165,9 @@ public class DescriptorStartupLog extends AbstractLifecycleBean
                 String line = msg.replaceAll(".", "-");
                 logger.info(line);
                 logger.info(msg);
-                logger.info("To extend the trial period visit: https://www.alfresco.com/platform/content-services-ecm/trial/docker");
+                logger.info("Note: this is a limited trial of the Enterprise version of Alfresco Content Services that " +
+                        "goes into read-only mode after 2-days. Request an extended 30-day trial at:" +
+                        " https://www.alfresco.com/platform/content-services-ecm/trial/docker");
                 logger.info(line);
             }
             else

--- a/src/main/java/org/alfresco/repo/descriptor/DescriptorStartupLog.java
+++ b/src/main/java/org/alfresco/repo/descriptor/DescriptorStartupLog.java
@@ -59,6 +59,7 @@ public class DescriptorStartupLog extends AbstractLifecycleBean
     
     private final String SYSTEM_INFO_STARTUP = "system.info.startup";
     private final String SYSTEM_WARN_READONLY = "system.warn.readonly";
+    private final String SYSTEM_INFO_NOTRAILID = "system.info.notrialid";
 
     /**
      * @param descriptorService  Descriptor Service
@@ -165,9 +166,7 @@ public class DescriptorStartupLog extends AbstractLifecycleBean
                 String line = msg.replaceAll(".", "-");
                 logger.info(line);
                 logger.info(msg);
-                logger.info("Note: this is a limited trial of the Enterprise version of Alfresco Content Services that " +
-                        "goes into read-only mode after 2-days. Request an extended 30-day trial at:" +
-                        " https://www.alfresco.com/platform/content-services-ecm/trial/docker");
+                logger.info(I18NUtil.getMessage(SYSTEM_INFO_NOTRAILID));
                 logger.info(line);
             }
             else

--- a/src/main/java/org/alfresco/repo/descriptor/DescriptorStartupLog.java
+++ b/src/main/java/org/alfresco/repo/descriptor/DescriptorStartupLog.java
@@ -59,7 +59,7 @@ public class DescriptorStartupLog extends AbstractLifecycleBean
     
     private final String SYSTEM_INFO_STARTUP = "system.info.startup";
     private final String SYSTEM_WARN_READONLY = "system.warn.readonly";
-    private final String SYSTEM_INFO_NOTRAILID = "system.info.notrialid";
+    private final String SYSTEM_INFO_NOTRAILID = "system.info.limited_trial";
 
     /**
      * @param descriptorService  Descriptor Service
@@ -163,7 +163,7 @@ public class DescriptorStartupLog extends AbstractLifecycleBean
              */
             if ("Trial User".equals(holder) && days != null && days == 2)
             {
-                String line = msg.replaceAll(".", "-");
+                String line = "================================================================";
                 logger.info(line);
                 logger.info(msg);
                 logger.info(I18NUtil.getMessage(SYSTEM_INFO_NOTRAILID));

--- a/src/main/java/org/alfresco/repo/descriptor/DescriptorStartupLog.java
+++ b/src/main/java/org/alfresco/repo/descriptor/DescriptorStartupLog.java
@@ -160,14 +160,18 @@ public class DescriptorStartupLog extends AbstractLifecycleBean
             /*
              * This is an important information logging since it logs the license
              */
-            String line = msg.replaceAll(".", "-");
-            logger.info(line);
-            logger.info(msg);
             if ("Trial User".equals(holder) && days != null && days == 2)
             {
+                String line = msg.replaceAll(".", "-");
+                logger.info(line);
+                logger.info(msg);
                 logger.info("To extend the trial period visit: https://www.alfresco.com/platform/content-services-ecm/trial/docker");
+                logger.info(line);
             }
-            logger.info(line);
+            else
+            {
+                logger.info(msg);
+            }
         }
         
         // Log Repository Descriptors

--- a/src/main/resources/alfresco/messages/system-messages.properties
+++ b/src/main/resources/alfresco/messages/system-messages.properties
@@ -114,4 +114,4 @@ system.license.err.reloadFailed=Failed to reload license: {0}
 # Startup message
 system.info.startup=Alfresco Content Services started ({0}{1}{2}). Current version: {3} schema {4}. Originally installed version: {5} schema {6}.
 system.warn.readonly=Alfresco Content Services is currently in read-only mode. Check your license.
-system.info.notrialid=Note: this is a limited trial of the Enterprise version of Alfresco Content Services that goes into read-only mode after 2-days. Request an extended 30-day trial at: https://www.alfresco.com/platform/content-services-ecm/trial/docker
+system.info.limited_trial=Note: this is a limited trial of the Enterprise version of Alfresco Content Services that goes into read-only mode after 2-days. Request an extended 30-day trial at: https://www.alfresco.com/platform/content-services-ecm/trial/docker

--- a/src/main/resources/alfresco/messages/system-messages.properties
+++ b/src/main/resources/alfresco/messages/system-messages.properties
@@ -114,3 +114,4 @@ system.license.err.reloadFailed=Failed to reload license: {0}
 # Startup message
 system.info.startup=Alfresco Content Services started ({0}{1}{2}). Current version: {3} schema {4}. Originally installed version: {5} schema {6}.
 system.warn.readonly=Alfresco Content Services is currently in read-only mode. Check your license.
+system.info.notrialid=Note: this is a limited trial of the Enterprise version of Alfresco Content Services that goes into read-only mode after 2-days. Request an extended 30-day trial at: https://www.alfresco.com/platform/content-services-ecm/trial/docker


### PR DESCRIPTION
Added log message: "To extend the trial period visit: https://www.alfresco.com/platform/content-services-ecm/trial/docker"