### PR TITLE
REPO-3972  doc to pdf is not sent to the Transform Service

### DIFF
--- a/src/main/java/org/alfresco/repo/rendition2/TransformationOptionsConverter.java
+++ b/src/main/java/org/alfresco/repo/rendition2/TransformationOptionsConverter.java
@@ -112,7 +112,7 @@ public class TransformationOptionsConverter implements InitializingBean
 
     private static Set<String> PDF_OPTIONS = new HashSet<>(Arrays.asList(new String[]
             {
-                    PAGE, WIDTH, HEIGHT, ALLOW_ENLARGEMENT, MAINTAIN_ASPECT_RATIO
+                    PAGE, WIDTH, HEIGHT
             }));
 
     private static Set<String> FLASH_OPTIONS = new HashSet<>(Arrays.asList(new String[]
@@ -182,16 +182,19 @@ public class TransformationOptionsConverter implements InitializingBean
         TransformationOptions transformationOptions = null;
         Set<String> optionNames = options.keySet();
 
+        // The "pdf" rendition is special as it was incorrectly set up as an SWFTransformationOptions in 6.0
+        boolean isPdfRendition = "pdf".equals(renditionName);
+
         Set<String> subclassOptionNames = new HashSet<>(optionNames);
         subclassOptionNames.removeAll(LIMIT_OPTIONS);
         subclassOptionNames.remove(INCLUDE_CONTENTS);
-        if (!subclassOptionNames.isEmpty())
+        if (isPdfRendition || !subclassOptionNames.isEmpty())
         {
-            if (FLASH_OPTIONS.containsAll(subclassOptionNames))
+            if (isPdfRendition || FLASH_OPTIONS.containsAll(subclassOptionNames))
             {
                 SWFTransformationOptions opts = new SWFTransformationOptions();
                 transformationOptions = opts;
-                opts.setFlashVersion(options.get(FLASH_VERSION));
+                opts.setFlashVersion(isPdfRendition ? "9" : options.get(FLASH_VERSION));
             }
             else if (IMAGE_OPTIONS.containsAll(subclassOptionNames) ||  PDF_OPTIONS.containsAll(subclassOptionNames))
             {

--- a/src/main/java/org/alfresco/repo/rendition2/TransformationOptionsConverter.java
+++ b/src/main/java/org/alfresco/repo/rendition2/TransformationOptionsConverter.java
@@ -183,12 +183,14 @@ public class TransformationOptionsConverter implements InitializingBean
         Set<String> optionNames = options.keySet();
 
         // The "pdf" rendition is special as it was incorrectly set up as an SWFTransformationOptions in 6.0
+        // It should have been simply a TransformationOptions.
         boolean isPdfRendition = "pdf".equals(renditionName);
 
         Set<String> subclassOptionNames = new HashSet<>(optionNames);
         subclassOptionNames.removeAll(LIMIT_OPTIONS);
         subclassOptionNames.remove(INCLUDE_CONTENTS);
-        if (isPdfRendition || !subclassOptionNames.isEmpty())
+        boolean hasOptions = !subclassOptionNames.isEmpty();
+        if (isPdfRendition || hasOptions)
         {
             if (isPdfRendition || FLASH_OPTIONS.containsAll(subclassOptionNames))
             {
@@ -262,12 +264,19 @@ public class TransformationOptionsConverter implements InitializingBean
                 }
             }
         }
+        else if (!hasOptions)
+        {
+            // This what the "pdf" rendition should have used in 6.0 and it is not unreasonable for a custom transformer
+            // and rendition to do the same.
+            transformationOptions = new TransformationOptions();
+        }
 
         if (transformationOptions == null)
         {
             StringJoiner sj = new StringJoiner("\n    ");
             sj.add("The RenditionDefinition2 "+renditionName +
-                    " contains options that cannot be mapped to TransformationOptions used by local transformers");
+                    " contains options that cannot be mapped to TransformationOptions used by local transformers. "+
+                    " The TransformOptionConverter may need to be sub classed to support this conversion.");
             HashSet<String> otherNames = new HashSet<>(optionNames);
             otherNames.removeAll(FLASH_OPTIONS);
             otherNames.removeAll(IMAGE_OPTIONS);

--- a/src/main/java/org/alfresco/repo/rendition2/TransformationOptionsConverter.java
+++ b/src/main/java/org/alfresco/repo/rendition2/TransformationOptionsConverter.java
@@ -264,7 +264,7 @@ public class TransformationOptionsConverter implements InitializingBean
                 }
             }
         }
