### PR TITLE
REPO-4099 Change of mimetype to unsupported rendition hangs Share (#298)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>repo-4099-1</version>
+    <version>7.39-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -15,7 +15,7 @@
         <connection>scm:git:git@github.com:Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:git@github.com:Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>alfresco-repository-repo-4099-1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>7.39-SNAPSHOT</version>
+    <version>repo-4099-1</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -15,7 +15,7 @@
         <connection>scm:git:git@github.com:Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:git@github.com:Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>HEAD</tag>
+        <tag>alfresco-repository-repo-4099-1</tag>
     </scm>
 
     <distributionManagement>

--- a/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -494,7 +494,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
         if (contentData != null)
         {
             // Originally we used the contentData URL, but that is not enough if the mimetype changes.
-            String contentString = contentData.toString();
+            String contentString = contentData.getContentUrl()+contentData.getMimetype();
             if (contentString != null)
             {
                 hashCode = contentString.hashCode();

--- a/src/test/java/org/alfresco/repo/rendition2/LegacyLocalTransformClientIntegrationTest.java
+++ b/src/test/java/org/alfresco/repo/rendition2/LegacyLocalTransformClientIntegrationTest.java
@@ -137,10 +137,8 @@ public class LegacyLocalTransformClientIntegrationTest extends AbstractRendition
             // split into separate transactions as the client is async
             NodeRef sourceNode = transactionService.getRetryingTransactionHelper().doInTransaction(() ->
                     createContentNodeFromQuickFile(testFileName));
-            int sourceContentHashCode = DefaultTypeConverter.INSTANCE.convert(
-                    ContentData.class,
-                    nodeService.getProperty(sourceNode, PROP_CONTENT))
-                    .toString().hashCode();
+            ContentData contentData = DefaultTypeConverter.INSTANCE.convert(ContentData.class, nodeService.getProperty(sourceNode, PROP_CONTENT));
+            int sourceContentHashCode = (contentData == null ? "" : contentData.getContentUrl()+contentData.getMimetype()).hashCode();
             transactionService.getRetryingTransactionHelper().doInTransaction(() ->
             {
                 RenditionDefinition2 renditionDefinition =


### PR DESCRIPTION
Only include URL and mimetype when working out the content hashCode as we don't want it to change if deleted.