### PR TITLE
REPO-4090: mariadb queries changes.

### DIFF
--- a/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/query-people-common-SqlMap.xml
+++ b/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/query-people-common-SqlMap.xml
@@ -41,7 +41,7 @@
               prop3.string_value, ' ',  
             </if>
               <if test="prop1qnameId != null or prop2qnameId != null or prop3qnameId != null ">  
-              ' ')) like lower(#{item}) <include refid="alfresco.util.escape"/>
+              ' ')) like lower(#{item})
             </if>
             </foreach>
             <if test="includeAspectIds != null">

--- a/src/test/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/query-test-common-SqlMap.xml
+++ b/src/test/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/query-test-common-SqlMap.xml
@@ -96,5 +96,19 @@
         order by
             ca.child_node_id
     </select>
+    
+     <select id="select_GetPeopleTest_CannedQuery" parameterType="org.alfresco.repo.domain.query.CannedQueryDAOTest$TestUserNamePattern" resultType="Long">
+    	select
+         	childNode.uuid as uuid, lower(userName.string_value) as userName
+        from
+        alf_child_assoc assoc
+        join alf_node childNode on (childNode.id = assoc.child_node_id)
+        left join alf_node_properties userName on (userName.node_id = childNode.id)
+        where
+        assoc.parent_node_id not null
+        and (lower(userName.string_value) like lower(#{userNamePattern})  <include refid="alfresco.util.escape"/>
+        and lower(userName.username) like lower(#{domainPattern}) <include refid="alfresco.util.escape"/>)
+      
+    </select>
 
 </mapper>


### PR DESCRIPTION
REPO-4090: The backslash character \ as an escape character within strings is the default and no escape is needed. This is valid for mariadb and Mysql.