### PR TITLE
REPO-3744 Make query limit configurable

### DIFF
--- a/src/main/java/org/alfresco/repo/security/authority/AuthorityDAOImpl.java
+++ b/src/main/java/org/alfresco/repo/security/authority/AuthorityDAOImpl.java
@@ -138,6 +138,8 @@ public class AuthorityDAOImpl implements AuthorityDAO, NodeServicePolicies.Befor
     private int zoneAuthoritySampleSize = 10000;
 
     private boolean useBridgeTable = true;
+    /** limits the findAuthorities search query */
+    private int findAuthoritiesLimit = 100;
     
     private QNameDAO qnameDAO;
     private CannedQueryDAO cannedQueryDAO;
@@ -273,6 +275,11 @@ public class AuthorityDAOImpl implements AuthorityDAO, NodeServicePolicies.Befor
     public void setAuthorityBridgeDAO(AuthorityBridgeDAO authorityBridgeDAO)
     {
         this.authorityBridgeDAO = authorityBridgeDAO;
+    }
+
+    public void setFindAuthoritiesLimit(int findAuthoritiesLimit)
+    {
+        this.findAuthoritiesLimit = findAuthoritiesLimit;
     }
 
     @Override
@@ -718,7 +725,7 @@ public class AuthorityDAOImpl implements AuthorityDAO, NodeServicePolicies.Befor
             } 
         }
         sp.setQuery(query.toString());
-        sp.setMaxItems(100);
+        sp.setMaxItems(findAuthoritiesLimit);
         ResultSet rs = null;
         try
         {

--- a/src/main/resources/alfresco/authority-services-context.xml
+++ b/src/main/resources/alfresco/authority-services-context.xml
@@ -105,6 +105,7 @@
         <property name="authorityBridgeDAO" ref="authorityBridgeDAO" />
         <property name="authorityBridgeTableCache" ref="authorityBridgeTableCache" />
         <property name="useBridgeTable" value="${authority.useBridgeTable}" />
+        <property name="findAuthoritiesLimit" value="${authority.findAuthorityLimit}" />
     </bean>
 
     <bean id="authorityTypeBehaviour" class="org.alfresco.repo.security.authority.AuthorityTypeBehaviour" init-method="init">

--- a/src/main/resources/alfresco/repository.properties
+++ b/src/main/resources/alfresco/repository.properties
@@ -971,6 +971,9 @@ trashcan.MaxSize=1000
 #
 authority.useBridgeTable=true
 
+# Limit the number of results from findAuthority query
+authority.findAuthorityLimit=10000
+
 # enable QuickShare - if false then the QuickShare-specific REST APIs will return 403 Forbidden
 system.quickshare.enabled=true
 system.quickshare.email.from.default=noreply@alfresco.com


### PR DESCRIPTION
The hardcoded 100 max items limit was changed to a configurable parameter `authority.findAuthorityLimit` which now has a default of 10000.
This limit is applied to a query that is going in SearchService, therefore can go to Solr instead of database if Full Text Search queries are configured to use Solr instead of the database.
As the query returns all items and sorting and paging is done in remote-api in `GroupsImpl#getAuthoritiesInfo`, the execution can be slow on large datasets. Local tests showed about 6s to get results for a group of 10000 users.