### PR TITLE
REPO-4099 Change of mimetype to unsupported rendition hangs Share

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency.alfresco-legacy-lucene.version>6.2</dependency.alfresco-legacy-lucene.version>
         <dependency.alfresco-core.version>7.5</dependency.alfresco-core.version>
         <dependency.alfresco-greenmail.version>6.1</dependency.alfresco-greenmail.version>
-        <dependency.alfresco-data-model.version>8.22</dependency.alfresco-data-model.version>
+        <dependency.alfresco-data-model.version>8.25</dependency.alfresco-data-model.version>
         <dependency.alfresco-jlan.version>7.1</dependency.alfresco-jlan.version>
         <dependency.alfresco-pdf-renderer.version>1.1</dependency.alfresco-pdf-renderer.version>
         <dependency.alfresco-hb-data-sender.version>1.0.9</dependency.alfresco-hb-data-sender.version>

--- a/src/main/java/org/alfresco/repo/rendition/RenditionServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/rendition/RenditionServiceImpl.java
@@ -271,7 +271,9 @@ public class RenditionServiceImpl implements
     public ChildAssociationRef render(NodeRef sourceNode, RenditionDefinition definition)
     {
         checkSourceNodeForPreventionClass(sourceNode);
-        
+
+        deleteRenditionService2Rendition(sourceNode, definition);
+
         ChildAssociationRef result = executeRenditionAction(sourceNode, definition, false);
         
         if (log.isDebugEnabled())
@@ -286,7 +288,9 @@ public class RenditionServiceImpl implements
             RenderCallback callback)
     {
         checkSourceNodeForPreventionClass(sourceNode);
-        
+
+        deleteRenditionService2Rendition(sourceNode, definition);
+
         // The asynchronous render can't return a ChildAssociationRef as it is created
         // asynchronously after this method returns.
         definition.setCallback(callback);
@@ -690,6 +694,28 @@ public class RenditionServiceImpl implements
             if (log.isDebugEnabled())
             {
                 log.debug("OnContentUpdate remove rendition for \""+sourceNodeRef+"\", \""+renditionName+"\" so we switch back to the original service, as the new service is disabled.");
+            }
+            renditionService2.deleteRendition(sourceNodeRef, renditionName);
+        }
+
+        return useRenditionService2;
+    }
+
+    // For the situation where a rendition has been created by rendition service 2 and is marked as invalid,
+    // but is about to be replaced by code from the original rendition service, delete the rendition.
+    public boolean deleteRenditionService2Rendition(NodeRef sourceNodeRef, RenditionDefinition rendDefn)
+    {
+        boolean useRenditionService2 = false;
+
+        QName renditionQName = rendDefn.getRenditionName();
+        String renditionName = renditionQName.getLocalName();
+        boolean createdByRenditionService2 = renditionService2.isCreatedByRenditionService2(sourceNodeRef, renditionName);
+
+        if (createdByRenditionService2)
+        {
+            if (log.isDebugEnabled())
+            {
+                log.debug("Remove rendition for \""+sourceNodeRef+"\", \""+renditionName+"\" and switch back to the original service.");
             }
             renditionService2.deleteRendition(sourceNodeRef, renditionName);
         }

--- a/src/main/java/org/alfresco/repo/rendition/RenditionServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/rendition/RenditionServiceImpl.java
@@ -271,9 +271,7 @@ public class RenditionServiceImpl implements
     public ChildAssociationRef render(NodeRef sourceNode, RenditionDefinition definition)
     {
         checkSourceNodeForPreventionClass(sourceNode);
-
         log.debug("Original RenditionService render no callback START");
-//        deleteRenditionService2Rendition(sourceNode, definition);
 
         ChildAssociationRef result = executeRenditionAction(sourceNode, definition, false);
         
@@ -290,9 +288,7 @@ public class RenditionServiceImpl implements
             RenderCallback callback)
     {
         checkSourceNodeForPreventionClass(sourceNode);
-
         log.debug("Original RenditionService render    callback START");
-//        deleteRenditionService2Rendition(sourceNode, definition);
 
         // The asynchronous render can't return a ChildAssociationRef as it is created
         // asynchronously after this method returns.
@@ -701,24 +697,6 @@ public class RenditionServiceImpl implements
         }
 
         return useRenditionService2;
-    }
-
-    // For the situation where a rendition has been created by rendition service 2 and is marked as invalid,
-    // but is about to be replaced by code from the original rendition service, delete the rendition.
-    public void deleteRenditionService2Rendition(NodeRef sourceNodeRef, RenditionDefinition rendDefn)
-    {
-        QName renditionQName = rendDefn.getRenditionName();
-        String renditionName = renditionQName.getLocalName();
-        boolean createdByRenditionService2 = renditionService2.isCreatedByRenditionService2(sourceNodeRef, renditionName);
-
-        if (createdByRenditionService2)
-        {
-            if (log.isDebugEnabled())
-            {
-                log.debug("Remove rendition for \""+sourceNodeRef+"\", \""+renditionName+"\" and switch back to the original service.");
-            }
-//            renditionService2.deleteRendition(sourceNodeRef, renditionName);
-        }
     }
 
     // Finds a RenditionDefinition2 with the same name (local part) and target mimetype.