-        else if (!hasOptions)
+        else
         {
             // This what the "pdf" rendition should have used in 6.0 and it is not unreasonable for a custom transformer
             // and rendition to do the same.

--- a/src/main/resources/alfresco/rendition-services2-context.xml
+++ b/src/main/resources/alfresco/rendition-services2-context.xml
@@ -211,11 +211,6 @@
     <bean id="renditionDefinition2Pdf" parent="baseRenditionDefinition2">
         <constructor-arg name="renditionName" value="pdf"/>
         <constructor-arg name="targetMimetype" value="application/pdf"/>
-        <constructor-arg name="transformOptions">
-            <map merge="true">
-                <entry key="allowEnlargement" value="false"/> <!-- does nothing other than select ImageTransformationOptions -->
-            </map>
-        </constructor-arg>
     </bean>
 
     <bean id="renditionEventProcessor" class="org.alfresco.repo.rendition2.RenditionEventProcessor">

--- a/src/test/java/org/alfresco/repo/rendition2/LegacyLocalTransformServiceRegistryTest.java
+++ b/src/test/java/org/alfresco/repo/rendition2/LegacyLocalTransformServiceRegistryTest.java
@@ -25,6 +25,7 @@
  */
 package org.alfresco.repo.rendition2;
 
+import com.sun.star.auth.InvalidArgumentException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,15 +64,12 @@ public class LegacyLocalTransformServiceRegistryTest extends AbstractRenditionIn
     public void testIsSupported()
     {
         // +ve
-        // Source, Target and Props are in dictionary.properties
-        Map<String, String> badValidationProps = new HashMap<>();
-        badValidationProps.put("timeout", "true");
         // No props
         Assert.assertTrue(transformServiceRegistry.isSupported(MIMETYPE_OPENXML_WORDPROCESSING, 1234, MIMETYPE_PDF, options, RENDITION_NAME));
 
         // -ve
         // Bad Source
-        Assert.assertFalse(transformServiceRegistry.isSupported("docxBad", 1234, MIMETYPE_PDF, options, ""));
+        Assert.assertFalse(transformServiceRegistry.isSupported("docxBad", 1234, MIMETYPE_PDF, options, RENDITION_NAME));
         // Bad Target
         Assert.assertFalse(transformServiceRegistry.isSupported(MIMETYPE_OPENXML_WORDPROCESSING, 1234, "pdfBad", options, RENDITION_NAME));
 
@@ -81,6 +79,24 @@ public class LegacyLocalTransformServiceRegistryTest extends AbstractRenditionIn
         // -ve
         // Bad MaxSize docx max size is 768K
         Assert.assertFalse(transformServiceRegistry.isSupported(MIMETYPE_OPENXML_WORDPROCESSING, 768L*1024+1, MIMETYPE_PDF, options, RENDITION_NAME));
+    }
+
+    @Test
+    public void testNoOptions()
+    {
+        // The options for "pdf" are empty once "timeout" has been removed. As a result the converter just creates a
+        // basic TransformationOption object for a custom transformer and rendition without any options.
+        Assert.assertTrue(transformServiceRegistry.isSupported(MIMETYPE_OPENXML_WORDPROCESSING, 1234, MIMETYPE_PDF, options, "custom"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadOptions()
+    {
+        // Source, Target and Props are in dictionary.properties
+        Map<String, String> options = new HashMap<>();
+        options.put("timeout", "true");
+        options.put("unknown", "optionValue");
+        Assert.assertFalse(transformServiceRegistry.isSupported("docxBad", 1234, MIMETYPE_PDF, options, ""));
     }
 
     @Test

--- a/src/test/java/org/alfresco/repo/rendition2/RenditionDefinitionTest.java
+++ b/src/test/java/org/alfresco/repo/rendition2/RenditionDefinitionTest.java
@@ -120,18 +120,19 @@ public class RenditionDefinitionTest extends TestCase
             TransformationOptions transformationOptions2 = transformationOptionsConverter.getTransformationOptions(renditionName, options);
             transformationOptions2.setUse(null); // The use is not set in the original until much later
 
-            // These 2 original thumbnails are wrong, as they don't include the 'limits' and in the
-            // case of 'pdf' used the wrong TransformationOptions subclass, so don't use them.
+            // The original pdf and webpreview thumbnails are wrong, as they don't include the 'limits' and in the
+            // case of pdf used the wrong TransformationOptions subclass, so this code only checks the type rather
+            // than checking transformationOptions is equal to transformationOptions2.
             if (!renditionName.equals("pdf") && !renditionName.equals("webpreview"))
             {
                 assertEquals("The TransformationOptions used in transforms for " + renditionName + " should be the same",
                         transformationOptions.toStringAll(), transformationOptions2.toStringAll());
             }
-            else if (renditionName.equals("pdf"))
+            else
             {
-                assertEquals("The converted class for \"pdf\" should be the same as before",
+                assertEquals("The converted class for "+renditionName+" should be the same as before",
                         transformationOptions.getClass(), transformationOptions2.getClass());
-                assertEquals("The converted class for \"pdf\" should be SWFTransformationOptions",
+                assertEquals("The converted class for "+renditionName+" should be SWFTransformationOptions",
                         SWFTransformationOptions.class, transformationOptions2.getClass());
             }
         }

--- a/src/test/java/org/alfresco/repo/rendition2/RenditionDefinitionTest.java
+++ b/src/test/java/org/alfresco/repo/rendition2/RenditionDefinitionTest.java
@@ -26,6 +26,7 @@
 package org.alfresco.repo.rendition2;
 
 import junit.framework.TestCase;
+import org.alfresco.repo.content.transform.swf.SWFTransformationOptions;
 import org.alfresco.repo.rendition.RenditionServiceImpl;
 import org.alfresco.repo.security.authentication.AuthenticationComponent;
 import org.alfresco.repo.thumbnail.ThumbnailDefinition;
@@ -125,6 +126,13 @@ public class RenditionDefinitionTest extends TestCase
             {
                 assertEquals("The TransformationOptions used in transforms for " + renditionName + " should be the same",
                         transformationOptions.toStringAll(), transformationOptions2.toStringAll());
+            }
+            else if (renditionName.equals("pdf"))
+            {
+                assertEquals("The converted class for \"pdf\" should be the same as before",
+                        transformationOptions.getClass(), transformationOptions2.getClass());
+                assertEquals("The converted class for \"pdf\" should be SWFTransformationOptions",
+                        SWFTransformationOptions.class, transformationOptions2.getClass());
             }
         }
 

--- a/src/test/java/org/alfresco/transform/client/model/config/TransformServiceRegistryImplTest.java
+++ b/src/test/java/org/alfresco/transform/client/model/config/TransformServiceRegistryImplTest.java
@@ -382,10 +382,10 @@ public class TransformServiceRegistryImplTest
 
             // Check the count of transforms supported
             assertEquals("The number of UNIQUE source to target mimetypes transforms has changed. Config change?",
-                    64, countSupportedTransforms(true));
+                    63, countSupportedTransforms(true));
             assertEquals("The number of source to target mimetypes transforms has changed. " +
                             "There may be multiple transformers for the same combination. Config change?",
-                    64, countSupportedTransforms(false));
+                    63, countSupportedTransforms(false));
 
             // Check a supported transform for each transformer.
             assertSupported(DOC, 1234, PDF, null, null, ""); // libreoffice
@@ -394,6 +394,10 @@ public class TransformServiceRegistryImplTest
             assertSupported(JPEG,1234, GIF, null, null, ""); // imagemagick
             assertSupported(MSG, 1234, TXT, null, null, ""); // tika
             assertSupported(MSG, 1234, GIF, null, null, ""); // officeToImageViaPdf
+
+            Map<String, String> invalidPdfOptions = new HashMap<>();
+            invalidPdfOptions.put("allowEnlargement", "false");
+            assertSupported(DOC, 1234, PDF, invalidPdfOptions, null, "Invalid as there is a extra option");
         }
     }
 


### PR DESCRIPTION
The RemoteTransformClient was not sending the transform to the Transform Service because, the "pdf" rendition had an extra allowEnlargement option, which had been added in 6.1 EA3 as a way to force the conversion to use the ImageTransformationOptions sub class rather then TransformationOptions. While investigation this bug, it was found the type should have been SWFTransformationOptions, which had been incorrectly added in ACS 5.2

Green build: https://bamboo.alfresco.com/bamboo/browse/PLAT-REP263-UNIT-2