### PR TITLE
MM-769 : Release Gytheio 0.9 (OpenJDK 11 compatible)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -775,7 +775,7 @@
         <dependency>
             <groupId>org.gytheio</groupId>
             <artifactId>gytheio-messaging-camel</artifactId>
-            <version>0.8</version>
+            <version>0.9</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>


### PR DESCRIPTION
  - updated Gytheio to 0.9 OpenJDK11 compatible

Gytheio 0.9 [release notes](https://github.com/Alfresco/gytheio/releases/tag/v0.9).

With this release the Gytheio library is OpenJDK11 compatible.

Note: v0.9 is equivalent to v0.8 with the following specific changes

* [MM-764](https://issues.alfresco.com/jira/browse/MM-764) :  Build: MM / Gytheio updates for OpenJDK 11 support (build tests)
* [MM-665](https://issues.alfresco.com/jira/browse/MM-665) : Gytheio: Update to commons-io 2.6
* Update compile source/target from 1.8 to 11 (including build plan)

Changes included:
* setting `maven.compiler.source` & `maven.compiler.target` to 11, see [this line](https://github.com/Alfresco/gytheio/blob/9253edfa4fbd175cf9aefe1c31352af593d65666/pom.xml#L36)
* addition of `javax.xml.bind:jaxb-api:2.3.1`, see [this line](https://github.com/Alfresco/gytheio/blob/9253edfa4fbd175cf9aefe1c31352af593d65666/gytheio-content-handlers/pom.xml#L23)
* commons-io upgrade, see [this line](https://github.com/Alfresco/gytheio/blob/9253edfa4fbd175cf9aefe1c31352af593d65666/gytheio-commons/pom.xml#L15)