### PR TITLE
REPO-3627 / MNT-19630: CMIS: Unable to call getAllVersions() if node is checked out and if binding type is WSDL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>7.22-SNAPSHOT</version>
+    <version>test-repo3627</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -15,7 +15,7 @@
         <connection>scm:git:git@github.com:Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:git@github.com:Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>HEAD</tag>
+        <tag>alfresco-repository-test-repo3627</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>test-repo3627</version>
+    <version>7.22-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -15,7 +15,7 @@
         <connection>scm:git:git@github.com:Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:git@github.com:Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>alfresco-repository-test-repo3627</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceImpl.java
+++ b/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceImpl.java
@@ -2385,18 +2385,6 @@ public class AlfrescoCmisServiceImpl extends AbstractCmisService implements Alfr
         // what kind of object is it?
         CMISNodeInfo info = getOrCreateNodeInfo(versionSeriesId, "Version Series");
 
-        // when webservices binding is used, objectId points to null and versionSeriesId points to original node instead of PWC
-        // see MNT-13839
-        if (objectId == null)
-        {
-            info = getOrCreateNodeInfo(versionSeriesId);
-            if (info.hasPWC())
-            {
-                NodeRef nodeRef = info.getNodeRef();
-                info = getOrCreateNodeInfo(connector.getCheckOutCheckInService().getWorkingCopy(nodeRef).toString());
-            }
-        }
-
         if (!info.isVariant(CMISObjectVariant.CURRENT_VERSION))
         {
             // the version series id is the id of current version, which is a


### PR DESCRIPTION
- removed code that was made useless by previous code changes (see MNT-15338)
- added junit for the case when getAllVersions() is used with null objectId (Cmis WS binding) 