### PR TITLE
parent pom(alfresco-super-pom) version modify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-super-pom</artifactId>
-        <version>10</version>
+        <version>11-SNAPSHOT</version>
     </parent>
 
     <scm>


### PR DESCRIPTION
Failed to build maven via version 10 of alfresco-super-pom.

So I checked ["alfresco-super-pom"](https://github.com/Alfresco/alfresco-super-pom) and saw that the version was changed to 11-SNAPSHOT several days ago.

The build succeeded after changing the later version.

If it is correct that I have changed the version appropriately, please respond to my pull request.

Thank you.