### PR TITLE
REPO-3876: Fix Remote User Mapper

### DIFF
--- a/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceConfig.java
+++ b/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceConfig.java
@@ -56,21 +56,37 @@ public class IdentityServiceConfig extends AdapterConfig implements Initializing
         this.globalProperties = globalProperties;
     }
 
+    /**
+     *
+     * @return Client connection timeout in milliseconds.
+     */
     public int getClientConnectionTimeout()
     {
         return clientConnectionTimeout;
     }
 
+    /**
+     *
+     * @param clientConnectionTimeout Client connection timeout in milliseconds.
+     */
     public void setClientConnectionTimeout(int clientConnectionTimeout)
     {
         this.clientConnectionTimeout = clientConnectionTimeout;
     }
 
+    /**
+     *
+     * @return Client socket timeout in milliseconds.s
+     */
     public int getClientSocketTimeout()
     {
         return clientSocketTimeout;
     }
 
+    /**
+     *
+     * @param clientSocketTimeout Client socket timeout in milliseconds.
+     */
     public void setClientSocketTimeout(int clientSocketTimeout)
     {
         this.clientSocketTimeout = clientSocketTimeout;

--- a/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceConfig.java
+++ b/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceConfig.java
@@ -47,10 +47,33 @@ public class IdentityServiceConfig extends AdapterConfig implements Initializing
     private static final String CREDENTIALS_PROVIDER = "identity-service.credentials.provider";
     
     private Properties globalProperties;
+
+    private int clientConnectionTimeout;
+    private int clientSocketTimeout;
     
     public void setGlobalProperties(Properties globalProperties)
     {
         this.globalProperties = globalProperties;
+    }
+
+    public int getClientConnectionTimeout()
+    {
+        return clientConnectionTimeout;
+    }
+
+    public void setClientConnectionTimeout(int clientConnectionTimeout)
+    {
+        this.clientConnectionTimeout = clientConnectionTimeout;
+    }
+
+    public int getClientSocketTimeout()
+    {
+        return clientSocketTimeout;
+    }
+
+    public void setClientSocketTimeout(int clientSocketTimeout)
+    {
+        this.clientSocketTimeout = clientSocketTimeout;
     }
     
     @Override

--- a/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceDeploymentFactoryBean.java
+++ b/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceDeploymentFactoryBean.java
@@ -56,14 +56,22 @@ public class IdentityServiceDeploymentFactoryBean implements FactoryBean<Keycloa
     {
         KeycloakDeployment deployment = KeycloakDeploymentBuilder.build(this.identityServiceConfig);
 
-        // Set client with custom timeout values. This can be removed if the future versions of Keycloak accept timeout values through the config.
-        int connectionTimeout = identityServiceConfig.getClientConnectionTimeout();
-        int socketTimeout = identityServiceConfig.getClientSocketTimeout();
-        HttpClient client = new HttpClientBuilder()
-                .establishConnectionTimeout(connectionTimeout, TimeUnit.MILLISECONDS)
-                .socketTimeout(socketTimeout, TimeUnit.MILLISECONDS)
-                .build(this.identityServiceConfig);
-        deployment.setClient(client);
+        // Set client with custom timeout values if client was created. This can be removed if the future versions of Keycloak accept timeout values through the config.
+        if (deployment.getClient() != null)
+        {
+            int connectionTimeout = identityServiceConfig.getClientConnectionTimeout();
+            int socketTimeout = identityServiceConfig.getClientSocketTimeout();
+            HttpClient client = new HttpClientBuilder()
+                    .establishConnectionTimeout(connectionTimeout, TimeUnit.MILLISECONDS)
+                    .socketTimeout(socketTimeout, TimeUnit.MILLISECONDS)
+                    .build(this.identityServiceConfig);
+            deployment.setClient(client);
+
+            if (logger.isDebugEnabled())
+            {
+                logger.debug("Created HttpClient for Keycloak deployment with connection timeout: "+ connectionTimeout + " ms, socket timeout: "+ socketTimeout+" ms.");
+            }
+        }
 
         if (logger.isInfoEnabled())
         {

--- a/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceDeploymentFactoryBean.java
+++ b/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceDeploymentFactoryBean.java
@@ -27,9 +27,13 @@ package org.alfresco.repo.security.authentication.identityservice;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.client.HttpClient;
+import org.keycloak.adapters.HttpClientBuilder;
 import org.keycloak.adapters.KeycloakDeployment;
 import org.keycloak.adapters.KeycloakDeploymentBuilder;
 import org.springframework.beans.factory.FactoryBean;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Creates an instance of a KeycloakDeployment object for communicating with the Identity Service.
@@ -51,7 +55,14 @@ public class IdentityServiceDeploymentFactoryBean implements FactoryBean<Keycloa
     public KeycloakDeployment getObject() throws Exception
     {
         KeycloakDeployment deployment = KeycloakDeploymentBuilder.build(this.identityServiceConfig);
-        
+
+        // Set client with custom timeout values. This can be removed if the future versions of Keycloak accept timeout values through the config.
+        HttpClient client = new HttpClientBuilder()
+                .establishConnectionTimeout(2, TimeUnit.SECONDS)
+                .socketTimeout(2, TimeUnit.SECONDS)
+                .build(this.identityServiceConfig);
+        deployment.setClient(client);
+
         if (logger.isInfoEnabled())
         {
             logger.info("Keycloak JWKS URL: " + deployment.getJwksUrl());

--- a/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceDeploymentFactoryBean.java
+++ b/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceDeploymentFactoryBean.java
@@ -56,7 +56,8 @@ public class IdentityServiceDeploymentFactoryBean implements FactoryBean<Keycloa
     {
         KeycloakDeployment deployment = KeycloakDeploymentBuilder.build(this.identityServiceConfig);
 
-        // Set client with custom timeout values if client was created. This can be removed if the future versions of Keycloak accept timeout values through the config.
+        // Set client with custom timeout values if client was created by the KeycloakDeploymentBuilder.
+        // This can be removed if the future versions of Keycloak accept timeout values through the config.
         if (deployment.getClient() != null)
         {
             int connectionTimeout = identityServiceConfig.getClientConnectionTimeout();
@@ -70,6 +71,13 @@ public class IdentityServiceDeploymentFactoryBean implements FactoryBean<Keycloa
             if (logger.isDebugEnabled())
             {
                 logger.debug("Created HttpClient for Keycloak deployment with connection timeout: "+ connectionTimeout + " ms, socket timeout: "+ socketTimeout+" ms.");
+            }
+        }
+        else
+        {
+            if (logger.isDebugEnabled())
+            {
+                logger.debug("HttpClient for Keycloak deployment was not set.");
             }
         }
 

--- a/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceDeploymentFactoryBean.java
+++ b/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceDeploymentFactoryBean.java
@@ -57,9 +57,11 @@ public class IdentityServiceDeploymentFactoryBean implements FactoryBean<Keycloa
         KeycloakDeployment deployment = KeycloakDeploymentBuilder.build(this.identityServiceConfig);
 
         // Set client with custom timeout values. This can be removed if the future versions of Keycloak accept timeout values through the config.
+        int connectionTimeout = identityServiceConfig.getClientConnectionTimeout();
+        int socketTimeout = identityServiceConfig.getClientSocketTimeout();
         HttpClient client = new HttpClientBuilder()
-                .establishConnectionTimeout(2, TimeUnit.SECONDS)
-                .socketTimeout(2, TimeUnit.SECONDS)
+                .establishConnectionTimeout(connectionTimeout, TimeUnit.MILLISECONDS)
+                .socketTimeout(socketTimeout, TimeUnit.MILLISECONDS)
                 .build(this.identityServiceConfig);
         deployment.setClient(client);
 

--- a/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceRemoteUserMapper.java
+++ b/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceRemoteUserMapper.java
@@ -35,7 +35,6 @@ import org.alfresco.repo.security.authentication.external.RemoteUserMapper;
 import org.alfresco.service.cmr.security.PersonService;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.keycloak.adapters.BasicAuthRequestAuthenticator;
 import org.keycloak.adapters.KeycloakDeployment;
 import org.keycloak.adapters.spi.AuthOutcome;
 import org.keycloak.representations.AccessToken;
@@ -132,8 +131,7 @@ public class IdentityServiceRemoteUserMapper implements RemoteUserMapper, Activa
         }
         catch (Exception e)
         {
-            logger.error("Failed to authenticate user using IdentityServiceRemoteUserMapper.", e);
-
+            logger.error("Failed to authenticate user using IdentityServiceRemoteUserMapper: " + e.getMessage(), e);
         }
 
         return null;
@@ -187,7 +185,6 @@ public class IdentityServiceRemoteUserMapper implements RemoteUserMapper, Activa
         }
         else
         {
-            // Basic auth in IdentityServiceRemoteUserMapper was removed as part of https://issues.alfresco.com/jira/browse/REPO-3876
             if (logger.isDebugEnabled())
             {
                 logger.debug("User could not be authenticated by IdentityServiceRemoteUserMapper.");

--- a/src/main/resources/alfresco/subsystems/Authentication/identity-service/identity-service-authentication-context.xml
+++ b/src/main/resources/alfresco/subsystems/Authentication/identity-service/identity-service-authentication-context.xml
@@ -182,6 +182,12 @@
       <property name="ignoreOAuthQueryParameter">
          <value>${identity-service.ignore-oauth-query-parameter:false}</value>
       </property>
+      <property name="clientConnectionTimeout">
+         <value>${identity-service.client-connection-timeout:2000}</value>
+      </property>
+      <property name="clientSocketTimeout">
+         <value>${identity-service.client-socket-timeout:2000}</value>
+      </property>
    </bean>
 
    <bean name="identityServiceDeployment" class="org.alfresco.repo.security.authentication.identityservice.IdentityServiceDeploymentFactoryBean">

--- a/src/test/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceRemoteUserMapperTest.java
+++ b/src/test/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceRemoteUserMapperTest.java
@@ -93,9 +93,6 @@ public class IdentityServiceRemoteUserMapperTest extends AbstractChainedSubsyste
     private KeyPair keyPair;
     private IdentityServiceConfig identityServiceConfig;
 
-    /* (non-Javadoc)
-     * @see junit.framework.TestCase#setUp()
-     */
     @Override
     protected void setUp() throws Exception
     {
@@ -115,10 +112,7 @@ public class IdentityServiceRemoteUserMapperTest extends AbstractChainedSubsyste
         this.identityServiceConfig = (IdentityServiceConfig)childApplicationContextFactory.
                     getApplicationContext().getBean(CONFIG_BEAN_NAME);
     }
-    
-    /* (non-Javadoc)
-     * @see junit.framework.TestCase#tearDown()
-     */
+
     @Override
     protected void tearDown() throws Exception
     {

--- a/src/test/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceRemoteUserMapperTest.java
+++ b/src/test/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceRemoteUserMapperTest.java
@@ -300,18 +300,10 @@ public class IdentityServiceRemoteUserMapperTest extends AbstractChainedSubsyste
         // create mock request object
         HttpServletRequest mockRequest = createMockTokenRequest(jwt);
         
-        // ensure an exception is thrown with correct description
-        try
-        {
-            ((RemoteUserMapper)childApplicationContextFactory.getApplicationContext().getBean(
-                        REMOTE_USER_MAPPER_BEAN_NAME)).getRemoteUser(mockRequest);
-            fail("Expected an AuthenticationException to be thrown");
-        }
-        catch (AuthenticationException ae)
-        {
-            assertTrue("Exception message contains 'Invalid token signature'", 
-                        ae.getMessage().indexOf("Invalid token signature") != -1);
-        }
+        // ensure user mapper falls through instead of throwing an exception
+        String user = ((RemoteUserMapper)childApplicationContextFactory.getApplicationContext().getBean(
+                REMOTE_USER_MAPPER_BEAN_NAME)).getRemoteUser(mockRequest);
+        assertEquals("Returned user should be null when wrong public key is used.",  null, user);
     }
     
     public void testInvalidJwt() throws Exception
@@ -361,17 +353,9 @@ public class IdentityServiceRemoteUserMapperTest extends AbstractChainedSubsyste
         HttpServletRequest mockRequest = createMockTokenRequest(jwt);
         
         // ensure an exception is thrown with correct description
-        try
-        {
-            ((RemoteUserMapper)childApplicationContextFactory.getApplicationContext().getBean(
+        String user = ((RemoteUserMapper)childApplicationContextFactory.getApplicationContext().getBean(
                         REMOTE_USER_MAPPER_BEAN_NAME)).getRemoteUser(mockRequest);
-            fail("Expected an AuthenticationException to be thrown");
-        }
-        catch (AuthenticationException ae)
-        {
-            assertTrue("Exception message contains 'Token is not active'", 
-                        ae.getMessage().indexOf("Token is not active") != -1);
-        }
+        assertEquals("Returned user should be null when the token is expired.", null, user);
     }
     
     public void testMissingHeader() throws Exception
@@ -381,22 +365,6 @@ public class IdentityServiceRemoteUserMapperTest extends AbstractChainedSubsyste
         
         // ensure null is returned if the header was missing
         assertNull(((RemoteUserMapper) childApplicationContextFactory.getApplicationContext().getBean(
-              REMOTE_USER_MAPPER_BEAN_NAME)).getRemoteUser(mockRequest));
-    }
-    
-    public void testBasicAuthFallback() throws Exception
-    {
-        // create mock objects
-        HttpServletRequest mockRequest = createMockBasicRequest();
-        HttpClient mockHttpClient = createMockHttpClient();
-        
-        // override the http client on the keycloak deployment
-        KeycloakDeployment deployment  = (KeycloakDeployment)childApplicationContextFactory.getApplicationContext().
-                    getBean(DEPLOYMENT_BEAN_NAME);
-        deployment.setClient(mockHttpClient);
-        
-        // validate correct user was found
-        assertEquals(TEST_USER_USERNAME, ((RemoteUserMapper) childApplicationContextFactory.getApplicationContext().getBean(
               REMOTE_USER_MAPPER_BEAN_NAME)).getRemoteUser(mockRequest));
     }
     

--- a/src/test/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceRemoteUserMapperTest.java
+++ b/src/test/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceRemoteUserMapperTest.java
@@ -205,7 +205,13 @@ public class IdentityServiceRemoteUserMapperTest extends AbstractChainedSubsyste
         
         assertEquals("identity-service.public-key-cache-ttl", 3600, 
                     this.identityServiceConfig.getPublicKeyCacheTtl());
-        
+
+        assertEquals("identity-service.client-connection-timeout", 3000,
+                this.identityServiceConfig.getClientConnectionTimeout());
+
+        assertEquals("identity-service.client-socket-timeout", 1000,
+                this.identityServiceConfig.getClientSocketTimeout());
+
         // check boolean overrides
         assertFalse("identity-service.public-client", 
                     this.identityServiceConfig.isPublicClient());
@@ -247,8 +253,8 @@ public class IdentityServiceRemoteUserMapperTest extends AbstractChainedSubsyste
                     this.identityServiceConfig.isIgnoreOAuthQueryParameter());
         
         assertTrue("identity-service.turn-off-change-session-id-on-login", 
-                    this.identityServiceConfig.getTurnOffChangeSessionIdOnLogin());    
-        
+                    this.identityServiceConfig.getTurnOffChangeSessionIdOnLogin());
+
         // check credentials overrides
         Map<String, Object> credentials = this.identityServiceConfig.getCredentials();
         assertNotNull("Expected a credentials map", credentials);

--- a/src/test/resources/alfresco-global.properties
+++ b/src/test/resources/alfresco-global.properties
@@ -43,4 +43,6 @@ identity-service.enable-pkce=true
 identity-service.ignore-oauth-query-parameter=true
 identity-service.credentials.secret=11111
 identity-service.credentials.provider=secret
+identity-service.client-socket-timeout=1000
+identity-service.client-connection-timeout=3000
 


### PR DESCRIPTION
* Set timeout to the http client used by keycloak to retrieve a public key
* Ensure that the user mapper does not throw exceptions
* IdentityServiceRemoteUserMapper should not attempt basic authentication