### PR TITLE
REPO-3808: Fix activiti table bootstrap in large cluster and add more logging

### DIFF
--- a/src/main/java/org/alfresco/repo/domain/schema/SchemaBootstrap.java
+++ b/src/main/java/org/alfresco/repo/domain/schema/SchemaBootstrap.java
@@ -918,7 +918,7 @@ public class SchemaBootstrap extends AbstractLifecycleBean
             if (logger.isInfoEnabled())
             {
                 logger.info(
-                    "Update case: checkSchemaPatchScripts scripts executed in " + (System.currentTimeMillis() - start) + " ms");
+                    "Update scripts executed in " + (System.currentTimeMillis() - start) + " ms");
             }
         }
 
@@ -992,7 +992,7 @@ public class SchemaBootstrap extends AbstractLifecycleBean
 
             if (logger.isInfoEnabled())
             {
-                logger.info("Update case: checking all patches are applied, executed in: " + (System.currentTimeMillis() - start)
+                logger.info("Checking all patches have been applied, executed in: " + (System.currentTimeMillis() - start) 
                     + " ms");
             }
         }
@@ -1727,11 +1727,16 @@ public class SchemaBootstrap extends AbstractLifecycleBean
                 {
                     try
                     {
+                        long start = System.currentTimeMillis();
+
                         createdSchema = updateSchema(connection);
                         updatedSchema = true;
+
                         if (logger.isInfoEnabled())
                         {
-                            logger.info("Created schema value: " + createdSchema);
+                            logger.info(
+                                (createdSchema ? "Created" : "Updated") +
+                                    " schema in " + (System.currentTimeMillis() - start) + " ms");
                         }
                         break;
                     }

--- a/src/main/java/org/alfresco/repo/domain/schema/SchemaBootstrap.java
+++ b/src/main/java/org/alfresco/repo/domain/schema/SchemaBootstrap.java
@@ -928,7 +928,7 @@ public class SchemaBootstrap extends AbstractLifecycleBean
         boolean activitiTablesExist = checkActivitiTablesExist(connection);
         if (logger.isInfoEnabled())
         {
-            logger.info("Activiti tables exist: " + activitiTablesExist);
+            logger.info("Activiti tables need to be " + (activitiTablesExist ? "checked for patches" : " created"));
         }
 
         if(!activitiTablesExist)
@@ -992,8 +992,8 @@ public class SchemaBootstrap extends AbstractLifecycleBean
 
             if (logger.isInfoEnabled())
             {
-                logger.info("Checking all patches have been applied, executed in: " + (System.currentTimeMillis() - start) 
-                    + " ms");
+                logger.info("Checking all patches have been applied, executed in: " +
+                             (System.currentTimeMillis() - start) + " ms");
             }
         }
 

--- a/src/main/java/org/alfresco/repo/domain/schema/SchemaBootstrap.java
+++ b/src/main/java/org/alfresco/repo/domain/schema/SchemaBootstrap.java
@@ -1114,7 +1114,7 @@ public class SchemaBootstrap extends AbstractLifecycleBean
     {
         if (isAnotherClusterMemberBootstrapping(connection))
         {
-            logger.info("Another Alfresco cluster node is updating the DB. Waiting for the other node to finish...");
+            logger.info("Another Alfresco cluster node is updating the DB");
 
             // We throw a well-known exception to be handled by retrying code if required
             throw new LockFailedException();
@@ -1731,14 +1731,16 @@ public class SchemaBootstrap extends AbstractLifecycleBean
                         if (logger.isInfoEnabled())
                         {
                             logger.info(
-                                (createdSchema ? "Created" : "Updated") +
-                                    " schema in " + (System.currentTimeMillis() - start) + " ms");
+                                (createdSchema ? "Creating" : "Updating") +
+                                    " the DB schema took " + (System.currentTimeMillis() - start) + " ms");
                         }
                         break;
                     }
                     catch (LockFailedException e)
                     {
-                        logger.info("DB lock failed on schema bootstrap. Attempt: " + i);
+                        logger.info(
+                            "The current Alfresco cluster node is waiting for another chance to bootstrap the DB schema. "
+                                + "Attempt: " + (i + 1) + " of " + schemaUpdateLockRetryCount);
                         try { this.wait(schemaUpdateLockRetryWaitSeconds * 1000L); } catch (InterruptedException ee) {}
                     }
                 }

--- a/src/main/java/org/alfresco/repo/domain/schema/SchemaBootstrap.java
+++ b/src/main/java/org/alfresco/repo/domain/schema/SchemaBootstrap.java
@@ -781,6 +781,10 @@ public class SchemaBootstrap extends AbstractLifecycleBean
         {
             stmt.executeUpdate("create table alf_bootstrap_lock (charval CHAR(1) NOT NULL)");
             // Success
+            if (logger.isInfoEnabled())
+            {
+                logger.info("Bootstrap started.");
+            }
             return;
         }
         catch (Throwable e)
