### PR TITLE
[ MNT-19763 ] Sorting on smart folders using custom attributes fails

### DIFF
--- a/src/main/java/org/alfresco/repo/virtual/template/SortConstraint.java
+++ b/src/main/java/org/alfresco/repo/virtual/template/SortConstraint.java
@@ -67,7 +67,7 @@ public class SortConstraint extends VirtualQueryConstraintDecorator
             if (!IGNORED_SORT_PROPERTIES.contains(sort.getFirst()))
             {
                 SortDefinition sortDefinition = new SortDefinition(SortType.FIELD,
-                                                                   sort.getFirst().getLocalName(),
+                                                                   sort.getFirst().getPrefixString(),
                                                                    sort.getSecond());
                 searchParametersCopy.addSort(sortDefinition);
             }

--- a/src/test/java/org/alfresco/repo/virtual/template/VirtualQueryImplTest.java
+++ b/src/test/java/org/alfresco/repo/virtual/template/VirtualQueryImplTest.java
@@ -164,7 +164,7 @@ public class VirtualQueryImplTest extends TestCase
         assertNotNull(sortDefinitions);
         assertEquals(1,
                      sortDefinitions.size());
-        assertEquals(withSortDefinitions.getFirst().getLocalName(),
+        assertEquals(withSortDefinitions.getFirst().getPrefixString(),
                      sortDefinitions.get(0).getField());
 
         assertEquals(withSortDefinitions.getSecond(),
@@ -172,7 +172,7 @@ public class VirtualQueryImplTest extends TestCase
     }
 
     @Test
-    public void testPerform_deprecated_1() throws Exception
+    public void testPerform_deprecated_1()
     {
         Pair<QName, Boolean> withSortDefinitions = new Pair<QName, Boolean>(testQName2,
                                                                             true);
@@ -191,7 +191,7 @@ public class VirtualQueryImplTest extends TestCase
     }
 
     @Test
-    public void testPerform_deprecated_2() throws Exception
+    public void testPerform_deprecated_2()
     {
         query.perform(mockitoActualEnvironment,
                       false,


### PR DESCRIPTION
The PR contains: 

- a change in the SortConstraint class for using the prefixed attribute name (i.e. prefix:localname) instead of local name (the namespace was completely ignored) 
- the corresponding fix to the unit tests

The proposed solution doesn't include an integration test because at the moment we don't have the required infrastructure for setting up (through API) the required environment with the steps described in the issue. 