### PR TITLE
REPO-3688: Deprecate public APIs

### DIFF
--- a/src/main/java/org/alfresco/opencmis/CMISConnector.java
+++ b/src/main/java/org/alfresco/opencmis/CMISConnector.java
@@ -309,6 +309,7 @@ public class CMISConnector implements ApplicationContextAware, ApplicationListen
     private CheckOutCheckInService checkOutCheckInService;
     private LockService lockService;
     private ContentService contentService;
+    @Deprecated
     private RenditionService renditionService;
     private FileFolderService fileFolderService;
     private TenantAdminService tenantAdminService;
@@ -327,6 +328,7 @@ public class CMISConnector implements ApplicationContextAware, ApplicationListen
     private DictionaryService dictionaryService;
     private SiteService siteService;
     private ActionService actionService;
+    @Deprecated
     private ThumbnailService thumbnailService;
     private ServiceRegistry serviceRegistry;
     private EventPublisher eventPublisher;
@@ -498,6 +500,12 @@ public class CMISConnector implements ApplicationContextAware, ApplicationListen
         return openHttpSession;
     }
 
+    /**
+     *
+     *
+     * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     public void setThumbnailService(ThumbnailService thumbnailService)
     {
 		this.thumbnailService = thumbnailService;
@@ -614,7 +622,10 @@ public class CMISConnector implements ApplicationContextAware, ApplicationListen
 
     /**
      * Sets the rendition service.
+     *
+     * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
      */