--- a/src/main/java/org/alfresco/repo/rendition/RenditionServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/rendition/RenditionServiceImpl.java
@@ -272,7 +272,8 @@ public class RenditionServiceImpl implements
     {
         checkSourceNodeForPreventionClass(sourceNode);
 
-        deleteRenditionService2Rendition(sourceNode, definition);
+        log.debug("Original RenditionService render no callback START");
+//        deleteRenditionService2Rendition(sourceNode, definition);
 
         ChildAssociationRef result = executeRenditionAction(sourceNode, definition, false);
         
@@ -280,7 +281,8 @@ public class RenditionServiceImpl implements
         {
             log.debug("Produced rendition " + result);
         }
-        
+
+        log.debug("Original RenditionService render no callback END");
         return result;
     }
 
@@ -289,15 +291,15 @@ public class RenditionServiceImpl implements
     {
         checkSourceNodeForPreventionClass(sourceNode);
 
-        deleteRenditionService2Rendition(sourceNode, definition);
+        log.debug("Original RenditionService render    callback START");
+//        deleteRenditionService2Rendition(sourceNode, definition);
 
         // The asynchronous render can't return a ChildAssociationRef as it is created
         // asynchronously after this method returns.
         definition.setCallback(callback);
         
         executeRenditionAction(sourceNode, definition, true);
-        
-        return;
+        log.debug("Original RenditionService render   callback END");
     }
     
     /*
@@ -703,10 +705,8 @@ public class RenditionServiceImpl implements
 
     // For the situation where a rendition has been created by rendition service 2 and is marked as invalid,
     // but is about to be replaced by code from the original rendition service, delete the rendition.
-    public boolean deleteRenditionService2Rendition(NodeRef sourceNodeRef, RenditionDefinition rendDefn)
+    public void deleteRenditionService2Rendition(NodeRef sourceNodeRef, RenditionDefinition rendDefn)
     {
-        boolean useRenditionService2 = false;
-
         QName renditionQName = rendDefn.getRenditionName();
         String renditionName = renditionQName.getLocalName();
         boolean createdByRenditionService2 = renditionService2.isCreatedByRenditionService2(sourceNodeRef, renditionName);
@@ -717,10 +717,8 @@ public class RenditionServiceImpl implements
             {
                 log.debug("Remove rendition for \""+sourceNodeRef+"\", \""+renditionName+"\" and switch back to the original service.");
             }
-            renditionService2.deleteRendition(sourceNodeRef, renditionName);
+//            renditionService2.deleteRendition(sourceNodeRef, renditionName);
         }
-
-        return useRenditionService2;
     }
 
     // Finds a RenditionDefinition2 with the same name (local part) and target mimetype.

--- a/src/main/java/org/alfresco/repo/rendition2/LegacyLocalTransformClient.java
+++ b/src/main/java/org/alfresco/repo/rendition2/LegacyLocalTransformClient.java
@@ -128,7 +128,7 @@ public class LegacyLocalTransformClient extends AbstractTransformClient implemen
     }
 
     @Override
-    public void transform(NodeRef sourceNodeRef, RenditionDefinition2 renditionDefinition, String user, int sourceContentUrlHashCode)
+    public void transform(NodeRef sourceNodeRef, RenditionDefinition2 renditionDefinition, String user, int sourceContentHashCode)
     {
         executorService.submit(() ->
         {
@@ -155,7 +155,7 @@ public class LegacyLocalTransformClient extends AbstractTransformClient implemen
                         contentService.transform(reader, writer, transformationOptions);
 
                         InputStream inputStream = writer.getReader().getContentInputStream();
-                        renditionService2.consume(sourceNodeRef, inputStream, renditionDefinition, sourceContentUrlHashCode);
+                        renditionService2.consume(sourceNodeRef, inputStream, renditionDefinition, sourceContentHashCode);
                     }
                     catch (Exception e)
                     {
@@ -164,7 +164,7 @@ public class LegacyLocalTransformClient extends AbstractTransformClient implemen
                             String renditionName = renditionDefinition.getRenditionName();
                             logger.debug("Rendition of "+renditionName+" failed", e);
                         }
-                        renditionService2.failure(sourceNodeRef, renditionDefinition, sourceContentUrlHashCode);
+                        renditionService2.failure(sourceNodeRef, renditionDefinition, sourceContentHashCode);
                         throw e;
                     }
                     return null;

--- a/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -64,7 +64,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.alfresco.model.ContentModel.PROP_CONTENT;
-import static org.alfresco.model.RenditionModel.PROP_RENDITION_CONTENT_URL_HASH_CODE;
+import static org.alfresco.model.RenditionModel.PROP_RENDITION_CONTENT_HASH_CODE;
 import static org.alfresco.service.namespace.QName.createQName;
 
 /**
@@ -358,7 +358,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
                             {
                                 logger.debug("Set rendition hashcode " + transformContentHashCode + " and ThumbnailLastModified for " + renditionName);
                             }
-                            nodeService.setProperty(renditionNode, RenditionModel.PROP_RENDITION_CONTENT_URL_HASH_CODE, transformContentHashCode);
+                            nodeService.setProperty(renditionNode, RenditionModel.PROP_RENDITION_CONTENT_HASH_CODE, transformContentHashCode);
                             setThumbnailLastModified(sourceNodeRef, renditionName);
 
                             if (transformInputStream != null)
@@ -385,7 +385,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
                                 if (content != null)
                                 {
                                     nodeService.removeProperty(renditionNode, PROP_CONTENT);
-                                    nodeService.removeProperty(renditionNode, PROP_RENDITION_CONTENT_URL_HASH_CODE);
+                                    nodeService.removeProperty(renditionNode, PROP_RENDITION_CONTENT_HASH_CODE);
                                     if (logger.isDebugEnabled())
                                     {
                                         logger.debug("Cleared rendition content and hashcode");
@@ -515,7 +515,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
             return RENDITION2_DOES_NOT_EXIST;
         }
 
-        Serializable hashCode = nodeService.getProperty(renditionNode, PROP_RENDITION_CONTENT_URL_HASH_CODE);
+        Serializable hashCode = nodeService.getProperty(renditionNode, PROP_RENDITION_CONTENT_HASH_CODE);
         return hashCode == null
                 ? SOURCE_HAS_NO_CONTENT
                 : (int)hashCode;

--- a/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -356,7 +356,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
                             }
                             if (logger.isDebugEnabled())
                             {
-                                logger.debug("Set rendition hashcode " + transformContentUrlHashCode);
+                                logger.debug("Set rendition hashcode " + transformContentUrlHashCode + " and ThumbnailLastModified for " + renditionName);
                             }
                             nodeService.setProperty(renditionNode, RenditionModel.PROP_RENDITION_CONTENT_URL_HASH_CODE, transformContentUrlHashCode);
                             setThumbnailLastModified(sourceNodeRef, renditionName);
@@ -388,7 +388,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
                                     nodeService.removeProperty(renditionNode, PROP_RENDITION_CONTENT_URL_HASH_CODE);
                                     if (logger.isDebugEnabled())
                                     {
-                                        logger.debug("Clear rendition hashcode");
+                                        logger.debug("Cleared rendition content and hashcode");
                                     }
                                 }
                             }

--- a/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -224,8 +224,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
                 catch (UnsupportedOperationException e)
                 {
                     NodeRef renditionNode = getRenditionNode(sourceNodeRef, renditionName);
-                    int renditionContentUrlHashCode = getRenditionContentUrlHashCode(renditionNode);
-                    if (renditionContentUrlHashCode == RENDITION2_DOES_NOT_EXIST)
+                    if (renditionNode == null)
                     {
                         throw e;
                     }
@@ -374,6 +373,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
                                 if (content != null)
                                 {
                                     nodeService.removeProperty(renditionNode, PROP_CONTENT);
+                                    nodeService.removeProperty(renditionNode, PROP_RENDITION_CONTENT_URL_HASH_CODE);
                                 }
                             }
 

--- a/src/main/java/org/alfresco/repo/rendition2/SwitchingTransformClient.java
+++ b/src/main/java/org/alfresco/repo/rendition2/SwitchingTransformClient.java
@@ -62,15 +62,15 @@ public class SwitchingTransformClient implements TransformClient
     }
 
     @Override
-    public void transform(NodeRef sourceNodeRef, RenditionDefinition2 renditionDefinition, String user, int sourceContentUrlHashCode)
+    public void transform(NodeRef sourceNodeRef, RenditionDefinition2 renditionDefinition, String user, int sourceContentHashCode)
     {
         if (usePrimary.get())
         {
-            primary.transform(sourceNodeRef, renditionDefinition, user, sourceContentUrlHashCode);
+            primary.transform(sourceNodeRef, renditionDefinition, user, sourceContentHashCode);
         }
         else
         {
-            secondary.transform(sourceNodeRef, renditionDefinition, user, sourceContentUrlHashCode);
+            secondary.transform(sourceNodeRef, renditionDefinition, user, sourceContentHashCode);
         }
     }
 }

--- a/src/main/java/org/alfresco/repo/rendition2/TransformClient.java
+++ b/src/main/java/org/alfresco/repo/rendition2/TransformClient.java
@@ -53,7 +53,7 @@ public interface TransformClient
      * @param sourceNodeRef the source node
      * @param renditionDefinition which rendition to perform
      * @param user that requested the transform.
-     * @param sourceContentUrlHashCode the hash code of the source node's content URL. Used to check the transform result
+     * @param sourceContentHashCode the hash code of the source node's content URL. Used to check the transform result
      */