@@ -799,9 +803,7 @@ public class SchemaBootstrap extends AbstractLifecycleBean
      * has created the alf_bootstrap_lock table - This table indicates that a schema initialization
      * or schema DB update is in progress.
      *
-     * Advice: Do not consider this locking system as bullet proof!
-     *
-     * @return true if the alf_bootstrap_lock exists; false otherwise
+     * @return true if the alf_bootstrap_lock marker table exists in the DB; false otherwise
      *
      */
     private synchronized boolean isBootstrapInProgress(Connection connection) throws Exception
@@ -811,6 +813,10 @@ public class SchemaBootstrap extends AbstractLifecycleBean
         {
             stmt.executeQuery("select * from alf_bootstrap_lock");
             // Success
+            if (logger.isInfoEnabled())
+            {
+                logger.info("Bootstrap marker still present in the DB.");
+            }
             return true;
         }
         catch (Throwable e)
@@ -837,10 +843,17 @@ public class SchemaBootstrap extends AbstractLifecycleBean
 
             // from Thor
             executedStatementsThreadLocal.set(null);
+            if (logger.isInfoEnabled())
+            {
+                logger.info("Bootstrap completed.");
+            }
         }
         catch (Throwable e)
         {
-            // Table exists
+            if (logger.isDebugEnabled())
+            {
+                logger.debug("Exception in deleting the alf_bootstrap_lock table: " + e.getMessage(), e);
+            }
             throw AlfrescoRuntimeException.create(ERR_PREVIOUS_FAILED_BOOTSTRAP);
         }
         finally
@@ -857,12 +870,17 @@ public class SchemaBootstrap extends AbstractLifecycleBean
         boolean create = false;
         try
         {
-            countAppliedPatches(connection);
+            final int numberOfPatchesApplied = countAppliedPatches(connection);
+            if (logger.isInfoEnabled())
+            {
+                logger.info("Number of patches applied detected: " + numberOfPatchesApplied);
+            }
         }
         catch (NoSchemaException e)
         {
             create = true;
         }
+
         // Get the dialect
         final Dialect dialect = this.dialect;
         String dialectStr = dialect.getClass().getSimpleName();
@@ -884,22 +902,41 @@ public class SchemaBootstrap extends AbstractLifecycleBean
 
             if (logger.isInfoEnabled())
             {
-                logger.info("Create scripts executed in "+(System.currentTimeMillis()-start)+" ms");
+                logger.info("Create scripts executed in " + (System.currentTimeMillis() - start) + " ms");
             }
         }
         else
         {
+            long start = System.currentTimeMillis();
+
             // Execute any pre-auto-update scripts
             checkSchemaPatchScripts(connection, preUpdateScriptPatches, true);
             
             // Execute any post-auto-update scripts
             checkSchemaPatchScripts(connection, postUpdateScriptPatches, true);
+
+            if (logger.isInfoEnabled())
+            {
+                logger.info(
+                    "Update case: checkSchemaPatchScripts scripts executed in " + (System.currentTimeMillis() - start) + " ms");
+            }
         }
+
+        ensureCurrentClusterMemberIsBootstrapping(connection);
 
         // Initialise Activiti DB, using an unclosable connection
         boolean activitiTablesExist = checkActivitiTablesExist(connection);
+        if (logger.isInfoEnabled())
+        {
+            logger.info("Activiti tables exist: " + activitiTablesExist);
+        }
+
         if(!activitiTablesExist)
         {
+            long start = System.currentTimeMillis();
+
+            ensureCurrentClusterMemberIsBootstrapping(connection);
+
             // Activiti DB updates are performed as patches in alfresco, only give
             // control to activiti when creating new one.
             initialiseActivitiDBSchema(new UnclosableConnection(connection));
@@ -924,21 +961,40 @@ public class SchemaBootstrap extends AbstractLifecycleBean
                 appliedPatch.setReport("Placeholder for Activiti bootstrap at schema " + installedSchemaNumber);
                 appliedPatchDAO.createAppliedPatch(appliedPatch);
             }