+    @Deprecated
     public void setrenditionService(RenditionService renditionService)
     {
         this.renditionService = renditionService;
@@ -970,7 +981,10 @@ public class CMISConnector implements ApplicationContextAware, ApplicationListen
      * Asynchronously generates thumbnails for the given node.
      *
      * @param nodeRef NodeRef
+     *
+     * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public void createThumbnails(NodeRef nodeRef, Set<String> thumbnailNames)
     {
     	if(thumbnailNames == null || thumbnailNames.size() == 0)
@@ -2481,6 +2495,11 @@ public class CMISConnector implements ApplicationContextAware, ApplicationListen
         return result;
     }
 
+    /**
+     *
+     * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
+     */
+    @Deprecated
     public List<RenditionData> getRenditions(NodeRef nodeRef, String renditionFilter, BigInteger maxItems,
             BigInteger skipCount)
     {
@@ -4079,7 +4098,12 @@ public class CMISConnector implements ApplicationContextAware, ApplicationListen
 
         return result;
     }
-    
+
+    /**
+     *
+     * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
+     */
+    @Deprecated
     private CMISRenditionMapping getRenditionMapping()
     {
         CMISRenditionMapping renditionMapping = (CMISRenditionMapping)singletonCache.get(KEY_CMIS_RENDITION_MAPPING_NODEREF);

--- a/src/main/java/org/alfresco/opencmis/CMISRenditionMapping.java
+++ b/src/main/java/org/alfresco/opencmis/CMISRenditionMapping.java
@@ -53,6 +53,11 @@ import org.apache.chemistry.opencmis.commons.data.RenditionData;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisFilterNotValidException;
 import org.apache.chemistry.opencmis.commons.impl.dataobjects.RenditionDataImpl;
 
+/**
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
+ */
+@Deprecated
 public class CMISRenditionMapping
 {
     private NodeService nodeService;

--- a/src/main/java/org/alfresco/repo/content/AbstractContentReader.java
+++ b/src/main/java/org/alfresco/repo/content/AbstractContentReader.java
@@ -82,9 +82,11 @@ public abstract class AbstractContentReader extends AbstractContentAccessor impl
     private ReadableByteChannel channel;
     
     // Optional limits on reading
+    @Deprecated
     private TransformationOptionLimits limits;
     
     // Only needed if limits are set
+    @Deprecated
     private TransformerDebug transformerDebug;
     
     // For testing: Allows buffering to be turned off
@@ -100,22 +102,44 @@ public abstract class AbstractContentReader extends AbstractContentAccessor impl
         
         listeners = new ArrayList<ContentStreamListener>(2);
     }
-    
+
+    /**
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     public void setLimits(TransformationOptionLimits limits)
     {
         this.limits = limits;
     }
-    
+
+
+    /**
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     public TransformationOptionLimits getLimits()
     {
         return limits;
     }
 
+
+    /**
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     public void setTransformerDebug(TransformerDebug transformerDebug)
     {
         this.transformerDebug = transformerDebug;
     }
 
+    /**
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     public TransformerDebug getTransformerDebug()
     {
         return transformerDebug;
@@ -374,7 +398,10 @@ public abstract class AbstractContentReader extends AbstractContentAccessor impl
 
     /**
      * @see Channels#newInputStream(java.nio.channels.ReadableByteChannel)
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public InputStream getContentInputStream() throws ContentIOException
     {
         try
@@ -414,7 +441,10 @@ public abstract class AbstractContentReader extends AbstractContentAccessor impl
     /**
      * Copies the {@link #getContentInputStream() input stream} to the given
      * <code>OutputStream</code>
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public final void getContent(OutputStream os) throws ContentIOException
     {
         try
@@ -431,6 +461,11 @@ public abstract class AbstractContentReader extends AbstractContentAccessor impl
         }
     }
 
+    /**
+     *  *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     public final void getContent(File file) throws ContentIOException
     {
         try
@@ -448,7 +483,13 @@ public abstract class AbstractContentReader extends AbstractContentAccessor impl
                     e);
         }
     }
-    
+
+    /**
+     *
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     public final String getContentString(int length) throws ContentIOException
     {
         if (length < 0 || length > Integer.MAX_VALUE)
@@ -500,7 +541,10 @@ public abstract class AbstractContentReader extends AbstractContentAccessor impl
      * be careful with this method.
      * 
      * @see ContentAccessor#getEncoding()
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public final String getContentString() throws ContentIOException
     {
         try
@@ -569,7 +613,10 @@ public abstract class AbstractContentReader extends AbstractContentAccessor impl
      * (-1) or throwing an IOException.
 
      * @author Alan Davis
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     private class TimeSizeRestrictedInputStream extends InputStream
     {
         private final AtomicBoolean timeoutFlag = new AtomicBoolean(false);

--- a/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
@@ -98,10 +98,12 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     private MimetypeService mimetypeService;
     private RetryingTransactionHelper transactionHelper;
     private ApplicationContext applicationContext;
+    @Deprecated
     protected TransformerDebug transformerDebug;
 
 
     /** a registry of all available content transformers */
+    @Deprecated
     private ContentTransformerRegistry transformerRegistry;
     /** The cleaner that will ensure that rollbacks clean up after themselves */
     private EagerContentStoreCleaner eagerContentStoreCleaner;
@@ -109,6 +111,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     private ContentStore store;
     /** the store for all temporarily created content */
     private ContentStore tempStore;
+    @Deprecated
     private ContentTransformer imageMagickContentTransformer;
     /** Should we consider zero byte content to be the same as no content? */
     private boolean ignoreEmptyContent;
@@ -145,7 +148,11 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     {
         this.mimetypeService = mimetypeService;
     }
-    
+
+    /**
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     public void setTransformerRegistry(ContentTransformerRegistry transformerRegistry)
     {
         this.transformerRegistry = transformerRegistry;
@@ -165,7 +172,12 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     {
         this.policyComponent = policyComponent;
     }
-    
+
+    /**
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     public void setImageMagickContentTransformer(ContentTransformer imageMagickContentTransformer) 
     {
         this.imageMagickContentTransformer = imageMagickContentTransformer;
@@ -182,7 +194,10 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
      * of the transformer must go to a temporary file in case it fails.
      * @param transformerFailover {@code true} (the default) indicate
      *        that fail over should take place.
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the
+     * new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public void setTransformerFailover(boolean transformerFailover)
     {
         this.transformerFailover = transformerFailover;
@@ -199,7 +214,9 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     /**
      * Helper setter of the transformer debug. 
      * @param transformerDebug TransformerDebug
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public void setTransformerDebug(TransformerDebug transformerDebug)
     {
         this.transformerDebug = transformerDebug;
@@ -551,7 +568,9 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
      * @see org.alfresco.repo.content.transform.ContentTransformerRegistry
      * @see org.alfresco.repo.content.transform.ContentTransformer
      * @see org.alfresco.service.cmr.repository.ContentService#transform(org.alfresco.service.cmr.repository.ContentReader, org.alfresco.service.cmr.repository.ContentWriter)
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public void transform(ContentReader reader, ContentWriter writer)
     {
         // Call transform with no options
@@ -563,7 +582,9 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
      * @see org.alfresco.repo.content.transform.ContentTransformerRegistry
      * @see org.alfresco.repo.content.transform.ContentTransformer
      * @deprecated
-     */    
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     public void transform(ContentReader reader, ContentWriter writer, Map<String, Object> options)
             throws NoTransformerException, ContentIOException
     {
@@ -573,7 +594,9 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     /**
      * @see org.alfresco.repo.content.transform.ContentTransformerRegistry
      * @see org.alfresco.repo.content.transform.ContentTransformer
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public void transform(ContentReader reader, ContentWriter writer, TransformationOptions options) 
         throws NoTransformerException, ContentIOException
     {
@@ -627,6 +650,11 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         }
     }
 
+    /**
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     private void failoverTransformers(ContentReader reader, ContentWriter writer,
             TransformationOptions options, String targetMimetype,
             List<ContentTransformer> transformers)
@@ -747,12 +775,19 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     /**
      * @see org.alfresco.repo.content.transform.ContentTransformerRegistry
      * @see org.alfresco.repo.content.transform.ContentTransformer
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public ContentTransformer getTransformer(String sourceMimetype, String targetMimetype)
     {
         return getTransformer(null, sourceMimetype, -1, targetMimetype, new TransformationOptions());
     }
-    
+
+    /**
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     public ContentTransformer getTransformer(String sourceMimetype, String targetMimetype, TransformationOptions options)
     {
         return getTransformer(null, sourceMimetype, -1, targetMimetype, options);
@@ -760,7 +795,9 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     
     /**
      * @see org.alfresco.service.cmr.repository.ContentService#getTransformer(String, java.lang.String, long, java.lang.String, org.alfresco.service.cmr.repository.TransformationOptions)
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public ContentTransformer getTransformer(String sourceUrl, String sourceMimetype, long sourceSize, String targetMimetype, TransformationOptions options)
     {
         List<ContentTransformer> transformers = getTransformers(sourceUrl, sourceMimetype, sourceSize, targetMimetype, options);
@@ -769,7 +806,9 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
 
     /**
      * @see org.alfresco.service.cmr.repository.ContentService#getTransformers(String, java.lang.String, long, java.lang.String, org.alfresco.service.cmr.repository.TransformationOptions)
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public List<ContentTransformer> getTransformers(String sourceUrl, String sourceMimetype, long sourceSize, String targetMimetype, TransformationOptions options)
     {
         try
@@ -790,7 +829,9 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
      * Checks if the file just uploaded into Share is a special "debugTransformers.txt" file and
      * if it is creates TransformerDebug that lists all the supported mimetype transformation for
      * each transformer.
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     private void debugTransformations(String sourceMimetype, String targetMimetype,
             long sourceSize, TransformationOptions transformOptions)
     {
@@ -809,7 +850,9 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     
     /**
      * {@inheritDoc}
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public long getMaxSourceSizeBytes(String sourceMimetype, String targetMimetype, TransformationOptions options)
     {
         try
@@ -845,12 +888,22 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             transformerDebug.popAvailable();
         }
     }
-    
+
+    /**
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     public List<ContentTransformer> getActiveTransformers(String sourceMimetype, String targetMimetype, TransformationOptions options)
     {
         return getActiveTransformers(sourceMimetype, -1, targetMimetype, options);
     }
 
+    /**
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     public List<ContentTransformer> getActiveTransformers(String sourceMimetype, long sourceSize, String targetMimetype, TransformationOptions options)
     {
         return transformerRegistry.getActiveTransformers(sourceMimetype, sourceSize, targetMimetype, options);
@@ -858,7 +911,9 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
 
     /**
      * @see org.alfresco.service.cmr.repository.ContentService#getImageTransformer()
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public ContentTransformer getImageTransformer()
     {
         return imageMagickContentTransformer;
@@ -867,7 +922,9 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     /**
      * @see org.alfresco.repo.content.transform.ContentTransformerRegistry
      * @see org.alfresco.repo.content.transform.ContentTransformer
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public boolean isTransformable(ContentReader reader, ContentWriter writer)
     {
        return isTransformable(reader, writer, new TransformationOptions());
@@ -875,7 +932,9 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     
     /**
      * @see org.alfresco.service.cmr.repository.ContentService#isTransformable(org.alfresco.service.cmr.repository.ContentReader, org.alfresco.service.cmr.repository.ContentWriter, org.alfresco.service.cmr.repository.TransformationOptions)
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public boolean isTransformable(ContentReader reader, ContentWriter writer, TransformationOptions options)
     {
      // check that source and target mimetypes are available

--- a/src/main/java/org/alfresco/repo/content/transform/AbstractContentTransformer2.java
+++ b/src/main/java/org/alfresco/repo/content/transform/AbstractContentTransformer2.java
@@ -58,7 +58,10 @@ import org.apache.commons.logging.LogFactory;
  * 
  * @author Derek Hulley
  * @author Roy Wetherall
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public abstract class AbstractContentTransformer2 extends AbstractContentTransformerLimits
 {

--- a/src/main/java/org/alfresco/repo/content/transform/AbstractContentTransformerLimits.java
+++ b/src/main/java/org/alfresco/repo/content/transform/AbstractContentTransformerLimits.java
@@ -52,7 +52,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * c) for the {@link TransformationOptions} provided for a specific transform.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public abstract class AbstractContentTransformerLimits extends ContentTransformerHelper implements ContentTransformer
 {

--- a/src/main/java/org/alfresco/repo/content/transform/AbstractRemoteContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/AbstractRemoteContentTransformer.java
@@ -36,7 +36,10 @@ import org.apache.commons.logging.Log;
 /**
  * Optionally sends transformations to a remote transformer if a {@link RemoteTransformerClient} is set and
  * the ".url" Alfresco global property is set.
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public abstract class AbstractRemoteContentTransformer extends AbstractContentTransformer2
 {
     private RemoteTransformerClient remoteTransformerClient;

--- a/src/main/java/org/alfresco/repo/content/transform/AppleIWorksContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/AppleIWorksContentTransformer.java
@@ -48,7 +48,10 @@ import java.util.List;
  * 
  * @author Neil Mc Erlean
  * @since 4.0
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class AppleIWorksContentTransformer extends AbstractContentTransformer2
 {
     private static final Log log = LogFactory.getLog(AppleIWorksContentTransformer.class);

--- a/src/main/java/org/alfresco/repo/content/transform/ArchiveContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/ArchiveContentTransformer.java
@@ -52,7 +52,10 @@ import org.apache.tika.parser.pkg.PackageParser;
  * @author Neil McErlean
  * @author Nick Burch
  * @since 3.4
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ArchiveContentTransformer extends TikaPoweredContentTransformer
 { 
     /**

--- a/src/main/java/org/alfresco/repo/content/transform/BinaryPassThroughContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/BinaryPassThroughContentTransformer.java
@@ -41,7 +41,10 @@ import org.apache.commons.logging.LogFactory;
  * @see org.alfresco.repo.content.transform.StringExtractingContentTransformer
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class BinaryPassThroughContentTransformer extends AbstractContentTransformer2
 {
     @SuppressWarnings("unused")

--- a/src/main/java/org/alfresco/repo/content/transform/ComplexContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/ComplexContentTransformer.java
@@ -57,7 +57,10 @@ import org.springframework.beans.factory.InitializingBean;
  * in order to accomplish its goal.
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public class ComplexContentTransformer extends AbstractContentTransformer2 implements InitializingBean
 {

--- a/src/main/java/org/alfresco/repo/content/transform/ContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/ContentTransformer.java
@@ -39,7 +39,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * Interface for class that allow content transformation from one mimetype to another.
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 @AlfrescoPublicApi
 public interface ContentTransformer extends ContentWorker
 {

--- a/src/main/java/org/alfresco/repo/content/transform/ContentTransformerHelper.java
+++ b/src/main/java/org/alfresco/repo/content/transform/ContentTransformerHelper.java
@@ -44,7 +44,10 @@ import org.springframework.beans.factory.BeanNameAware;
  * A class providing basic functionality shared by both {@link ContentTransformer}s and {@link ContentTransformerWorker}s.
  * 
  * @author dward
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public class ContentTransformerHelper implements BeanNameAware
 {

--- a/src/main/java/org/alfresco/repo/content/transform/ContentTransformerRegistry.java
+++ b/src/main/java/org/alfresco/repo/content/transform/ContentTransformerRegistry.java
@@ -47,7 +47,10 @@ import org.apache.commons.logging.LogFactory;
  * @see org.alfresco.repo.content.transform.ContentTransformer
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 @AlfrescoPublicApi
 public class ContentTransformerRegistry
 {

--- a/src/main/java/org/alfresco/repo/content/transform/ContentTransformerWorker.java
+++ b/src/main/java/org/alfresco/repo/content/transform/ContentTransformerWorker.java
@@ -35,8 +35,11 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * performing the transformation.
  * 
  * @author dward
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
 // TODO Modify ContentTransformerWorker to understand transformer limits. At the moment no workers use them
+@Deprecated
 @AlfrescoPublicApi
 public interface ContentTransformerWorker
 {

--- a/src/main/java/org/alfresco/repo/content/transform/DoubleMap.java
+++ b/src/main/java/org/alfresco/repo/content/transform/DoubleMap.java
@@ -62,7 +62,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * </pre>
  * 
  * @author Alan Davis
+ *
  */
+@Deprecated
 public class DoubleMap<K1, K2, V>
 {
     private final Map<K1, Map<K2, V>> mapMap = new ConcurrentHashMap<K1, Map<K2, V>>();

--- a/src/main/java/org/alfresco/repo/content/transform/EMLTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/EMLTransformer.java
@@ -53,7 +53,10 @@ import org.alfresco.util.TempFileProvider;
  * parser. Would require a recursing parser to be specified, but not the full
  * Auto one (we don't want attachments), just one containing text and html
  * related parsers.
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class EMLTransformer extends AbstractContentTransformer2
 
 {

--- a/src/main/java/org/alfresco/repo/content/transform/EncodingAwareStringBean.java
+++ b/src/main/java/org/alfresco/repo/content/transform/EncodingAwareStringBean.java
@@ -40,7 +40,10 @@ import org.htmlparser.util.ParserException;
  * This allows us to correctly handle HTML files where the encoding
  *  is specified against the content property (rather than in the 
  *  HTML Head Meta), see ALF-10466 for details.
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 class EncodingAwareStringBean extends StringBean
 {
     private static final long serialVersionUID = -9033414360428669553L;

--- a/src/main/java/org/alfresco/repo/content/transform/ExplictTransformationDetails.java
+++ b/src/main/java/org/alfresco/repo/content/transform/ExplictTransformationDetails.java
@@ -29,7 +29,10 @@ package org.alfresco.repo.content.transform;
  * Specifies transformations that are considered to be 'exceptional' so 
  * should be used in preference to other transformers that can perform
  * the same transformation.
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ExplictTransformationDetails extends SupportedTransformation
 {
     public ExplictTransformationDetails()

--- a/src/main/java/org/alfresco/repo/content/transform/FailoverContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/FailoverContentTransformer.java
@@ -48,7 +48,10 @@ import org.springframework.beans.factory.InitializingBean;
  * <P/>Transformers are considered to have failed of they throw an exception.
  * 
  * @author Neil McErlean
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public class FailoverContentTransformer extends AbstractContentTransformer2 implements InitializingBean
 {

--- a/src/main/java/org/alfresco/repo/content/transform/HtmlParserContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/HtmlParserContentTransformer.java
@@ -58,7 +58,10 @@ import org.apache.commons.logging.LogFactory;
  * @see <a href="http://sourceforge.net/tracker/?func=detail&aid=1644504&group_id=24399&atid=381401">HTML Parser</a>
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class HtmlParserContentTransformer extends AbstractContentTransformer2
 {
     @SuppressWarnings("unused")

--- a/src/main/java/org/alfresco/repo/content/transform/JodContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/JodContentTransformer.java
@@ -40,7 +40,10 @@ import java.io.File;
  * OpenOffice application to perform OpenOffice-driven conversions.
  * 
  * @author Neil McErlean
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class JodContentTransformer extends OOoContentTransformerHelper implements ContentTransformerWorker, InitializingBean
 {
     private static Log logger = LogFactory.getLog(JodContentTransformer.class);

--- a/src/main/java/org/alfresco/repo/content/transform/LogEntries.java
+++ b/src/main/java/org/alfresco/repo/content/transform/LogEntries.java
@@ -29,7 +29,10 @@ import org.apache.commons.logging.Log;
 
 /**
  * Interface that gives access to Log entries
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 interface LogEntries extends Log
 {
     /**

--- a/src/main/java/org/alfresco/repo/content/transform/MailContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/MailContentTransformer.java
@@ -35,7 +35,10 @@ import org.apache.tika.parser.microsoft.OfficeParser;
  *  Outlook email msg files.
  * 
  * @author Nick Burch
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class MailContentTransformer extends TikaPoweredContentTransformer
 {
     public MailContentTransformer() {

--- a/src/main/java/org/alfresco/repo/content/transform/MediaWikiContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/MediaWikiContentTransformer.java
@@ -51,7 +51,10 @@ import org.htmlcleaner.ContentToken;
  *  transformer cannot currently be converted to use Tika.
  * 
  * @author Roy Wetherall
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class MediaWikiContentTransformer extends AbstractContentTransformer2
 {
     /** The file folder service */

--- a/src/main/java/org/alfresco/repo/content/transform/OOXMLThumbnailContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/OOXMLThumbnailContentTransformer.java
@@ -52,7 +52,10 @@ import org.apache.poi.openxml4j.opc.PackageRelationshipTypes;
  * 
  * @author Nick Burch
  * @since 4.0.1
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class OOXMLThumbnailContentTransformer extends AbstractContentTransformer2
 {
     public static final String NO_THUMBNAIL_PRESENT_IN_FILE = "No thumbnail present in file, unable to generate ";

--- a/src/main/java/org/alfresco/repo/content/transform/OOoContentTransformerHelper.java
+++ b/src/main/java/org/alfresco/repo/content/transform/OOoContentTransformerHelper.java
@@ -49,7 +49,10 @@ import java.io.*;
 /**
  * A class providing basic OOo-related functionality shared by both
  * {@link ContentTransformer}s and {@link ContentTransformerWorker}s.
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public abstract class OOoContentTransformerHelper extends ContentTransformerHelper
 {
     private String documentFormatsConfiguration;

--- a/src/main/java/org/alfresco/repo/content/transform/PdfBoxContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/PdfBoxContentTransformer.java
@@ -44,7 +44,10 @@ import org.apache.tika.parser.pdf.PDFParserConfig;
  * 
  * @author Nick Burch
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class PdfBoxContentTransformer extends TikaPoweredContentTransformer
 {
     /**

--- a/src/main/java/org/alfresco/repo/content/transform/PoiContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/PoiContentTransformer.java
@@ -42,7 +42,10 @@ import org.apache.tika.parser.microsoft.OfficeParser;
  *  this does all the other Office file formats.
  * 
  * @author Nick Burch
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class PoiContentTransformer extends TikaPoweredContentTransformer
 {
    /** 

--- a/src/main/java/org/alfresco/repo/content/transform/PoiHssfContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/PoiHssfContentTransformer.java
@@ -51,7 +51,10 @@ import org.xml.sax.SAXException;
  * 
  * @author Nick Burch
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class PoiHssfContentTransformer extends TikaPoweredContentTransformer
 {
     /**

--- a/src/main/java/org/alfresco/repo/content/transform/PoiOOXMLContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/PoiOOXMLContentTransformer.java
@@ -37,7 +37,10 @@ import org.apache.tika.parser.microsoft.ooxml.OOXMLParser;
  *  conversions from the newer OOXML Office documents.
  *
  * @author Nick Burch
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class PoiOOXMLContentTransformer extends TikaPoweredContentTransformer
 {
    /** 

--- a/src/main/java/org/alfresco/repo/content/transform/ProxyContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/ProxyContentTransformer.java
@@ -37,7 +37,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * Makes use of a {@link ContentTransformerWorker} to perform conversions.
  * 
  * @author dward
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public class ProxyContentTransformer extends AbstractContentTransformer2
 {

--- a/src/main/java/org/alfresco/repo/content/transform/RemoteTransformerClient.java
+++ b/src/main/java/org/alfresco/repo/content/transform/RemoteTransformerClient.java
@@ -53,7 +53,10 @@ import java.util.StringJoiner;
  * saved in a ContentWriter. In the event of an error an Exception is thrown.
  *
  * @since 6.0
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class RemoteTransformerClient
 {
     private final String name;

--- a/src/main/java/org/alfresco/repo/content/transform/RuntimeExecutableContentTransformerOptions.java
+++ b/src/main/java/org/alfresco/repo/content/transform/RuntimeExecutableContentTransformerOptions.java
@@ -38,7 +38,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * execution string. 
  * 
  * @author Roy Wetherall
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class RuntimeExecutableContentTransformerOptions extends TransformationOptions
 {
     /** Map of property values */

--- a/src/main/java/org/alfresco/repo/content/transform/RuntimeExecutableContentTransformerWorker.java
+++ b/src/main/java/org/alfresco/repo/content/transform/RuntimeExecutableContentTransformerWorker.java
@@ -69,7 +69,10 @@ import org.springframework.beans.factory.InitializingBean;
  * 
  * @since 1.1
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public class RuntimeExecutableContentTransformerWorker extends ContentTransformerHelper implements ContentTransformerWorker, InitializingBean
 {

--- a/src/main/java/org/alfresco/repo/content/transform/StringExtractingContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/StringExtractingContentTransformer.java
@@ -43,7 +43,10 @@ import org.apache.commons.logging.LogFactory;
  * The transformation is sensitive to the source and target string encodings.
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class StringExtractingContentTransformer extends AbstractContentTransformer2
 {
     public static final String PREFIX_TEXT = "text/";

--- a/src/main/java/org/alfresco/repo/content/transform/SupportedTransformation.java
+++ b/src/main/java/org/alfresco/repo/content/transform/SupportedTransformation.java
@@ -28,7 +28,10 @@ package org.alfresco.repo.content.transform;
 /**
  * Represents a supported transformation. Normally used in a spring bean that limits
  * the number of supported configures.
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class SupportedTransformation
 {
     private String sourceMimetype;

--- a/src/main/java/org/alfresco/repo/content/transform/TextMiningContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TextMiningContentTransformer.java
@@ -34,7 +34,10 @@ import org.apache.tika.parser.microsoft.OfficeParser;
  *  (Word 6, 95, 97, 2000, 2003) into plain text, using Apache Tika.
  * 
  * @author Nick Burch
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TextMiningContentTransformer extends TikaPoweredContentTransformer
 {
     public TextMiningContentTransformer()

--- a/src/main/java/org/alfresco/repo/content/transform/TextToPdfContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TextToPdfContentTransformer.java
@@ -55,7 +55,10 @@ import java.util.Map;
  * 
  * @author Derek Hulley
  * @since 2.1.0
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TextToPdfContentTransformer extends AbstractContentTransformer2
 {
     private static final Log logger = LogFactory.getLog(TextToPdfContentTransformer.class);

--- a/src/main/java/org/alfresco/repo/content/transform/TikaAutoContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TikaAutoContentTransformer.java
@@ -42,7 +42,10 @@ import org.apache.tika.parser.Parser;
  *  extractor is defined. 
  * 
  * @author Nick Burch
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TikaAutoContentTransformer extends TikaPoweredContentTransformer
 {
     private static AutoDetectParser parser;

--- a/src/main/java/org/alfresco/repo/content/transform/TikaPoweredContainerExtractor.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TikaPoweredContainerExtractor.java
@@ -78,7 +78,10 @@ import org.apache.tika.parser.AutoDetectParser;
  *  an extension context file.
  * 
  * @author Nick Burch
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TikaPoweredContainerExtractor
 {
     private static final Log logger = LogFactory.getLog(TikaPoweredContainerExtractor.class);

--- a/src/main/java/org/alfresco/repo/content/transform/TikaPoweredContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TikaPoweredContentTransformer.java
@@ -64,7 +64,10 @@ import org.xml.sax.ContentHandler;
  *  transformers and have them nicely take priority.
  * 
  * @author Nick Burch
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public abstract class TikaPoweredContentTransformer extends AbstractRemoteContentTransformer
 {
     private static final Log logger = LogFactory.getLog(TikaPoweredContentTransformer.class);

--- a/src/main/java/org/alfresco/repo/content/transform/TikaSpringConfiguredContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TikaSpringConfiguredContentTransformer.java
@@ -41,7 +41,10 @@ import org.apache.tika.parser.Parser;
  *  either a spring created bean, or a parser class name.
  * 
  * @author Nick Burch
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TikaSpringConfiguredContentTransformer extends TikaPoweredContentTransformer
 {
     private Parser tikaParser;

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerConfig.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerConfig.java
@@ -39,7 +39,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * Provides access to transformer configuration and current performance data.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public interface TransformerConfig
 {

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerConfigDynamicTransformers.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerConfigDynamicTransformers.java
@@ -52,7 +52,10 @@ import org.apache.commons.logging.LogFactory;
  * Adds dynamic transformers defined in alfresco global properties to the ContentTransformerRegistry.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerConfigDynamicTransformers extends TransformerPropertyNameExtractor
 {
     private static final Log logger = LogFactory.getLog(TransformerConfigDynamicTransformers.class);

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerConfigImpl.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerConfigImpl.java
@@ -50,7 +50,10 @@ import org.springframework.extensions.surf.util.AbstractLifecycleBean;
  * Provides access to transformer configuration and current performance data.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public class TransformerConfigImpl extends AbstractLifecycleBean implements TransformerConfig
 {
     private static final Log logger = LogFactory.getLog(TransformerConfigImpl.class);

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerConfigLimits.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerConfigLimits.java
@@ -47,7 +47,10 @@ import org.apache.commons.logging.LogFactory;
  * Provides access to transformer limits defined via properties.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerConfigLimits extends TransformerPropertyNameExtractor
 {
     private static Log logger = LogFactory.getLog(TransformerConfigLimits.class);

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerConfigMBean.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerConfigMBean.java
@@ -30,7 +30,10 @@ package org.alfresco.repo.content.transform;
  * and statistics.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public interface TransformerConfigMBean
 {
     /**

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerConfigMBeanImpl.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerConfigMBeanImpl.java
@@ -37,7 +37,10 @@ import org.alfresco.service.cmr.repository.MimetypeService;
  * and statistics.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerConfigMBeanImpl implements TransformerConfigMBean
 {
     private static final String NO_TRANSFORMATIONS_TO_REPORT = "No transformations to report";

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerConfigProperty.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerConfigProperty.java
@@ -43,7 +43,10 @@ import org.alfresco.service.cmr.repository.NodeRef;
  * transformer and source and target mimetypes, falling back to defaults.
  *  
  * @author Alan Davis
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public class TransformerConfigProperty  extends TransformerPropertyNameExtractor
 {
     private Map<String, DoubleMap<String, String, String>> values;

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerConfigStatistics.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerConfigStatistics.java
@@ -46,7 +46,10 @@ import org.alfresco.service.cmr.repository.MimetypeService;
  * of another transformation.
  *
  * @author Alan Davis
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public class TransformerConfigStatistics
 {
     private TransformerConfigImpl transformerConfigImpl;

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerConfigSupported.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerConfigSupported.java
@@ -41,7 +41,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * defined via properties for all transformers.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerConfigSupported extends TransformerPropertyNameExtractor
 {
     // Holds configured (entries only exist if configured rather than for all possible combinations)

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerDebug.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerDebug.java
@@ -81,7 +81,10 @@ import org.springframework.util.ResourceUtils;
  * transformers) and {@link #popAvailable} are called.<p>
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public class TransformerDebug
 {
@@ -91,6 +94,7 @@ public class TransformerDebug
     private final Log logger;
     private final Log info;
 
+    @Deprecated
     @AlfrescoPublicApi 
     private enum Call
     {
@@ -98,7 +102,8 @@ public class TransformerDebug
         TRANSFORM,
         AVAILABLE_AND_TRANSFORM
     };
-    
+
+    @Deprecated
     @AlfrescoPublicApi
     private static class ThreadInfo
     {
@@ -149,7 +154,8 @@ public class TransformerDebug
             threadInfo.get().sb = sb;
         }
     }
-    
+
+    @Deprecated
     @AlfrescoPublicApi
     private static class Frame
     {
@@ -226,7 +232,8 @@ public class TransformerDebug
             return transformerName;
         }
     }
-    
+
+    @Deprecated
     @AlfrescoPublicApi
     private class UnavailableTransformer implements Comparable<UnavailableTransformer>
     {
@@ -1445,6 +1452,7 @@ public class TransformerDebug
         return result;
     }
 
+    @Deprecated
     @AlfrescoPublicApi
     private abstract class TestTransform
     {

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerDebugLog.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerDebugLog.java
@@ -38,7 +38,10 @@ import org.apache.commons.logging.Log;
  * {@link TransformerConfigMBean#getTransformationDebugLog(int)}.<p>
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerDebugLog extends TransformerLogger<DebugEntry>
 {
     private static Pattern END_OF_REQUEST_ID_PATTERN = Pattern.compile("[^0-9]");
@@ -105,6 +108,7 @@ public class TransformerDebugLog extends TransformerLogger<DebugEntry>
 }
 
 // Collects multiple lines of debug for the same transformer request.
+@Deprecated
 class DebugEntry
 {
     final String requestId;

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerInfoException.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerInfoException.java
@@ -37,8 +37,10 @@ import org.alfresco.error.AlfrescoRuntimeException;
  * See {@link org.alfresco.repo.content.transform.PoiHssfContentTransformer} for pattern.
  * 
  * @author Arseny Kovalchuk
- * 
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerInfoException extends AlfrescoRuntimeException
 {
     private static final long serialVersionUID = -4343331677825559617L;

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerLog.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerLog.java
@@ -37,7 +37,10 @@ import org.alfresco.api.AlfrescoPublicApi;
  * {@link TransformerConfigMBean#getTransformationLog(int)}.<p>
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public class TransformerLog extends TransformerLogger<String>
 {

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerLogger.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerLogger.java
@@ -42,7 +42,10 @@ import org.apache.commons.logging.Log;
  * Only supports debug level logging.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 abstract class TransformerLogger<T> extends LogAdapter implements LogEntries
 {

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerProperties.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerProperties.java
@@ -46,7 +46,10 @@ import org.apache.commons.logging.LogFactory;
  * As this class allows this to happen for the Transformers subsystem.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerProperties
 {
     private static final String TRANSFORMERS_PROPERTIES = "alfresco/subsystems/Transformers/default/transformers.properties";

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerPropertyGetter.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerPropertyGetter.java
@@ -44,7 +44,10 @@ import org.alfresco.service.cmr.repository.MimetypeService;
  * where these are sorted into groups.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerPropertyGetter
 {
     private final String string;

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerPropertyNameExtractor.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerPropertyNameExtractor.java
@@ -44,7 +44,10 @@ import org.alfresco.service.cmr.repository.MimetypeService;
  * Provides access to transformer property names and values.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public abstract class TransformerPropertyNameExtractor
 {
     private static Pattern EXTENSIONS_SEPARATOR = Pattern.compile("[^]\\\\]\\.");

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerPropertySetter.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerPropertySetter.java
@@ -65,7 +65,9 @@ import org.alfresco.util.Pair;
  * Provides methods to set and remove transformer properties and values.
  * 
  * @author Alan Davis
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerPropertySetter
 {
     /**

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerSelector.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerSelector.java
@@ -35,7 +35,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * able to handle a given transformation.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public interface TransformerSelector
 {

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerSelectorImpl.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerSelectorImpl.java
@@ -48,7 +48,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * Old 'Explicit' transformers have been given a priority of {@code 5}.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerSelectorImpl implements TransformerSelector
 {
     private TransformerConfig transformerConfig;

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerSelectorImplOriginal.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerSelectorImplOriginal.java
@@ -40,7 +40,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * to maintain the previous approach if they really wish.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerSelectorImplOriginal implements TransformerSelector
 {
     private ContentTransformerRegistry contentTransformerRegistry;

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerStatistics.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerStatistics.java
@@ -32,7 +32,10 @@ import org.alfresco.api.AlfrescoPublicApi;
  * source, target and transformer combination.
  *  
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public interface TransformerStatistics
 {

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerStatisticsImpl.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerStatisticsImpl.java
@@ -34,7 +34,10 @@ import org.alfresco.service.cmr.repository.MimetypeService;
  * Implementation of a {@link TransformerStatistics}.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerStatisticsImpl implements TransformerStatistics
 {
     private final MimetypeService mimetypeService;

--- a/src/main/java/org/alfresco/repo/content/transform/UnimportantTransformException.java
+++ b/src/main/java/org/alfresco/repo/content/transform/UnimportantTransformException.java
@@ -34,7 +34,10 @@ import org.alfresco.error.AlfrescoRuntimeException;
  * embedded image).
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class UnimportantTransformException extends AlfrescoRuntimeException
 {
     public UnimportantTransformException(String msgId)

--- a/src/main/java/org/alfresco/repo/content/transform/UnsupportedTransformationException.java
+++ b/src/main/java/org/alfresco/repo/content/transform/UnsupportedTransformationException.java
@@ -35,7 +35,10 @@ import org.alfresco.error.AlfrescoRuntimeException;
  * size of the intermediate file is unknown at the start.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public class UnsupportedTransformationException extends AlfrescoRuntimeException
 {

--- a/src/main/java/org/alfresco/repo/content/transform/magick/AbstractImageMagickContentTransformerWorker.java
+++ b/src/main/java/org/alfresco/repo/content/transform/magick/AbstractImageMagickContentTransformerWorker.java
@@ -44,7 +44,10 @@ import java.io.InputStream;
  * Abstract helper for transformations based on <b>ImageMagick</b>
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public abstract class AbstractImageMagickContentTransformerWorker extends ContentTransformerHelper implements ContentTransformerWorker, InitializingBean
 {
     /** the prefix for mimetypes supported by the transformer */

--- a/src/main/java/org/alfresco/repo/content/transform/magick/ImageMagickContentTransformerWorker.java
+++ b/src/main/java/org/alfresco/repo/content/transform/magick/ImageMagickContentTransformerWorker.java
@@ -61,9 +61,12 @@ import static org.alfresco.repo.rendition2.RenditionDefinition2.THUMBNAIL;
 
 /**
  * Executes a statement to implement 
- * 
+ *
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ImageMagickContentTransformerWorker extends AbstractImageMagickContentTransformerWorker
 {
     /** options variable name */

--- a/src/main/java/org/alfresco/repo/content/transform/magick/ImageResizeOptions.java
+++ b/src/main/java/org/alfresco/repo/content/transform/magick/ImageResizeOptions.java
@@ -31,7 +31,10 @@ import org.alfresco.api.AlfrescoPublicApi;
  * Image resize options
  * 
  * @author Roy Wetherall
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi 
 public class ImageResizeOptions
 {

--- a/src/main/java/org/alfresco/repo/content/transform/magick/ImageTransformationOptions.java
+++ b/src/main/java/org/alfresco/repo/content/transform/magick/ImageTransformationOptions.java
@@ -37,7 +37,10 @@ import org.alfresco.service.cmr.repository.TransformationSourceOptions;
  * Image transformation options
  * 
  * @author Roy Wetherall
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public class ImageTransformationOptions extends TransformationOptions
 {

--- a/src/main/java/org/alfresco/repo/content/transform/pdfrenderer/AlfrescoPdfRendererContentTransformerWorker.java
+++ b/src/main/java/org/alfresco/repo/content/transform/pdfrenderer/AlfrescoPdfRendererContentTransformerWorker.java
@@ -52,6 +52,11 @@ import static org.alfresco.repo.rendition2.RenditionDefinition2.MAINTAIN_ASPECT_
 import static org.alfresco.repo.rendition2.RenditionDefinition2.PAGE;
 import static org.alfresco.repo.rendition2.RenditionDefinition2.WIDTH;
 
+/**
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+ */
+@Deprecated
 public class AlfrescoPdfRendererContentTransformerWorker extends ContentTransformerHelper implements ContentTransformerWorker, InitializingBean
 {
 

--- a/src/main/java/org/alfresco/repo/content/transform/swf/SWFTransformationOptions.java
+++ b/src/main/java/org/alfresco/repo/content/transform/swf/SWFTransformationOptions.java
@@ -38,7 +38,10 @@ import static org.alfresco.repo.rendition2.RenditionDefinition2.FLASH_VERSION;
  * SFW transformation options
  * 
  * @author Roy Wetherall
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class SWFTransformationOptions extends TransformationOptions
 {
     private static final String OPT_FLASH_VERSION = FLASH_VERSION;

--- a/src/main/java/org/alfresco/repo/jscript/ScriptNode.java
+++ b/src/main/java/org/alfresco/repo/jscript/ScriptNode.java
@@ -2706,7 +2706,10 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
      * @param mimetype   Mimetype destination for the transformation
      * 
      * @return Node representing the newly transformed document.
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public ScriptNode transformDocument(String mimetype)
     {
         return transformDocument(mimetype, getPrimaryParentAssoc().getParentRef());
@@ -2720,12 +2723,20 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
      * @param destination   Destination folder location
      * 
      * @return Node representing the newly transformed document.
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public ScriptNode transformDocument(String mimetype, ScriptNode destination)
     {
         return transformDocument(mimetype, destination.getNodeRef());
     }
-    
+
+    /**
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     private ScriptNode transformDocument(String mimetype, NodeRef destination)
     {
         ParameterCheck.mandatoryString("Mimetype", mimetype);
@@ -2755,7 +2766,10 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
      * @param destination   Destination folder location for the resulting document
      * 
      * @return Node representing the transformed content - or null if the transform failed
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     private ScriptNode transformNode(Transformer transformer, String mimetype, NodeRef destination)
     {
         ScriptNode transformedNode = null;
@@ -2797,7 +2811,10 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
      * @param mimetype   Mimetype destination for the transformation
      * 
      * @return Node representing the newly transformed image.
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public ScriptNode transformImage(String mimetype)
     {
         return transformImage(mimetype, null, getPrimaryParentAssoc().getParentRef());
@@ -2811,7 +2828,10 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
      * @param options    Image convert command options
      * 
      * @return Node representing the newly transformed image.
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public ScriptNode transformImage(String mimetype, String options)
     {
         return transformImage(mimetype, options, getPrimaryParentAssoc().getParentRef());
@@ -2825,7 +2845,10 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
      * @param destination   Destination folder location
      * 
      * @return Node representing the newly transformed image.
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public ScriptNode transformImage(String mimetype, ScriptNode destination)
     {
         ParameterCheck.mandatory("Destination Node", destination);
@@ -2842,13 +2865,20 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
      * @param destination   Destination folder location
      * 
      * @return Node representing the newly transformed image.
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public ScriptNode transformImage(String mimetype, String options, ScriptNode destination)
     {
         ParameterCheck.mandatory("Destination Node", destination);
         return transformImage(mimetype, options, destination.getNodeRef());
     }
-    
+
+    /**
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     private ScriptNode transformImage(String mimetype, final String options, NodeRef destination)
     {
         ParameterCheck.mandatoryString("Mimetype", mimetype);
@@ -2999,7 +3029,10 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
      * 
      * @param  thumbnailName    the name of the thumbnail
      * @return ScriptThumbnail  the newly create thumbnail node
+     *
+     * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public ScriptThumbnail createThumbnail(String thumbnailName)
     {
         return createThumbnail(thumbnailName, false);
@@ -3017,7 +3050,10 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
      * @param  thumbnailName    the name of the thumbnail
      * @param  async            indicates whether the thumbnail is create asynchronously or not
      * @return ScriptThumbnail  the newly create thumbnail node or null if async creation occures
+     *
+     * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public ScriptThumbnail createThumbnail(String thumbnailName, boolean async)
     {
         return createThumbnail(thumbnailName, async, false);
@@ -3038,7 +3074,10 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
      * @param  async            indicates whether the thumbnail is create asynchronously or not
      * @param  force            ignore system.thumbnail.generate=false
      * @return ScriptThumbnail  the newly create thumbnail node or null if async creation occures
+     *
+     * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public ScriptThumbnail createThumbnail(String thumbnailName, boolean async, boolean force)
     {
         final ThumbnailService thumbnailService = services.getThumbnailService();
@@ -3119,7 +3158,10 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
      * 
      * @param thumbnailName     the thumbnail name
      * @return ScriptThumbnail  the thumbnail
+     *
+     * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public ScriptThumbnail getThumbnail(String thumbnailName)
     {
         ScriptThumbnail result = null;
@@ -3138,7 +3180,10 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
      * Get the all the thumbnails for a given node's content property.
      * 
      * @return  Scriptable     list of thumbnails, empty if none available
+     *
+     * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public ScriptThumbnail[] getThumbnails()
     {
         List<NodeRef> thumbnails = this.services.getThumbnailService().getThumbnails(
@@ -3165,7 +3210,10 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
      * and the destinatino mimetype of the thumbnail.
      * 
      * @return  String[]    array of thumbnail names that are valid for the current content type
+     *
+     * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     public String[] getThumbnailDefinitions()
     {
         ThumbnailService thumbnailService = this.services.getThumbnailService();
@@ -3189,7 +3237,9 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
     }
     /**
      * This version of the method name spelling is retained (for now) for backwards compatibility
-     * @see #getThumbnailDefinitions() 
+     * @see #getThumbnailDefinitions()
+     *
+     * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
     @Deprecated
     public String[] getThumbnailDefintions()
@@ -4126,7 +4176,10 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
     
     /**
      * Interface contract for simple anonymous classes that implement document transformations
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     private interface Transformer
     {
         /**
@@ -4142,7 +4195,13 @@ public class ScriptNode implements Scopeable, NamespacePrefixResolverProvider
         ScriptNode transform(ContentService contentService, NodeRef noderef,
             ContentReader reader, ContentWriter writer);
     }
-    
+
+    /**
+     *
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
     private abstract class AbstractTransformer implements Transformer
     {
         public ScriptNode transform(ContentService contentService, NodeRef nodeRef,

--- a/src/main/java/org/alfresco/repo/rendition/RenditionLocation.java
+++ b/src/main/java/org/alfresco/repo/rendition/RenditionLocation.java
@@ -29,8 +29,10 @@ import org.alfresco.service.cmr.repository.NodeRef;
 
 /**
  * This simple interface defines a data class which identifies a rendition node, its parent and its name.
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
-
+@Deprecated
 public interface RenditionLocation
 {
     /**

--- a/src/main/java/org/alfresco/repo/rendition/RenditionLocationImpl.java
+++ b/src/main/java/org/alfresco/repo/rendition/RenditionLocationImpl.java
@@ -29,7 +29,10 @@ import org.alfresco.service.cmr.repository.NodeRef;
 
 /**
  * This simple class is a struct containing a rendition node, its parent and its name.
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public class RenditionLocationImpl implements RenditionLocation
 {
     private final NodeRef parentRef;

--- a/src/main/java/org/alfresco/repo/rendition/RenditionLocationResolver.java
+++ b/src/main/java/org/alfresco/repo/rendition/RenditionLocationResolver.java
@@ -31,7 +31,10 @@ import org.alfresco.service.cmr.repository.NodeRef;
 
 /**
  * This interface defines a type which can be used to resolve the location of rendition nodes.
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public interface RenditionLocationResolver
 {
 

--- a/src/main/java/org/alfresco/repo/rendition/RenditionNodeManager.java
+++ b/src/main/java/org/alfresco/repo/rendition/RenditionNodeManager.java
@@ -60,7 +60,10 @@ import org.apache.commons.logging.LogFactory;
  * other things.
  * 
  * @author Nick Smith
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public class RenditionNodeManager
 {
     /** Logger */

--- a/src/main/java/org/alfresco/repo/rendition/RenditionedAspect.java
+++ b/src/main/java/org/alfresco/repo/rendition/RenditionedAspect.java
@@ -70,7 +70,10 @@ import org.apache.commons.logging.LogFactory;
  * 
  * @author Neil McErlean
  * @author Roy Wetherall
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public class RenditionedAspect implements NodeServicePolicies.OnUpdatePropertiesPolicy,
                                           CopyServicePolicies.OnCopyNodePolicy
 {

--- a/src/main/java/org/alfresco/repo/rendition/StandardRenditionLocationResolverImpl.java
+++ b/src/main/java/org/alfresco/repo/rendition/StandardRenditionLocationResolverImpl.java
@@ -66,6 +66,12 @@ import freemarker.ext.dom.NodeModel;
 import freemarker.template.SimpleDate;
 import freemarker.template.SimpleHash;
 
+/**
+ *
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
+ */
+@Deprecated
 public class StandardRenditionLocationResolverImpl implements RenditionLocationResolver
 {
     private final static Log log = LogFactory.getLog(StandardRenditionLocationResolverImpl.class);

--- a/src/main/java/org/alfresco/repo/rendition/executer/AbstractRenderingEngine.java
+++ b/src/main/java/org/alfresco/repo/rendition/executer/AbstractRenderingEngine.java
@@ -86,7 +86,10 @@ import org.springframework.extensions.surf.util.I18NUtil;
  * @author Neil McErlean
  * @author Nick Smith
  * @since 3.3
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public abstract class AbstractRenderingEngine extends ActionExecuterAbstractBase
 {
 

--- a/src/main/java/org/alfresco/repo/rendition/executer/AbstractTransformationRenderingEngine.java
+++ b/src/main/java/org/alfresco/repo/rendition/executer/AbstractTransformationRenderingEngine.java
@@ -61,7 +61,10 @@ import org.apache.commons.logging.LogFactory;
 
 /**
  * @author Nick Smith
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public abstract class AbstractTransformationRenderingEngine extends AbstractRenderingEngine
 {
     private static Log logger = LogFactory.getLog(AbstractTransformationRenderingEngine.class);

--- a/src/main/java/org/alfresco/repo/rendition/executer/BaseTemplateRenderingEngine.java
+++ b/src/main/java/org/alfresco/repo/rendition/executer/BaseTemplateRenderingEngine.java
@@ -58,7 +58,10 @@ import org.springframework.extensions.surf.util.I18NUtil;
  * 
  * @author Brian Remmington
  * @since 3.3
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public abstract class BaseTemplateRenderingEngine extends AbstractRenderingEngine
 {
     private static final Log log = LogFactory.getLog(BaseTemplateRenderingEngine.class);

--- a/src/main/java/org/alfresco/repo/rendition/executer/CompositeRenderingEngine.java
+++ b/src/main/java/org/alfresco/repo/rendition/executer/CompositeRenderingEngine.java
@@ -47,7 +47,10 @@ import org.apache.commons.logging.LogFactory;
  * definition executed is the output of this rendering engine.
  * 
  * @author Nick Smith
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public class CompositeRenderingEngine extends AbstractRenderingEngine
 {
     /** Logger */

--- a/src/main/java/org/alfresco/repo/rendition/executer/DeleteRenditionActionExecuter.java
+++ b/src/main/java/org/alfresco/repo/rendition/executer/DeleteRenditionActionExecuter.java
@@ -62,7 +62,10 @@ import org.apache.commons.logging.LogFactory;
  * 
  * @see RenditionedAspect
  * @see AddFailedThumbnailActionExecuter
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public class DeleteRenditionActionExecuter extends ActionExecuterAbstractBase
 {
     private static Log log = LogFactory.getLog(DeleteRenditionActionExecuter.class);

--- a/src/main/java/org/alfresco/repo/rendition/executer/FreemarkerRenderingEngine.java
+++ b/src/main/java/org/alfresco/repo/rendition/executer/FreemarkerRenderingEngine.java
@@ -43,7 +43,10 @@ import org.alfresco.service.cmr.repository.TemplateImageResolver;
 /**
  * @author Nick Smith
  * @since 3.3
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public class FreemarkerRenderingEngine
             extends BaseTemplateRenderingEngine
 {

--- a/src/main/java/org/alfresco/repo/rendition/executer/HTMLRenderingEngine.java
+++ b/src/main/java/org/alfresco/repo/rendition/executer/HTMLRenderingEngine.java
@@ -83,7 +83,10 @@ import org.xml.sax.helpers.AttributesImpl;
  * 
  * @author Nick Burch
  * @since 3.4
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public class HTMLRenderingEngine extends AbstractRenderingEngine
 {
     private static Log logger = LogFactory.getLog(HTMLRenderingEngine.class);

--- a/src/main/java/org/alfresco/repo/rendition/executer/ImageRenderingEngine.java
+++ b/src/main/java/org/alfresco/repo/rendition/executer/ImageRenderingEngine.java
@@ -49,7 +49,10 @@ import static org.alfresco.repo.rendition2.RenditionDefinition2.MAINTAIN_ASPECT_
  * 
  * @author Neil McErlean
  * @since 3.3
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public class ImageRenderingEngine extends AbstractTransformationRenderingEngine
 {
     public static final String NAME = "imageRenderingEngine";

--- a/src/main/java/org/alfresco/repo/rendition/executer/ReformatRenderingEngine.java
+++ b/src/main/java/org/alfresco/repo/rendition/executer/ReformatRenderingEngine.java
@@ -53,7 +53,10 @@ import static org.alfresco.repo.rendition2.RenditionDefinition2.FLASH_VERSION;
  * 
  * @author Neil McErlean
  * @since 3.3
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public class ReformatRenderingEngine extends AbstractTransformationRenderingEngine
 {
     private static Log logger = LogFactory.getLog(ReformatRenderingEngine.class);

--- a/src/main/java/org/alfresco/repo/rendition/executer/XSLTFunctions.java
+++ b/src/main/java/org/alfresco/repo/rendition/executer/XSLTFunctions.java
@@ -54,8 +54,11 @@ import org.xml.sax.SAXException;
 /**
  * @author Brian Remmington
  * @since 3.3
- * 
+ *
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public class XSLTFunctions
 {
     private static final Log log = LogFactory.getLog(XSLTFunctions.class);

--- a/src/main/java/org/alfresco/repo/rendition/executer/XSLTRenderingEngine.java
+++ b/src/main/java/org/alfresco/repo/rendition/executer/XSLTRenderingEngine.java
@@ -56,7 +56,10 @@ import org.xml.sax.SAXException;
 /**
  * @author Brian Remmington
  * @since 3.3
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public class XSLTRenderingEngine extends BaseTemplateRenderingEngine
 {
     public static final String NAME = "xsltRenderingEngine";

--- a/src/main/java/org/alfresco/repo/rendition/script/ScriptRenditionDefinition.java
+++ b/src/main/java/org/alfresco/repo/rendition/script/ScriptRenditionDefinition.java
@@ -39,7 +39,10 @@ import org.mozilla.javascript.Scriptable;
  * 
  * @author Neil McErlean
  * @see org.alfresco.service.cmr.rendition.RenditionDefinition
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public final class ScriptRenditionDefinition extends ScriptAction
 {
     private static final long serialVersionUID = 8132935577891455490L;

--- a/src/main/java/org/alfresco/repo/rendition/script/ScriptRenditionService.java
+++ b/src/main/java/org/alfresco/repo/rendition/script/ScriptRenditionService.java
@@ -44,7 +44,10 @@ import org.apache.commons.logging.LogFactory;
  * Script object representing the rendition service.
  * 
  * @author Neil McErlean
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 public class ScriptRenditionService extends BaseScopableProcessorExtension
 {
     private static Log logger = LogFactory.getLog(ScriptRenditionService.class);

--- a/src/main/java/org/alfresco/repo/service/ServiceDescriptorRegistry.java
+++ b/src/main/java/org/alfresco/repo/service/ServiceDescriptorRegistry.java
@@ -355,7 +355,13 @@ public class ServiceDescriptorRegistry
     {
         return (MultilingualContentService) getService(MULTILINGUAL_CONTENT_SERVICE);
     }
-    
+
+    /**
+     *
+     * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2
+     * or other external libraries.
+     */
+    @Deprecated
     @Override
     public ThumbnailService getThumbnailService()
     {
@@ -373,7 +379,12 @@ public class ServiceDescriptorRegistry
     {
         return (FormService)getService(FORM_SERVICE);
     }
-    
+
+    /**
+     *
+     * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
+     */
+    @Deprecated
     @Override
     public RenditionService getRenditionService() 
     {

--- a/src/main/java/org/alfresco/repo/template/BaseContentNode.java
+++ b/src/main/java/org/alfresco/repo/template/BaseContentNode.java
@@ -588,7 +588,11 @@ public abstract class BaseContentNode implements TemplateContent
          * 
          * @return the binary content stream converted to text using any available transformer
          *         if fails to convert then null will be returned
+         *
+         * @deprecated The transformations code is being moved out of the codebase and replaced by the new async
+         * RenditionService2 or other external libraries.
          */
+        @Deprecated
         public String getContentAsText(int length)
         {
             String result = null;

--- a/src/main/java/org/alfresco/repo/thumbnail/AddFailedThumbnailActionExecuter.java
+++ b/src/main/java/org/alfresco/repo/thumbnail/AddFailedThumbnailActionExecuter.java
@@ -79,7 +79,10 @@ import org.apache.commons.logging.LogFactory;
  * @see FailedThumbnailInfo
  * @see NodeEligibleForRethumbnailingEvaluator
  * @see ThumbnailServiceImpl#init()
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class AddFailedThumbnailActionExecuter extends ActionExecuterAbstractBase
 {
     private static Log log = LogFactory.getLog(AddFailedThumbnailActionExecuter.class);

--- a/src/main/java/org/alfresco/repo/thumbnail/CreateThumbnailActionExecuter.java
+++ b/src/main/java/org/alfresco/repo/thumbnail/CreateThumbnailActionExecuter.java
@@ -54,7 +54,10 @@ import org.apache.commons.logging.LogFactory;
  * 
  * @author Roy Wetherall
  * @author Ph Dubois (optional thumbnail creation by mimetype and in general)
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class CreateThumbnailActionExecuter extends ActionExecuterAbstractBase
 {
     private static Log logger = LogFactory.getLog(CreateThumbnailActionExecuter.class);

--- a/src/main/java/org/alfresco/repo/thumbnail/FailedThumbnailSourceAspect.java
+++ b/src/main/java/org/alfresco/repo/thumbnail/FailedThumbnailSourceAspect.java
@@ -60,7 +60,10 @@ import org.apache.commons.logging.LogFactory;
 
  * @author Neil Mc Erlean
  * @since 3.5.0
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class FailedThumbnailSourceAspect implements NodeServicePolicies.OnDeleteNodePolicy,
                                                     ContentServicePolicies.OnContentUpdatePolicy
 {

--- a/src/main/java/org/alfresco/repo/thumbnail/FailureHandlingOptions.java
+++ b/src/main/java/org/alfresco/repo/thumbnail/FailureHandlingOptions.java
@@ -35,7 +35,10 @@ import org.alfresco.repo.thumbnail.conditions.NodeEligibleForRethumbnailingEvalu
  * @author Neil Mc Erlean
  * @since 3.5.0
  * @see NodeEligibleForRethumbnailingEvaluator for a description of how these configuration parameters are used.
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class FailureHandlingOptions
 {
     public static final int DEFAULT_PERIOD = 0;

--- a/src/main/java/org/alfresco/repo/thumbnail/SimpleThumbnailer.java
+++ b/src/main/java/org/alfresco/repo/thumbnail/SimpleThumbnailer.java
@@ -54,7 +54,10 @@ import org.springframework.beans.factory.InitializingBean;
  * synchronously, this is not recommended for production use.
  * 
  * @author dward
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class SimpleThumbnailer extends TransactionListenerAdapter implements
         ContentServicePolicies.OnContentUpdatePolicy, InitializingBean
 {

--- a/src/main/java/org/alfresco/repo/thumbnail/ThumbnailDefinition.java
+++ b/src/main/java/org/alfresco/repo/thumbnail/ThumbnailDefinition.java
@@ -36,7 +36,10 @@ import java.util.Objects;
  * This class provides the thumbnail details to the thumbnail service.
  * 
  * @author Roy Wetherall
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ThumbnailDefinition
 {
 

--- a/src/main/java/org/alfresco/repo/thumbnail/ThumbnailDefinitionSpringRegisterer.java
+++ b/src/main/java/org/alfresco/repo/thumbnail/ThumbnailDefinitionSpringRegisterer.java
@@ -37,7 +37,10 @@ import org.springframework.beans.factory.InitializingBean;
  *  the same way as other Alfresco beans to their registrys.
  * 
  * @author Nick Burch
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ThumbnailDefinitionSpringRegisterer implements InitializingBean
 {
    private ThumbnailRegistry thumbnailRegistry;

--- a/src/main/java/org/alfresco/repo/thumbnail/ThumbnailHelper.java
+++ b/src/main/java/org/alfresco/repo/thumbnail/ThumbnailHelper.java
@@ -42,7 +42,10 @@ import org.alfresco.service.cmr.action.ActionService;
  * 
  * @author Neil Mc Erlean
  * @since 3.5.0
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ThumbnailHelper
 {
     public static Action createCreateThumbnailAction(ThumbnailDefinition thumbnailDef, ServiceRegistry services)

--- a/src/main/java/org/alfresco/repo/thumbnail/ThumbnailRegistry.java
+++ b/src/main/java/org/alfresco/repo/thumbnail/ThumbnailRegistry.java
@@ -59,7 +59,10 @@ import org.springframework.extensions.surf.util.AbstractLifecycleBean;
  * 
  * @author Roy Wetherall
  * @author Neil McErlean
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ThumbnailRegistry implements ApplicationContextAware, ApplicationListener<ApplicationContextEvent>
 {
     /** Logger */

--- a/src/main/java/org/alfresco/repo/thumbnail/ThumbnailRenditionConvertor.java
+++ b/src/main/java/org/alfresco/repo/thumbnail/ThumbnailRenditionConvertor.java
@@ -72,7 +72,10 @@ import static org.alfresco.service.cmr.repository.TransformationOptionLimits.OPT
  * @see RenditionDefinition
  * 
  * @author Neil McErlean
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ThumbnailRenditionConvertor
 {
     private RenditionService renditionService;

--- a/src/main/java/org/alfresco/repo/thumbnail/ThumbnailServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/thumbnail/ThumbnailServiceImpl.java
@@ -86,7 +86,10 @@ import org.springframework.extensions.surf.util.ParameterCheck;
 /**
  * @author Roy Wetherall
  * @author Neil McErlean
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ThumbnailServiceImpl implements ThumbnailService,
                                              NodeServicePolicies.BeforeCreateNodePolicy,
                                              NodeServicePolicies.OnCreateNodePolicy,

--- a/src/main/java/org/alfresco/repo/thumbnail/UpdateThumbnailActionExecuter.java
+++ b/src/main/java/org/alfresco/repo/thumbnail/UpdateThumbnailActionExecuter.java
@@ -54,7 +54,10 @@ import org.apache.commons.logging.LogFactory;
  * @author Roy Wetherall
  * @author Neil McErlean
  * @author Ph Dubois (optional thumbnail creation by mimetype and in general)
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class UpdateThumbnailActionExecuter extends ActionExecuterAbstractBase
 {
     /** Logger */

--- a/src/main/java/org/alfresco/repo/thumbnail/conditions/NodeEligibleForRethumbnailingEvaluator.java
+++ b/src/main/java/org/alfresco/repo/thumbnail/conditions/NodeEligibleForRethumbnailingEvaluator.java
@@ -77,7 +77,10 @@ import org.apache.commons.logging.LogFactory;
  * 
  * @author Neil Mc Erlean.
  * @since 3.5.0
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class NodeEligibleForRethumbnailingEvaluator extends ActionConditionEvaluatorAbstractBase 
 {
     private static Log logger = LogFactory.getLog(NodeEligibleForRethumbnailingEvaluator.class);

--- a/src/main/java/org/alfresco/repo/thumbnail/script/ScriptThumbnail.java
+++ b/src/main/java/org/alfresco/repo/thumbnail/script/ScriptThumbnail.java
@@ -42,7 +42,10 @@ import org.mozilla.javascript.Scriptable;
 /**
  * @author Roy Wetherall
  * @author Neil McErlean
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ScriptThumbnail extends ScriptNode
 {
     private static final long serialVersionUID = 7854749986083635678L;

--- a/src/main/java/org/alfresco/repo/thumbnail/script/ScriptThumbnailService.java
+++ b/src/main/java/org/alfresco/repo/thumbnail/script/ScriptThumbnailService.java
@@ -37,7 +37,10 @@ import org.alfresco.service.ServiceRegistry;
  * Script object representing the site service.
  * 
  * @author Roy Wetherall
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ScriptThumbnailService extends BaseScopableProcessorExtension
 {
 	/** Service Registry */

--- a/src/main/java/org/alfresco/service/ServiceRegistry.java
+++ b/src/main/java/org/alfresco/service/ServiceRegistry.java
@@ -428,10 +428,11 @@ public interface ServiceRegistry
     EditionService getEditionService();
     
     /**
-     * Get the Thumbnail Service
-     * @deprecated This method has been deprecated as it would return a service that is not part of the public API. 
-     * The service itself is not deprecated, but access to it via the ServiceRegistry will be removed in the future.
+     *
+     * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2
+     * or other external libraries.
      */
+    @Deprecated
     @NotAuditable
     ThumbnailService getThumbnailService();
     
@@ -451,7 +452,10 @@ public interface ServiceRegistry
 
     /**
      * Get the rendition service (or null if one is not provided)
+     *
+     * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
      */
+    @Deprecated
     @NotAuditable
     RenditionService getRenditionService();
 

--- a/src/main/java/org/alfresco/service/cmr/repository/AbstractTransformationSourceOptions.java
+++ b/src/main/java/org/alfresco/service/cmr/repository/AbstractTransformationSourceOptions.java
@@ -34,7 +34,10 @@ import java.util.Map;
  * and handles merge of options.
  * 
  * @author Ray Gauss II
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public abstract class AbstractTransformationSourceOptions implements TransformationSourceOptions, Cloneable
 {
 

--- a/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
+++ b/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
@@ -170,7 +170,10 @@ public interface ContentService
      * @throws NoTransformerException if no transformer exists for the
      *      given source and target mimetypes of the reader and writer
      * @throws ContentIOException if the transformation fails
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     @Auditable(parameters = {"reader", "writer"})
     public void transform(ContentReader reader, ContentWriter writer)
             throws NoTransformerException, ContentIOException;
@@ -193,8 +196,8 @@ public interface ContentService
      * As of release 3.0 the TransformOptions class should be used to pass transformation options 
      * to a transformation execution.
      */
-    @Auditable(parameters = {"reader", "writer", "options"})
     @Deprecated
+    @Auditable(parameters = {"reader", "writer", "options"})
     public void transform(ContentReader reader, ContentWriter writer, Map<String, Object> options)
             throws NoTransformerException, ContentIOException;
     
@@ -209,7 +212,10 @@ public interface ContentService
      * @throws NoTransformerException if no transformer exists for the
      *      given source and target mimetypes of the reader and writer
      * @throws ContentIOException if the transformation fails
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     @Auditable(parameters = {"reader", "writer", "options"})
     public void transform(ContentReader reader, ContentWriter writer, TransformationOptions options)
             throws NoTransformerException, ContentIOException;
@@ -227,7 +233,10 @@ public interface ContentService
      * 
      * @see ContentService#getTransformer(String, String, long, String, TransformationOptions)
      * @see ContentAccessor#getMimetype()
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     @Auditable(parameters = {"sourceMimetype", "targetMimetype"})
     public ContentTransformer getTransformer(String sourceMimetype, String targetMimetype);
     
@@ -246,7 +255,10 @@ public interface ContentService
      * @param  options              the transformation options
      * 
      * @return ContentTransformer   the transformers that can be used, or null if none are available
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     @Auditable(parameters = {"sourceMimetype", "sourceSize", "targetMimetype", "options"})
     public List<ContentTransformer> getTransformers(String sourceUrl, String sourceMimetype, long sourceSize, String targetMimetype, TransformationOptions options);
     
@@ -267,13 +279,17 @@ public interface ContentService
      * @return ContentTransformer   a transformer that can be used, or null if one was not available
      * 
      * @see ContentAccessor#getMimetype()
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     @Auditable(parameters = {"sourceMimetype", "sourceSize", "targetMimetype", "options"})
     public ContentTransformer getTransformer(String sourceUrl, String sourceMimetype, long sourceSize, String targetMimetype, TransformationOptions options);
     
     /**
      * @deprecated use overloaded method with sourceSize parameter.
      */
+    @Deprecated
     public ContentTransformer getTransformer(String sourceMimetype, String targetMimetype, TransformationOptions options);
 
     /**
@@ -283,7 +299,10 @@ public interface ContentService
      * @param targetMimetype target mime type
      * @param options transformation options
      * @return 0 if there are no transformers, -1 if there is no limit or if positive number the size in bytes.
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     @Auditable(parameters = {"sourceMimetype", "targetMimetype", "options"})
     public long getMaxSourceSizeBytes(String sourceMimetype, String targetMimetype, TransformationOptions options);
 
@@ -303,13 +322,17 @@ public interface ContentService
      * Fetch the transformer that is capable of transforming image content.
      * 
      * @return Returns a transformer that can be used, or null if one was not available
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     @Auditable
     public ContentTransformer getImageTransformer();
     
     /**
      * @deprecated use {@link #isTransformable(ContentReader, ContentWriter, TransformationOptions)}.
      */
+    @Deprecated
     @Auditable(parameters = {"reader", "writer"})
     public boolean isTransformable(ContentReader reader, ContentWriter writer);
     
@@ -330,7 +353,10 @@ public interface ContentService
      * @param  writer   the target content location and mimetype
      * @param  options  the transformation options
      * @return boolean  true if a transformer exists, false otherwise
+     *
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
      */
+    @Deprecated
     @Auditable(parameters = {"reader", "writer", "options"})
     public boolean isTransformable(ContentReader reader, ContentWriter writer, TransformationOptions options);
 }

--- a/src/main/java/org/alfresco/service/cmr/repository/SerializedTransformationOptionsAccessor.java
+++ b/src/main/java/org/alfresco/service/cmr/repository/SerializedTransformationOptionsAccessor.java
@@ -33,7 +33,10 @@ import org.alfresco.service.cmr.rendition.RenditionServiceException;
  * transformation options.
  * 
  * @author Ray Gauss II
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public interface SerializedTransformationOptionsAccessor
 {

--- a/src/main/java/org/alfresco/service/cmr/repository/TemporalSourceOptions.java
+++ b/src/main/java/org/alfresco/service/cmr/repository/TemporalSourceOptions.java
@@ -43,7 +43,10 @@ import org.alfresco.service.cmr.repository.AbstractTransformationSourceOptions;
  * a transform from the start until that duration is reached if possible.
  * 
  * @author Ray Gauss II
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TemporalSourceOptions extends AbstractTransformationSourceOptions
 {
 

--- a/src/main/java/org/alfresco/service/cmr/repository/TransformationOptionLimitsMap.java
+++ b/src/main/java/org/alfresco/service/cmr/repository/TransformationOptionLimitsMap.java
@@ -60,7 +60,10 @@ import org.apache.commons.logging.LogFactory;
  * </pre>
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformationOptionLimitsMap extends
         AbstractMap<String, Map<String, TransformationOptionLimits>>
 {

--- a/src/main/java/org/alfresco/service/cmr/repository/TransformationOptionPair.java
+++ b/src/main/java/org/alfresco/service/cmr/repository/TransformationOptionPair.java
@@ -46,7 +46,10 @@ import org.alfresco.repo.content.transform.TransformerDebug;
  * using the lowest of the four values.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public class TransformationOptionPair implements Serializable
 {

--- a/src/main/java/org/alfresco/service/cmr/repository/TransformationOptions.java
+++ b/src/main/java/org/alfresco/service/cmr/repository/TransformationOptions.java
@@ -43,7 +43,10 @@ import org.alfresco.service.namespace.QName;
  * 
  * @author Roy Wetherall
  * @since 3.0.0
+ *
+ * @deprecated The RenditionService is being replace by the simpler async RenditionService2.
  */
+@Deprecated
 @AlfrescoPublicApi
 public class TransformationOptions implements Cloneable
 {

--- a/src/main/java/org/alfresco/service/cmr/repository/TransformationSourceOptions.java
+++ b/src/main/java/org/alfresco/service/cmr/repository/TransformationSourceOptions.java
@@ -42,7 +42,10 @@ import org.alfresco.service.cmr.repository.PagedSourceOptions;
  * describes the page number that should be used from the source content.
  * 
  * @author Ray Gauss II
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @AlfrescoPublicApi
 public interface TransformationSourceOptions
 {

--- a/src/main/java/org/alfresco/service/cmr/thumbnail/FailedThumbnailInfo.java
+++ b/src/main/java/org/alfresco/service/cmr/thumbnail/FailedThumbnailInfo.java
@@ -40,7 +40,10 @@ import org.alfresco.service.cmr.repository.NodeRef;
  * 
  * @author Neil Mc Erlean
  * @since 3.5.0
+ *
+ * @deprecated We are introducing the new async RenditionService2.
  */
+@Deprecated
 public class FailedThumbnailInfo
 {
     private final String thumbnailDefinitionName;

--- a/src/main/java/org/alfresco/service/cmr/thumbnail/ThumbnailException.java
+++ b/src/main/java/org/alfresco/service/cmr/thumbnail/ThumbnailException.java
@@ -31,7 +31,10 @@ import org.alfresco.error.AlfrescoRuntimeException;
  * Thumbnail service exception class
  * 
  * @author Roy Wetherall
+ *
+ * @deprecated We are introducing the new async RenditionService2.
  */
+@Deprecated
 public class ThumbnailException extends AlfrescoRuntimeException 
 {
 	/**

--- a/src/main/java/org/alfresco/service/cmr/thumbnail/ThumbnailParentAssociationDetails.java
+++ b/src/main/java/org/alfresco/service/cmr/thumbnail/ThumbnailParentAssociationDetails.java
@@ -33,7 +33,10 @@ import org.springframework.extensions.surf.util.ParameterCheck;
  * Encapsulates the details of a thumbnails parent association
  * 
  * @author Roy Wetherall
+ *
+ * @deprecated We are introducing the new async RenditionService2.
  */
+@Deprecated
 public class ThumbnailParentAssociationDetails
 {
     /** The parent node reference */

--- a/src/main/java/org/alfresco/service/cmr/thumbnail/ThumbnailService.java
+++ b/src/main/java/org/alfresco/service/cmr/thumbnail/ThumbnailService.java
@@ -40,7 +40,10 @@ import org.alfresco.service.namespace.QName;
  * Thumbnail Service API
  * 
  * @author Roy Wetherall (based on original contribution by Ray Gauss II)
+ *
+ * @deprecated We are introducing the new async RenditionService2.
  */
+@Deprecated
 public interface ThumbnailService
 {
     /**

--- a/src/test/java/org/alfresco/repo/content/transform/AbstractContentTransformerLimitsTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/AbstractContentTransformerLimitsTest.java
@@ -52,7 +52,10 @@ import org.springframework.context.ApplicationContext;
 
 /**
  * Test methods that control limits in {@link AbstractContentTransformerLimits}
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class AbstractContentTransformerLimitsTest
 {
     private static final String A = MimetypeMap.MIMETYPE_XML;

--- a/src/test/java/org/alfresco/repo/content/transform/AbstractContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/AbstractContentTransformerTest.java
@@ -63,7 +63,10 @@ import org.springframework.util.ResourceUtils;
  * implementations.
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public abstract class AbstractContentTransformerTest extends TestCase
 {
     protected static String QUICK_CONTENT = "The quick brown fox jumps over the lazy dog";

--- a/src/test/java/org/alfresco/repo/content/transform/AppleIWorksContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/AppleIWorksContentTransformerTest.java
@@ -33,7 +33,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * 
  * @author Neil Mc Erlean
  * @since 4.0
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class AppleIWorksContentTransformerTest extends AbstractContentTransformerTest
 {
     private AppleIWorksContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/content/transform/ArchiveContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/ArchiveContentTransformerTest.java
@@ -44,7 +44,10 @@ import org.alfresco.util.TempFileProvider;
  * @see org.alfresco.repo.content.transform.ArchiveContentTransformer
  * 
  * @author Neil McErlean
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ArchiveContentTransformerTest extends AbstractContentTransformerTest
 {
     private ArchiveContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/content/transform/BinaryPassThroughContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/BinaryPassThroughContentTransformerTest.java
@@ -32,7 +32,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * @see org.alfresco.repo.content.transform.BinaryPassThroughContentTransformer
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class BinaryPassThroughContentTransformerTest extends AbstractContentTransformerTest
 {
     private BinaryPassThroughContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/content/transform/ComplexContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/ComplexContentTransformerTest.java
@@ -38,7 +38,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * @see org.alfresco.repo.content.transform.ComplexContentTransformer
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ComplexContentTransformerTest extends AbstractContentTransformerTest
 {
     private ComplexContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/content/transform/ContentTransformerRegistryTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/ContentTransformerRegistryTest.java
@@ -41,7 +41,10 @@ import org.alfresco.util.TempFileProvider;
  * @see org.alfresco.repo.content.transform.ContentTransformerRegistry
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ContentTransformerRegistryTest extends AbstractContentTransformerTest
 {
     private static final String A = MimetypeMap.MIMETYPE_TEXT_PLAIN;

--- a/src/test/java/org/alfresco/repo/content/transform/DifferrentMimeTypeTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/DifferrentMimeTypeTest.java
@@ -69,7 +69,10 @@ import junit.framework.TestCase;
  * mimetype of the node matches the content. This is the opposite of what this
  * test class was originally written to prove for MNT-11015. The current version
  * was reworked for MNT-16381.
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class DifferrentMimeTypeTest extends TestCase
 {
     private static Log log = LogFactory.getLog(DifferrentMimeTypeTest.class);

--- a/src/test/java/org/alfresco/repo/content/transform/EMLTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/EMLTransformerTest.java
@@ -42,7 +42,10 @@ import org.alfresco.util.TempFileProvider;
  * @see org.alfresco.repo.content.transform.EMLTransformer
  * 
  * @author Jamal Kaabi-Mofrad
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class EMLTransformerTest extends AbstractContentTransformerTest
 {
     private static final String QUICK_EML_CONTENT = "Gym class featuring a brown fox and lazy dog";

--- a/src/test/java/org/alfresco/repo/content/transform/FailoverContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/FailoverContentTransformerTest.java
@@ -43,7 +43,10 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
  * @see org.alfresco.repo.content.transform.FailoverContentTransformer
  * 
  * @author Neil McErlean
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class FailoverContentTransformerTest extends AbstractContentTransformerTest
 {
     private static final String sourceMimeType = MimetypeMap.MIMETYPE_PDF;
@@ -88,7 +91,10 @@ public class FailoverContentTransformerTest extends AbstractContentTransformerTe
  * This dummy class is used only for test purposes within this source file.
  * 
  * @author Neil McErlean
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 class DummyTestContentTransformer extends AbstractContentTransformer2 implements BeanNameAware
 {
     private static Log logger = LogFactory.getLog(DummyTestContentTransformer.class);

--- a/src/test/java/org/alfresco/repo/content/transform/FailoverUnsupportedSubtransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/FailoverUnsupportedSubtransformerTest.java
@@ -46,7 +46,10 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
  * @see org.alfresco.repo.content.transform.FailoverContentTransformer
  * 
  * @author Viachaslau Tsikhanovich
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class FailoverUnsupportedSubtransformerTest extends AbstractContentTransformerTest
 {
     private static final String sourceMimeType = MimetypeMap.MIMETYPE_EXCEL;
@@ -136,6 +139,7 @@ public class FailoverUnsupportedSubtransformerTest extends AbstractContentTransf
 /**
  * To share with DummyTestComplexSubtransformer to detect if html2pdf was triggered
  */
+@Deprecated
 class TestHtml2PdfTriggeredFlag
 {
     private boolean value;
@@ -151,6 +155,7 @@ class TestHtml2PdfTriggeredFlag
     }
 }
 
+@Deprecated
 class TestFailoverContentTransformer extends FailoverContentTransformer
 {
     private TestHtml2PdfTriggeredFlag triggered;
@@ -169,6 +174,7 @@ class TestFailoverContentTransformer extends FailoverContentTransformer
 /**
  * This dummy class is used only for test purposes within this source file.
  */
+@Deprecated
 class DummyTestComplexSubtransformer extends ComplexContentTransformer
 {
 
@@ -210,6 +216,7 @@ class DummyTestComplexSubtransformer extends ComplexContentTransformer
  * 
  * Supported source mimetype can be set
  */
+@Deprecated
 class DummyAnyToPDFTestSubtransformer extends DummyTestContentTransformer
 {
     @Override

--- a/src/test/java/org/alfresco/repo/content/transform/HtmlParserContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/HtmlParserContentTransformerTest.java
@@ -37,7 +37,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * @see org.alfresco.repo.content.transform.HtmlParserContentTransformer
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class HtmlParserContentTransformerTest extends AbstractContentTransformerTest
 {
     private HtmlParserContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/content/transform/JodContentTransformerOOoTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/JodContentTransformerOOoTest.java
@@ -41,7 +41,10 @@ import org.junit.Test;
  * 
  * @author Neil McErlean
  * @since 3.2 SP1
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class JodContentTransformerOOoTest extends AbstractJodConverterBasedTest
 {
     private static Log log = LogFactory.getLog(JodContentTransformerOOoTest.class);

--- a/src/test/java/org/alfresco/repo/content/transform/MailContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/MailContentTransformerTest.java
@@ -39,7 +39,10 @@ import org.alfresco.util.TempFileProvider;
  * @see org.alfresco.repo.content.transform.MailContentTransformer
  * 
  * @author Kevin Roast
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class MailContentTransformerTest extends AbstractContentTransformerTest
 {
     private MailContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/content/transform/MediaWikiContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/MediaWikiContentTransformerTest.java
@@ -42,7 +42,10 @@ import org.alfresco.util.TempFileProvider;
  * @see org.alfresco.repo.content.transform.MediaWikiContentTransformer
  * 
  * @author Roy Wetherall
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class MediaWikiContentTransformerTest extends AbstractContentTransformerTest
 {
     private MediaWikiContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/content/transform/OOXMLThumbnailContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/OOXMLThumbnailContentTransformerTest.java
@@ -33,7 +33,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * 
  * @author Nick Burch
  * @since 4.0.1
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class OOXMLThumbnailContentTransformerTest extends AbstractContentTransformerTest
 {
     private ContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/content/transform/OpenOfficeContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/OpenOfficeContentTransformerTest.java
@@ -41,7 +41,10 @@ import org.alfresco.util.TempFileProvider;
  * from the Enterprise Edition.
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class OpenOfficeContentTransformerTest extends AbstractContentTransformerTest
 {
     private static String MIMETYPE_RUBBISH = "text/rubbish";

--- a/src/test/java/org/alfresco/repo/content/transform/PdfBoxContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/PdfBoxContentTransformerTest.java
@@ -46,7 +46,10 @@ import org.alfresco.util.TempFileProvider;
  * @see org.alfresco.repo.content.transform.PdfBoxContentTransformer
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class PdfBoxContentTransformerTest extends AbstractContentTransformerTest
 {
     private PdfBoxContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/content/transform/PoiContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/PoiContentTransformerTest.java
@@ -32,7 +32,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * @see org.alfresco.repo.content.transform.PoiContentTransformer
  * 
  * @author Nick Burch
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class PoiContentTransformerTest extends AbstractContentTransformerTest
 {
     private PoiContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/content/transform/PoiHssfContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/PoiHssfContentTransformerTest.java
@@ -40,7 +40,10 @@ import org.alfresco.util.TempFileProvider;
  * @see org.alfresco.repo.content.transform.PoiHssfContentTransformer
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class PoiHssfContentTransformerTest extends TikaPoweredContentTransformerTest
 {
     private PoiHssfContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/content/transform/PoiOOXMLContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/PoiOOXMLContentTransformerTest.java
@@ -44,7 +44,10 @@ import org.alfresco.service.cmr.repository.TransformationOptions;
  * 
  * @author Nick Burch
  * @author Dmitry Velichkevich
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class PoiOOXMLContentTransformerTest extends AbstractContentTransformerTest
 {
     private static final int SMALL_TIMEOUT = 30;

--- a/src/test/java/org/alfresco/repo/content/transform/RemoteTransformerClientTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/RemoteTransformerClientTest.java
@@ -57,7 +57,10 @@ import static org.springframework.test.util.AssertionErrors.assertTrue;
  * Tests the retry mechanism in the RemoteTransformerClient.
  *
  * @since 6.0
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class RemoteTransformerClientTest
 {
     public static final int STARTUP_RETRY_PERIOD_SECONDS = 2;

--- a/src/test/java/org/alfresco/repo/content/transform/RuntimeExecutableContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/RuntimeExecutableContentTransformerTest.java
@@ -44,7 +44,10 @@ import org.alfresco.util.exec.RuntimeExec;
  * @see org.alfresco.repo.content.transform.RuntimeExecutableContentTransformerWorker
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class RuntimeExecutableContentTransformerTest extends BaseAlfrescoTestCase
 {
     private ContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/content/transform/StringExtractingContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/StringExtractingContentTransformerTest.java
@@ -46,7 +46,10 @@ import org.alfresco.util.TempFileProvider;
  * @see org.alfresco.repo.content.transform.StringExtractingContentTransformer
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class StringExtractingContentTransformerTest extends AbstractContentTransformerTest
 {
     private static final String SOME_CONTENT;

--- a/src/test/java/org/alfresco/repo/content/transform/TextMiningContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TextMiningContentTransformerTest.java
@@ -40,7 +40,10 @@ import org.alfresco.util.TempFileProvider;
  *  old and unsupported Text Mining library!
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TextMiningContentTransformerTest extends AbstractContentTransformerTest
 {
     private TextMiningContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/content/transform/TextToPdfContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TextToPdfContentTransformerTest.java
@@ -44,7 +44,10 @@ import org.apache.pdfbox.text.PDFTextStripper;
  * 
  * @author Derek Hulley
  * @since 2.1.0
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TextToPdfContentTransformerTest extends AbstractContentTransformerTest
 {
     private TextToPdfContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/content/transform/TikaAutoContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TikaAutoContentTransformerTest.java
@@ -36,7 +36,10 @@ import org.apache.tika.config.TikaConfig;
  * @see org.alfresco.repo.content.transform.TikaAutoContentTransformer
  * 
  * @author Nick Burch
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TikaAutoContentTransformerTest extends TikaPoweredContentTransformerTest
 {
     private TikaAutoContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/content/transform/TikaPoweredContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TikaPoweredContentTransformerTest.java
@@ -31,7 +31,10 @@ import org.alfresco.repo.content.MimetypeMap;
  * Parent test for Tika powered transformer tests 
  * 
  * @author Nick Burch
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public abstract class TikaPoweredContentTransformerTest extends AbstractContentTransformerTest
 {
    protected boolean isQuickPhraseExpected(String targetMimetype)

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerConfigDynamicTransformersTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerConfigDynamicTransformersTest.java
@@ -48,7 +48,10 @@ import org.mockito.MockitoAnnotations;
  * Tests the TransformerConfigDynamicTransformers class.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerConfigDynamicTransformersTest
 {
     @Mock

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerConfigImplTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerConfigImplTest.java
@@ -55,7 +55,10 @@ import org.springframework.context.ApplicationContext;
  * the real method is called.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerConfigImplTest
 {
     @Mock

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerConfigLimitsTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerConfigLimitsTest.java
@@ -40,7 +40,10 @@ import org.mockito.MockitoAnnotations;
  * Test class for TransformerConfigLimits.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerConfigLimitsTest
 {
     @Mock

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerConfigMBeanImplTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerConfigMBeanImplTest.java
@@ -49,7 +49,10 @@ import org.mockito.MockitoAnnotations;
  * Test class for TransformerConfigMBeanImpl.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerConfigMBeanImplTest
 {
     @Mock

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerConfigPropertyTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerConfigPropertyTest.java
@@ -45,7 +45,10 @@ import org.mockito.MockitoAnnotations;
  * Test class for TransformerConfigProperty.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerConfigPropertyTest
 {
     @Mock

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerConfigStatisticsTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerConfigStatisticsTest.java
@@ -40,7 +40,10 @@ import org.mockito.MockitoAnnotations;
  * Test class for TransformerConfigStatistics.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerConfigStatisticsTest
 {
     @Mock

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerConfigSupportedTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerConfigSupportedTest.java
@@ -40,7 +40,10 @@ import org.mockito.MockitoAnnotations;
  * Test class for TransformerConfigSupported.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerConfigSupportedTest
 {
     @Mock

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerConfigTestSuite.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerConfigTestSuite.java
@@ -63,7 +63,10 @@ import org.junit.runners.Suite.SuiteClasses;
  * Test classes in the Transformers subsystem
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerConfigTestSuite
 {
 }

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerDebugLogTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerDebugLogTest.java
@@ -41,7 +41,10 @@ import org.mockito.MockitoAnnotations;
  * Test class for TransformerDebugLog.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerDebugLogTest
 {
     @Mock

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerDebugTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerDebugTest.java
@@ -49,7 +49,10 @@ import static org.mockito.Mockito.when;
  * Test class for TransformerDebug.
  *
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerDebugTest
 {
     @Mock

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerLogTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerLogTest.java
@@ -39,7 +39,10 @@ import org.mockito.MockitoAnnotations;
  * Test class for TransformerLog.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerLogTest
 {
     @Mock

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerLoggerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerLoggerTest.java
@@ -44,7 +44,10 @@ import org.mockito.MockitoAnnotations;
  * Test class for TransformerLogger.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerLoggerTest
 {
     @Mock

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerPropertiesTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerPropertiesTest.java
@@ -44,7 +44,10 @@ import static org.mockito.Mockito.when;
  * are aliased to JodConverter settings if they are not set up.
  *
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerPropertiesTest
 {
     @Mock

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerPropertyGetterTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerPropertyGetterTest.java
@@ -48,7 +48,10 @@ import org.mockito.MockitoAnnotations;
  * Test class for TransformerPropertyGetter.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerPropertyGetterTest
 {
     @Mock

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerPropertyNameExtractorTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerPropertyNameExtractorTest.java
@@ -53,7 +53,11 @@ import org.mockito.MockitoAnnotations;
  * Test class for some of the regex methods and TransformerPropertyNameExtractor in general.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
+@SuppressWarnings("deprecation")
 public class TransformerPropertyNameExtractorTest
 {
     @Mock
@@ -698,6 +702,8 @@ public class TransformerPropertyNameExtractorTest
     }
 }
 
+@Deprecated
+@SuppressWarnings("deprecation")
 class TestTransformerPropertyNameExtractor extends TransformerPropertyNameExtractor
 {
     public Collection<TransformerSourceTargetSuffixValue> callGetTransformerSourceTargetValues(Collection<String> suffixes,

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerPropertySetterTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerPropertySetterTest.java
@@ -54,7 +54,10 @@ import org.mockito.MockitoAnnotations;
  * Tests TransformerPropertySetter.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerPropertySetterTest
 {
     @Mock
@@ -641,6 +644,7 @@ public class TransformerPropertySetterTest
     }
 }
 
+@Deprecated
 class DummyContentTransformer implements ContentTransformer
 {
     private final String name;

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerSelectorImplTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerSelectorImplTest.java
@@ -42,7 +42,10 @@ import org.mockito.MockitoAnnotations;
  * Test class for TransformerSelectorImpl.
  * 
  * @author Alan Davis
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformerSelectorImplTest
 {
     private static final String PNG = "image/png";
@@ -299,6 +302,7 @@ public class TransformerSelectorImplTest
     }
 }
 
+@Deprecated
 class DummyTransformerStatistics extends TransformerStatisticsImpl
 {
     private final long count;

--- a/src/test/java/org/alfresco/repo/content/transform/magick/ImageMagickContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/magick/ImageMagickContentTransformerTest.java
@@ -47,7 +47,10 @@ import org.alfresco.util.TempFileProvider;
  * @see org.alfresco.repo.content.transform.magick.ImageMagickContentTransformerWorker
  * 
  * @author Derek Hulley
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ImageMagickContentTransformerTest extends AbstractContentTransformerTest
 {
     private ProxyContentTransformer transformer;

--- a/src/test/java/org/alfresco/repo/rendition/MockedTestServiceRegistry.java
+++ b/src/test/java/org/alfresco/repo/rendition/MockedTestServiceRegistry.java
@@ -89,6 +89,11 @@ import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
 import org.alfresco.service.transaction.TransactionService;
 
+/**
+ *
+ * @deprecated We are introducing the new async RenditionService2.
+ */
+@Deprecated
 public class MockedTestServiceRegistry implements ServiceRegistry
 {
     private final ActionService actionService = mock(ActionService.class);

--- a/src/test/java/org/alfresco/repo/rendition/MultiUserRenditionTest.java
+++ b/src/test/java/org/alfresco/repo/rendition/MultiUserRenditionTest.java
@@ -68,7 +68,10 @@ import org.springframework.context.ApplicationContext;
  * 
  * @author Neil McErlean
  * @since 3.3.4
+ *
+ * @deprecated We are introducing the new async RenditionService2.
  */
+@Deprecated
 public class MultiUserRenditionTest
 {
     private ApplicationContext appContext;

--- a/src/test/java/org/alfresco/repo/rendition/RenditionNodeManagerTest.java
+++ b/src/test/java/org/alfresco/repo/rendition/RenditionNodeManagerTest.java
@@ -51,7 +51,10 @@ import org.alfresco.service.namespace.QName;
 
 /**
  * @author Nick Smith
+ *
+ * @deprecated We are introducing the new async RenditionService2.
  */
+@Deprecated
 public class RenditionNodeManagerTest extends TestCase
 {
     private final NodeService nodeService = mock(NodeService.class);

--- a/src/test/java/org/alfresco/repo/rendition/RenditionServiceImplTest.java
+++ b/src/test/java/org/alfresco/repo/rendition/RenditionServiceImplTest.java
@@ -45,7 +45,10 @@ import org.alfresco.service.namespace.QName;
 
 /**
  * @author Nick Smith
+ *
+ * @deprecated We are introducing the new async RenditionService2.
  */
+@Deprecated
 public class RenditionServiceImplTest extends TestCase
 {
     private final static String ENGINE_NAME = "Engine Name";

--- a/src/test/java/org/alfresco/repo/rendition/RenditionServiceIntegrationTest.java
+++ b/src/test/java/org/alfresco/repo/rendition/RenditionServiceIntegrationTest.java
@@ -105,7 +105,10 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Neil McErlean
  * @author Nick Smith
  * @since 3.3
+ *
+ * @deprecated We are introducing the new async RenditionService2.
  */
+@Deprecated
 @SuppressWarnings("deprecation")
 @Category({OwnJVMTestsCategory.class})
 @Transactional

--- a/src/test/java/org/alfresco/repo/rendition/RenditionServicePermissionsTest.java
+++ b/src/test/java/org/alfresco/repo/rendition/RenditionServicePermissionsTest.java
@@ -82,7 +82,10 @@ import static org.junit.Assert.*;
 /**
  * @author Neil McErlean
  * @since 3.3
+ *
+ * @deprecated We are introducing the new async RenditionService2.
  */
+@Deprecated
 @Category(OwnJVMTestsCategory.class)
 public class RenditionServicePermissionsTest
 {

--- a/src/test/java/org/alfresco/repo/rendition/StandardRenditionLocationResolverTest.java
+++ b/src/test/java/org/alfresco/repo/rendition/StandardRenditionLocationResolverTest.java
@@ -51,7 +51,10 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * @author Brian Remmington
  * @author Nick Smith
+ *
+ * @deprecated We are introducing the new async RenditionService2.
  */
+@Deprecated
 @Category(BaseSpringTestsCategory.class)
 @Transactional
 public class StandardRenditionLocationResolverTest extends BaseAlfrescoSpringTest

--- a/src/test/java/org/alfresco/repo/rendition/executer/AbstractRenderingEngineTest.java
+++ b/src/test/java/org/alfresco/repo/rendition/executer/AbstractRenderingEngineTest.java
@@ -55,7 +55,10 @@ import org.mockito.ArgumentCaptor;
 
 /**
  * @author Nick Smith
+ *
+ * @deprecated We are introducing the new async RenditionService2.
  */
+@Deprecated
 public class AbstractRenderingEngineTest extends TestCase
 {
     private final NodeRef source = new NodeRef("http://test/sourceId");

--- a/src/test/java/org/alfresco/repo/rendition/executer/HTMLRenderingEngineTest.java
+++ b/src/test/java/org/alfresco/repo/rendition/executer/HTMLRenderingEngineTest.java
@@ -62,7 +62,10 @@ import org.springframework.transaction.annotation.Transactional;
  * Unit tests for the HTML Rendering Engine
  * 
  * @author Nick Burch
+ *
+ * @deprecated We are introducing the new async RenditionService2.
  */
+@Deprecated
 @Category(BaseSpringTestsCategory.class)
 @Transactional
 public class HTMLRenderingEngineTest extends BaseAlfrescoSpringTest

--- a/src/test/java/org/alfresco/repo/rendition/executer/XSLTFunctionsTest.java
+++ b/src/test/java/org/alfresco/repo/rendition/executer/XSLTFunctionsTest.java
@@ -58,7 +58,10 @@ import org.w3c.dom.NodeList;
 /**
  * @author Brian
  *
+ *
+ * @deprecated We are introducing the new async RenditionService2.
  */
+@Deprecated
 @Category({BaseSpringTestsCategory.class})
 @Transactional
 public class XSLTFunctionsTest extends BaseAlfrescoSpringTest

--- a/src/test/java/org/alfresco/repo/rendition/executer/XSLTRenderingEngineTest.java
+++ b/src/test/java/org/alfresco/repo/rendition/executer/XSLTRenderingEngineTest.java
@@ -58,8 +58,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Brian
- * 
+ *
+ *
+ * @deprecated We are introducing the new async RenditionService2.
  */
+@Deprecated
 @Category(BaseSpringTestsCategory.class)
 @Transactional
 public class XSLTRenderingEngineTest extends BaseAlfrescoSpringTest

--- a/src/test/java/org/alfresco/repo/thumbnail/ThumbnailServiceImplParameterTest.java
+++ b/src/test/java/org/alfresco/repo/thumbnail/ThumbnailServiceImplParameterTest.java
@@ -71,7 +71,10 @@ import org.mockito.ArgumentCaptor;
  * Thumbnail service implementation unit test
  * 
  * @author Neil McErlean
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class ThumbnailServiceImplParameterTest
 {
     // Mocked services.

--- a/src/test/java/org/alfresco/repo/thumbnail/ThumbnailServiceImplTest.java
+++ b/src/test/java/org/alfresco/repo/thumbnail/ThumbnailServiceImplTest.java
@@ -110,7 +110,10 @@ import org.springframework.transaction.annotation.Transactional;
  * 
  * @author Roy Wetherall
  * @author Neil McErlean
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @Category(OwnJVMTestsCategory.class)
 @Transactional
 @ContextConfiguration({"classpath:alfresco/application-context.xml",

--- a/src/test/java/org/alfresco/repo/thumbnail/conditions/NodeEligibleForRethumbnailingEvaluatorTest.java
+++ b/src/test/java/org/alfresco/repo/thumbnail/conditions/NodeEligibleForRethumbnailingEvaluatorTest.java
@@ -54,7 +54,10 @@ import org.springframework.transaction.annotation.Transactional;
  * 
  * @author Neil Mc Erlean
  * @since 3.5.0
+ *
+ * @deprecated The thumbnails code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 @Category(OwnJVMTestsCategory.class)
 @Transactional
 public class NodeEligibleForRethumbnailingEvaluatorTest extends BaseSpringTest

--- a/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
+++ b/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
@@ -107,6 +107,7 @@ public class ContentServiceImplTest extends BaseVersionStoreTest
     }
 
     @Test
+    @Deprecated
     public void testTransformAndNulls()
     {
         NodeRef versionableNode = createNewVersionableNode();

--- a/src/test/java/org/alfresco/service/cmr/repository/TemporalSourceOptionsTest.java
+++ b/src/test/java/org/alfresco/service/cmr/repository/TemporalSourceOptionsTest.java
@@ -35,7 +35,10 @@ import org.junit.Test;
  * Test {@link TemporalSourceOptions}.
  * 
  * @author Ray Gauss II
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TemporalSourceOptionsTest
 {
     private TemporalSourceOptions temporalSourceOptions;

--- a/src/test/java/org/alfresco/service/cmr/repository/TransformationOptionLimitsTest.java
+++ b/src/test/java/org/alfresco/service/cmr/repository/TransformationOptionLimitsTest.java
@@ -36,7 +36,10 @@ import org.junit.Test;
 
 /**
  * Test TransformationOptionLimits
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformationOptionLimitsTest
 {
     private TransformationOptionLimits limits;

--- a/src/test/java/org/alfresco/service/cmr/repository/TransformationOptionPairTest.java
+++ b/src/test/java/org/alfresco/service/cmr/repository/TransformationOptionPairTest.java
@@ -37,7 +37,10 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Test TransformationOptionPair
+ *
+ * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
+@Deprecated
 public class TransformationOptionPairTest
 {
     TransformationOptionPair pair;


### PR DESCRIPTION
* Deprecate all classes in the following packages and their subpackages:
org.alfresco.repo.content.transform
org.alfresco.repo.rendition (not deprecated RenditionPreventionRegistry)
org.alfresco.service.cmr.rendition
org.alfresco.repo.thumbnail
org.alfresco.service.cmr.thumbnail

* Deprecate transformation related methods in ContentService and ContentServiceImpl

* Deprecated other classes used for local transformations or renditions:
AbstractTransformationSourceOptions
SerializedTransformationOptionsAccessor
TemporalSourceOptions
TransformationSourceOptions
CMISRenditionMapping

* Deprecate all other methods where the classes from the deprecated packages are used:
AbstractContentReader - Deprecated methods relating to transformations
ScriptNode - Deprecated thumbnail, transformation and Rendering API methods
BaseContentNode - Deprecated getContentAsText() as it uses deprecated transformation methods
CMISConnector - Deprecated methods relating to transformations

* Deprecated methods in ServiceRegistry and ServiceDescriptorRegistry that return deprecated services

* Deprecate related junit tests