-    void transform(NodeRef sourceNodeRef, RenditionDefinition2 renditionDefinition, String user, int sourceContentUrlHashCode);
+    void transform(NodeRef sourceNodeRef, RenditionDefinition2 renditionDefinition, String user, int sourceContentHashCode);
 }

--- a/src/test/java/org/alfresco/repo/rendition2/AbstractRenditionIntegrationTest.java
+++ b/src/test/java/org/alfresco/repo/rendition2/AbstractRenditionIntegrationTest.java
@@ -153,7 +153,7 @@ public abstract class AbstractRenditionIntegrationTest extends BaseSpringTest
         {
             NodeRef sourceNodeRef = createSource(ADMIN, testFileName);
             render(ADMIN, sourceNodeRef, renditionName);
-            waitForRendition(ADMIN, sourceNodeRef, renditionName);
+            waitForRendition(ADMIN, sourceNodeRef, renditionName, true);
             if (!expectedToPass)
             {
                 fail("The " + renditionName + " rendition should NOT be supported for " + testFileName);
@@ -241,11 +241,11 @@ public abstract class AbstractRenditionIntegrationTest extends BaseSpringTest
     }
 
     // As a given user waitForRendition for a rendition to appear. Creates new transactions to do this.
-    protected NodeRef waitForRendition(String user, NodeRef sourceNodeRef, String renditionName) throws AssertionFailedError
+    protected NodeRef waitForRendition(String user, NodeRef sourceNodeRef, String renditionName, boolean shouldExist) throws AssertionFailedError
     {
         try
         {
-            return AuthenticationUtil.runAs(() -> waitForRendition(sourceNodeRef, renditionName), user);
+            return AuthenticationUtil.runAs(() -> waitForRendition(sourceNodeRef, renditionName, shouldExist), user);
         }
         catch (RuntimeException e)
         {
@@ -259,7 +259,7 @@ public abstract class AbstractRenditionIntegrationTest extends BaseSpringTest
     }
 
     // As the current user waitForRendition for a rendition to appear. Creates new transactions to do this.
-    private NodeRef waitForRendition(NodeRef sourceNodeRef, String renditionName) throws InterruptedException
+    private NodeRef waitForRendition(NodeRef sourceNodeRef, String renditionName, boolean shouldExist) throws InterruptedException
     {
         long maxMillis = 10000;
         ChildAssociationRef assoc = null;
@@ -275,8 +275,16 @@ public abstract class AbstractRenditionIntegrationTest extends BaseSpringTest
             logger.debug("RenditionService2.getRenditionByName(...) sleep "+i);
             sleep(1000);
         }
-        assertNotNull("Rendition " + renditionName + " failed", assoc);
-        return assoc.getChildRef();
+        if (shouldExist)
+        {
+            assertNotNull("Rendition " + renditionName + " failed", assoc);
+            return assoc.getChildRef();
+        }
+        else
+        {
+            assertNull("Rendition " + renditionName + " did not fail", assoc);
+            return null;
+        }
     }
 
     protected String getTestFileName(String sourceMimetype) throws FileNotFoundException

--- a/src/test/java/org/alfresco/repo/rendition2/LegacyLocalTransformClientIntegrationTest.java
+++ b/src/test/java/org/alfresco/repo/rendition2/LegacyLocalTransformClientIntegrationTest.java
@@ -137,10 +137,10 @@ public class LegacyLocalTransformClientIntegrationTest extends AbstractRendition
             // split into separate transactions as the client is async
             NodeRef sourceNode = transactionService.getRetryingTransactionHelper().doInTransaction(() ->
                     createContentNodeFromQuickFile(testFileName));
-            int sourceContentUrlHash = DefaultTypeConverter.INSTANCE.convert(
+            int sourceContentHashCode = DefaultTypeConverter.INSTANCE.convert(
                     ContentData.class,
                     nodeService.getProperty(sourceNode, PROP_CONTENT))
-                    .getContentUrl().hashCode();
+                    .toString().hashCode();
             transactionService.getRetryingTransactionHelper().doInTransaction(() ->
             {
                 RenditionDefinition2 renditionDefinition =
@@ -149,7 +149,7 @@ public class LegacyLocalTransformClientIntegrationTest extends AbstractRendition
                         sourceNode,
                         renditionDefinition,
                         AuthenticationUtil.getAdminUserName(),
-                        sourceContentUrlHash);
+                        sourceContentHashCode);
                 return null;
             });
             ChildAssociationRef childAssociationRef = null;