+            if (logger.isInfoEnabled())
+            {
+                logger.info("Creating and patching activiti tables executed in: " + (System.currentTimeMillis() - start) + " ms");
+            }
         }
         else
         {
+            long start = System.currentTimeMillis();
+
             // Execute any auto-update scripts for Activiti tables
             checkSchemaPatchScripts(connection, updateActivitiScriptPatches, true);
 
             // verify that all Activiti patches have been applied correctly
             checkSchemaPatchScripts(connection, updateActivitiScriptPatches, false);
+
+            if (logger.isInfoEnabled())
+            {
+                logger.info("Checking and patching activiti tables executed in: " + (System.currentTimeMillis() - start) + " ms");
+            }
         }
 
         if (!create)
         {
+            long start = System.currentTimeMillis();
+
             // verify that all patches have been applied correctly
             checkSchemaPatchScripts(connection, preUpdateScriptPatches, false);       // check scripts
             checkSchemaPatchScripts(connection, postUpdateScriptPatches, false);      // check scripts
+
+            if (logger.isInfoEnabled())
+            {
+                logger.info("Update case: checking all patches are applied, executed in: " + (System.currentTimeMillis() - start)
+                    + " ms");
+            }
         }
 
         return create;
@@ -951,6 +1007,11 @@ public class SchemaBootstrap extends AbstractLifecycleBean
      */
     private void initialiseActivitiDBSchema(Connection connection)
     {
+        if (logger.isInfoEnabled())
+        {
+            logger.info("Initialise Activiti DB Schema tables");
+        }
+
         // create instance of activiti engine to initialise schema
         ProcessEngine engine = null;
         ProcessEngineConfiguration engineConfig = ProcessEngineConfiguration.createStandaloneProcessEngineConfiguration();
@@ -995,17 +1056,7 @@ public class SchemaBootstrap extends AbstractLifecycleBean
             return;
         }
 
-        if (executedStatementsThreadLocal.get()== null && isBootstrapInProgress(connection))
-        {
-            // This means that there is a bootstrap in progress and this node has NOT executed any queries
-            // therefore this node is NOT the one doing the schema initialization/upgrade
-            // we should therefore wait for the other node to finish and then continue the checks
-            logger.info("Another cluster node is doing a DB schema initialization or DB update. "
-                + "Waiting for the other node to finish...");
-
-            // We throw a well-known exception to be handled by retrying code if required
-            throw new LockFailedException();
-        }
+        ensureCurrentClusterMemberIsBootstrapping(connection);
 
         // Retrieve the first installed schema number
         int installedSchema = getInstalledSchemaNumber(connection);
@@ -1050,7 +1101,42 @@ public class SchemaBootstrap extends AbstractLifecycleBean
             executeScriptUrl(connection, scriptUrl);
         }
     }
-    
+
+    /**
+     * This method throws a LockFailedException in case the current Alfresco cluster node
+     * is NOT the node that is doing the schema bootstrap;
+     * This is the exception that signals that this node should wait for a while and retry
+     *
+     *
+     * Only one node from the cluster should do the initialization of the DB, so all other
+     * nodes should just retry to execute the schema checks after the initialization of
+     * the DB has ended;
+     *
+     */
+    private void ensureCurrentClusterMemberIsBootstrapping(Connection connection) throws Exception
+    {
+        if (isAnotherClusterMemberBootstrapping(connection))
+        {
+            logger.info("Another cluster node is doing a DB schema initialization or DB update. "
+                + "Waiting for the other node to finish...");
+
+            // We throw a well-known exception to be handled by retrying code if required
+            throw new LockFailedException();
+        }
+    }
+
+    /**
+     *
+     * @return true if there is a bootstrap in progress and this node has NOT executed any queries
+     * therefore this node is NOT the one doing the schema initialization/upgrade
+     *
+     * @throws Exception if the DB connections has problems
+     */
+    private boolean isAnotherClusterMemberBootstrapping(Connection connection) throws Exception
+    {
+        return executedStatementsThreadLocal.get()== null && isBootstrapInProgress(connection);
+    }
+
     private void executeScriptUrl(Connection connection, String scriptUrl) throws Exception
     {
         Dialect dialect = this.dialect;
@@ -1161,9 +1247,8 @@ public class SchemaBootstrap extends AbstractLifecycleBean
             String scriptUrl) throws Exception
     {
         final Dialect dialect = this.dialect;
-        
-        StringBuilder executedStatements = executedStatementsThreadLocal.get();
-        if (executedStatements == null)
+
+        if (executedStatementsThreadLocal.get() == null)
         {
             // Validate the schema, pre-upgrade
             validateSchema("Alfresco-{0}-Validation-Pre-Upgrade-{1}-", null);
@@ -1172,8 +1257,7 @@ public class SchemaBootstrap extends AbstractLifecycleBean
 
             // There is no lock at this stage.  This process can fall out if the lock can't be applied.
             setBootstrapStarted(connection);
-            executedStatements = new StringBuilder(8094);
-            executedStatementsThreadLocal.set(executedStatements);
+            executedStatementsThreadLocal.set(new StringBuilder(8094));
         }
         
         if (scriptUrl == null)
@@ -1645,6 +1729,10 @@ public class SchemaBootstrap extends AbstractLifecycleBean
                     {
                         createdSchema = updateSchema(connection);
                         updatedSchema = true;
+                        if (logger.isInfoEnabled())
+                        {
+                            logger.info("Created schema value: " + createdSchema);
+                        }
                         break;
                     }
                     catch (LockFailedException e)

--- a/src/main/java/org/alfresco/repo/domain/schema/SchemaBootstrap.java
+++ b/src/main/java/org/alfresco/repo/domain/schema/SchemaBootstrap.java
@@ -873,7 +873,7 @@ public class SchemaBootstrap extends AbstractLifecycleBean
             final int numberOfPatchesApplied = countAppliedPatches(connection);
             if (logger.isInfoEnabled())
             {
-                logger.info("Number of patches applied detected: " + numberOfPatchesApplied);
+                logger.info("Applied patches detected: " + numberOfPatchesApplied);
             }
         }
         catch (NoSchemaException e)
