### PR TITLE
MM-773 : Release Gytheio 0.9.1 (OpenJDK 11 compatible)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -775,7 +775,7 @@
         <dependency>
             <groupId>org.gytheio</groupId>
             <artifactId>gytheio-messaging-camel</artifactId>
-            <version>0.9</version>
+            <version>0.9.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>


### PR DESCRIPTION
As per @killerboot request we have reverted `maven.compiler.source` and `maven.compiler.target` back to `1.8` in the Gytheio library.

This meant another another release, therefor, here is Gytheio 0.9.1.
This was done in order to ensure backwards compatibility.

FYI
Previous 0.9 [pull request](https://github.com/Alfresco/alfresco-repository/pull/267).
Gytheio 0.9.1 [release notes](https://github.com/Alfresco/gytheio/releases/tag/v0.9.1).