--- a/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
+++ b/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
@@ -30,13 +30,18 @@ import org.alfresco.model.RenditionModel;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.security.permissions.AccessDeniedException;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
+import org.alfresco.service.cmr.repository.ContentData;
 import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.datatype.DefaultTypeConverter;
 import org.alfresco.service.cmr.security.PermissionService;
 import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
 import org.junit.Test;
 
 import java.util.List;
+
+import static org.alfresco.model.ContentModel.PROP_CONTENT;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * Integration tests for {@link RenditionService2}
@@ -153,11 +158,16 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
     {
         NodeRef sourceNodeRef = createSource(ADMIN, "quick.jpg");
         render(ADMIN, sourceNodeRef, DOC_LIB);
-        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
+        NodeRef rendition1 = waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
+        ContentData contentData1 = DefaultTypeConverter.INSTANCE.convert(ContentData.class, nodeService.getProperty(rendition1, PROP_CONTENT));
 
         updateContent(ADMIN, sourceNodeRef, "quick.png");
         render(ADMIN, sourceNodeRef, DOC_LIB);
-        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
+        NodeRef rendition2 = waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
+        ContentData contentData2 = DefaultTypeConverter.INSTANCE.convert(ContentData.class, nodeService.getProperty(rendition2, PROP_CONTENT));
+
+        assertEquals("The rendition node should not change", rendition1, rendition2);
+        assertNotEquals("The content should have change", contentData1.toString(), contentData2.toString());
     }
 
     @Test