@@ -902,7 +902,7 @@ public class SchemaBootstrap extends AbstractLifecycleBean
 
             if (logger.isInfoEnabled())
             {
-                logger.info("Create scripts executed in " + (System.currentTimeMillis() - start) + " ms");
+                logger.info("Creating Alfresco tables took " + (System.currentTimeMillis() - start) + " ms");
             }
         }
         else
@@ -918,7 +918,7 @@ public class SchemaBootstrap extends AbstractLifecycleBean
             if (logger.isInfoEnabled())
             {
                 logger.info(
-                    "Update scripts executed in " + (System.currentTimeMillis() - start) + " ms");
+                    "Checking and patching Alfresco tables took " + (System.currentTimeMillis() - start) + " ms");
             }
         }
 
@@ -963,7 +963,7 @@ public class SchemaBootstrap extends AbstractLifecycleBean
             }
             if (logger.isInfoEnabled())
             {
-                logger.info("Creating and patching activiti tables executed in: " + (System.currentTimeMillis() - start) + " ms");
+                logger.info("Creating Activiti tables took " + (System.currentTimeMillis() - start) + " ms");
             }
         }
         else
@@ -978,7 +978,7 @@ public class SchemaBootstrap extends AbstractLifecycleBean
 
             if (logger.isInfoEnabled())
             {
-                logger.info("Checking and patching activiti tables executed in: " + (System.currentTimeMillis() - start) + " ms");
+                logger.info("Checking and patching Activiti tables took " + (System.currentTimeMillis() - start) + " ms");
             }
         }
 
@@ -992,8 +992,7 @@ public class SchemaBootstrap extends AbstractLifecycleBean
 
             if (logger.isInfoEnabled())
             {
-                logger.info("Checking all patches have been applied, executed in: " +
-                             (System.currentTimeMillis() - start) + " ms");
+                logger.info("Checking that all patches have been applied took " + (System.currentTimeMillis() - start) + " ms");
             }
         }
 
@@ -1007,11 +1006,6 @@ public class SchemaBootstrap extends AbstractLifecycleBean
      */
     private void initialiseActivitiDBSchema(Connection connection)
     {
-        if (logger.isInfoEnabled())
-        {
-            logger.info("Initialise Activiti DB Schema tables");
-        }
-
         // create instance of activiti engine to initialise schema
         ProcessEngine engine = null;
         ProcessEngineConfiguration engineConfig = ProcessEngineConfiguration.createStandaloneProcessEngineConfiguration();
@@ -1026,7 +1020,10 @@ public class SchemaBootstrap extends AbstractLifecycleBean
                 buildProcessEngine();
 
             String schemaName = dbSchemaName != null ? dbSchemaName : databaseMetaDataHelper.getSchema(connection);
-            // create or upgrade the DB schema
+            if (logger.isInfoEnabled())
+            {
+                logger.info("Creating Activiti DB schema tables");
+            }
             engine.getManagementService().databaseSchemaUpgrade(connection, null, schemaName);
         }
         finally
@@ -1117,8 +1114,7 @@ public class SchemaBootstrap extends AbstractLifecycleBean
     {
         if (isAnotherClusterMemberBootstrapping(connection))
         {
-            logger.info("Another cluster node is doing a DB schema initialization or DB update. "
-                + "Waiting for the other node to finish...");
+            logger.info("Another Alfresco cluster node is updating the DB. Waiting for the other node to finish...");
 
             // We throw a well-known exception to be handled by retrying code if required
             throw new LockFailedException();


### PR DESCRIPTION
- There was a check for the bootstrap marker missing in the if statement that initialized and created the activiti tables in the DB.
- Added more logging as the cluster boot up is much more frequent now with Kubernetes and docker, we need better logging so we can determine if there are problems, what went wrong