--- a/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
+++ b/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
@@ -27,34 +27,18 @@ package org.alfresco.repo.rendition2;
 
 import java.util.List;
 
-import junit.framework.AssertionFailedError;
 import org.alfresco.model.ContentModel;
 import org.alfresco.model.RenditionModel;
-import org.alfresco.repo.content.MimetypeMap;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.security.permissions.AccessDeniedException;
-import org.alfresco.repo.thumbnail.ThumbnailRegistry;
-import org.alfresco.service.cmr.rendition.RenditionService;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
-import org.alfresco.service.cmr.repository.ContentWriter;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.security.PermissionService;
 import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
-import org.alfresco.util.ApplicationContextHelper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.util.ResourceUtils;
-
-import java.io.File;
-import java.io.FileNotFoundException;
 
 import static java.lang.Thread.sleep;
-import static org.alfresco.model.ContentModel.PROP_CONTENT;
-import static org.alfresco.repo.content.MimetypeMap.EXTENSION_BINARY;
 
 /**
  * Integration tests for {@link RenditionService2}
@@ -148,7 +132,7 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
     {
         NodeRef sourceNodeRef = createSource(ADMIN, "quick.jpg");
         render(ADMIN, sourceNodeRef, DOC_LIB);
-        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB);
+        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
     }
 
     @Test
@@ -156,30 +140,45 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
     {
         NodeRef sourceNodeRef = createSource(ADMIN, "quick.jpg");
         render(ADMIN, sourceNodeRef, DOC_LIB);
-        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB);
+        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
 
         clearContent(ADMIN, sourceNodeRef);
         render(ADMIN, sourceNodeRef, DOC_LIB);
         ChildAssociationRef assoc = AuthenticationUtil.runAs(() ->
                 renditionService2.getRenditionByName(sourceNodeRef, DOC_LIB), ADMIN);
+        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, false);
         assertNull("There should be no rendition as there was no content", assoc);
     }
 
     @Test
-    public void changedSourceToNonNull() 
+    public void changedSourceToNonNull()
     {
         NodeRef sourceNodeRef = createSource(ADMIN, "quick.jpg");
         render(ADMIN, sourceNodeRef, DOC_LIB);
-        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB);
+        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
+
+        updateContent(ADMIN, sourceNodeRef, "quick.png");
+        render(ADMIN, sourceNodeRef, DOC_LIB);
+        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
+    }
+
+    @Test
+    public void changedSourceFromNull()
+    {
+        NodeRef sourceNodeRef = createSource(ADMIN, "quick.jpg");
+        render(ADMIN, sourceNodeRef, DOC_LIB);
+        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
 
         clearContent(ADMIN, sourceNodeRef);
         render(ADMIN, sourceNodeRef, DOC_LIB);
         ChildAssociationRef assoc = AuthenticationUtil.runAs(() ->
                 renditionService2.getRenditionByName(sourceNodeRef, DOC_LIB), ADMIN);
+        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, false);
         assertNull("There should be no rendition as there was no content", assoc);
 
         updateContent(ADMIN, sourceNodeRef, "quick.png");
-        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB);
+        render(ADMIN, sourceNodeRef, DOC_LIB);
+        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
     }
 
     @Test
@@ -188,7 +187,7 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
         String userName = createRandomUser();
         NodeRef sourceNodeRef = createSource(userName, "quick.jpg");
         render(userName, sourceNodeRef, DOC_LIB);
-        NodeRef renditionNodeRef = waitForRendition(userName, sourceNodeRef, DOC_LIB);
+        NodeRef renditionNodeRef = waitForRendition(userName, sourceNodeRef, DOC_LIB, true);
         assertNotNull("The rendition was not generated for non-admin user", renditionNodeRef);
     }
 
@@ -204,9 +203,9 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
             return null;
         });
         render(ownerUserName, sourceNodeRef, DOC_LIB);
-        NodeRef renditionNodeRef = waitForRendition(ownerUserName, sourceNodeRef, DOC_LIB);
+        NodeRef renditionNodeRef = waitForRendition(ownerUserName, sourceNodeRef, DOC_LIB, true);
         assertNotNull("The rendition is not visible for owner of source node", renditionNodeRef);
-        renditionNodeRef = waitForRendition(otherUserName, sourceNodeRef, DOC_LIB);
+        renditionNodeRef = waitForRendition(otherUserName, sourceNodeRef, DOC_LIB, true);
         assertNotNull("The rendition is not visible for non-owner user with read permissions", renditionNodeRef);
         assertEquals("The creator of the rendition is not correct",
                 ownerUserName, nodeService.getProperty(sourceNodeRef, ContentModel.PROP_CREATOR));
@@ -224,9 +223,9 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
             return null;
         });
         render(otherUserName, sourceNodeRef, DOC_LIB);
-        NodeRef renditionNodeRef = waitForRendition(ownerUserName, sourceNodeRef, DOC_LIB);
+        NodeRef renditionNodeRef = waitForRendition(ownerUserName, sourceNodeRef, DOC_LIB, true);
         assertNotNull("The rendition is not visible for owner of source node", renditionNodeRef);
-        renditionNodeRef = waitForRendition(otherUserName, sourceNodeRef, DOC_LIB);
+        renditionNodeRef = waitForRendition(otherUserName, sourceNodeRef, DOC_LIB, true);
         assertNotNull("The rendition is not visible for owner of rendition node", renditionNodeRef);
         assertEquals("The creator of the rendition is not correct",
                 ownerUserName, nodeService.getProperty(sourceNodeRef, ContentModel.PROP_CREATOR));
@@ -246,7 +245,7 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
         });
         try
         {
-            waitForRendition(noPermissionsUser, sourceNodeRef, DOC_LIB);
+            waitForRendition(noPermissionsUser, sourceNodeRef, DOC_LIB, true);
             fail("The rendition should not be visible for user with no permissions");
         }
         catch (AccessDeniedException ade)
@@ -272,7 +271,7 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
                 AuthenticationUtil.runAs(() -> nodeService.hasAspect(oldRendition, RenditionModel.ASPECT_RENDITION2), ownerUserName));
 
         updateContent(ownerUserName, sourceNodeRef, "quick.png");
-        NodeRef newRendition = waitForRendition(ownerUserName, sourceNodeRef, DOC_LIB);
+        NodeRef newRendition = waitForRendition(ownerUserName, sourceNodeRef, DOC_LIB, true);
         assertNotNull("The rendition should be reported via RenditionService2", newRendition);
         Thread.sleep(200);
         boolean hasRenditionedAspect = false;
@@ -307,7 +306,7 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
                     .doInTransaction(() ->
                             AuthenticationUtil.runAs(() ->
                                     renditionService.render(sourceNodeRef, doclibRendDefQName), ADMIN));
-            assertNotNull("The old renditions service did not render", waitForRendition(ADMIN, sourceNodeRef, DOC_LIB));
+            assertNotNull("The old renditions service did not render", waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true));
             List<String> lastThumbnailModification = transactionService.getRetryingTransactionHelper()
                     .doInTransaction(() ->
                             AuthenticationUtil.runAs(() ->
@@ -349,14 +348,14 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
     {
         NodeRef sourceNodeRef = createSource(ADMIN, "quick.jpg");
         render(ADMIN, sourceNodeRef, DOC_LIB);
-        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB);
+        waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
 
         renditionService2.setEnabled(false);
         try
         {
             updateContent(ADMIN, sourceNodeRef, "quick.png");
             Thread.sleep(200);
-            NodeRef renditionNodeRef = waitForRendition(ADMIN, sourceNodeRef, DOC_LIB);
+            NodeRef renditionNodeRef = waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
             boolean hasRendition2Aspect = true;
             for (int i = 0; i < 5; i++)
             {
@@ -394,12 +393,12 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
                     .doInTransaction(() ->
                             AuthenticationUtil.runAs(() ->
                                     renditionService.render(sourceNodeRef, doclibRendDefQName), ADMIN));
-            waitForRendition(ADMIN, sourceNodeRef, DOC_LIB);
+            waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
 
             renditionService2.setEnabled(true);
 
             updateContent(ADMIN, sourceNodeRef, "quick.png");
-            NodeRef renditionNodeRef = waitForRendition(ADMIN, sourceNodeRef, DOC_LIB);
+            NodeRef renditionNodeRef = waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
             boolean hasAspect = nodeService.hasAspect(renditionNodeRef, RenditionModel.ASPECT_RENDITION2);
             assertFalse("Should have switched to the old rendition service", hasAspect);
         }
@@ -419,7 +418,7 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
         String ownerUserName = createRandomUser();
         NodeRef sourceNodeRef = createSource(ownerUserName, "quick.jpg");
         render(ownerUserName, sourceNodeRef, DOC_LIB);
-        NodeRef newRendition = waitForRendition(ownerUserName, sourceNodeRef, DOC_LIB);
+        NodeRef newRendition = waitForRendition(ownerUserName, sourceNodeRef, DOC_LIB, true);
         boolean hasRendition2Aspect = AuthenticationUtil.runAs(() -> nodeService.hasAspect(newRendition, RenditionModel.ASPECT_RENDITION2), ownerUserName);
         assertTrue("The source should have the old renditioned aspect",
                 AuthenticationUtil.runAs(() -> nodeService.hasAspect(sourceNodeRef, RenditionModel.ASPECT_RENDITIONED), ownerUserName));
@@ -428,7 +427,7 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
         {
             renditionService2.setEnabled(false);
             updateContent(ownerUserName, sourceNodeRef, "quick.png");
-            NodeRef oldRendition = waitForRendition(ownerUserName, sourceNodeRef, DOC_LIB);
+            NodeRef oldRendition = waitForRendition(ownerUserName, sourceNodeRef, DOC_LIB, true);
             Thread.sleep(200);
             hasRendition2Aspect = false;
             for (int i = 0; i < 5; i++)
@@ -467,12 +466,12 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
                     .doInTransaction(() ->
                             AuthenticationUtil.runAs(() ->
                                     renditionService.render(sourceNodeRef, doclibRendDefQName), ADMIN));
-            waitForRendition(ADMIN, sourceNodeRef, DOC_LIB);
+            waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
 
             renditionService2.setEnabled(true);
             render(ADMIN, sourceNodeRef, DOC_LIB);
             Thread.sleep(200);
-            NodeRef renditionNodeRef = waitForRendition(ADMIN, sourceNodeRef, DOC_LIB);
+            NodeRef renditionNodeRef = waitForRendition(ADMIN, sourceNodeRef, DOC_LIB, true);
             boolean hasRendition2Aspect = false;
             for (int i = 0; i < 5; i++)
             {

--- a/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
+++ b/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
@@ -25,8 +25,6 @@
  */
 package org.alfresco.repo.rendition2;
 
-import java.util.List;
-
 import org.alfresco.model.ContentModel;
 import org.alfresco.model.RenditionModel;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
@@ -38,7 +36,7 @@ import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
 import org.junit.Test;
 
-import static java.lang.Thread.sleep;
+import java.util.List;
 
 /**
  * Integration tests for {@link RenditionService2}

--- a/src/test/java/org/alfresco/repo/thumbnail/ThumbnailServiceImplParameterTest.java
+++ b/src/test/java/org/alfresco/repo/thumbnail/ThumbnailServiceImplParameterTest.java
@@ -26,17 +26,6 @@
 
 package org.alfresco.repo.thumbnail;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.content.MimetypeMap;
 import org.alfresco.repo.content.transform.magick.ImageResizeOptions;
@@ -45,9 +34,9 @@ import org.alfresco.repo.rendition.MockedTestServiceRegistry;
 import org.alfresco.repo.rendition.RenditionServiceImpl;
 import org.alfresco.repo.rendition.executer.AbstractRenderingEngine;
 import org.alfresco.repo.rendition.executer.ImageRenderingEngine;
+import org.alfresco.repo.rendition2.RenditionService2Impl;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.repo.transaction.TransactionServiceImpl;
-import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.service.cmr.action.Action;
 import org.alfresco.service.cmr.action.ActionService;
 import org.alfresco.service.cmr.rendition.RenditionDefinition;
@@ -67,6 +56,18 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 /**
  * Thumbnail service implementation unit test
  * 
@@ -79,6 +80,7 @@ public class ThumbnailServiceImplParameterTest
 {
     // Mocked services.
     private ActionService mockActionService = mock(ActionService.class);
+    private RenditionService2Impl mockRenditionService2 = mock(RenditionService2Impl.class);
 
     // Real services - backed by mocked services.
     private RenditionServiceImpl renditionService;
@@ -103,6 +105,8 @@ public class ThumbnailServiceImplParameterTest
 
         renditionService.setActionService(mockActionService);
         renditionService.setServiceRegistry(new MockedTestServiceRegistry());
+        renditionService.setRenditionService2(mockRenditionService2);
+        when(mockRenditionService2.isCreatedByRenditionService2(any(), any())).thenReturn(false);
 
         ThumbnailServiceImpl thumbs = new ThumbnailServiceImpl()
         {


### PR DESCRIPTION
An exception was being thrown if there was no supported rendition. In the case where a rendition already existed, RenditionService2 should have removed the content and hashcode on the rendition node and updated the source nodes thumbnailLastModified value. This is what happens if there is a  transform failure when there is a rendition available. 