### PR TITLE
Update identity-service configuration to match AIS 1.0 defaults

### DIFF
--- a/src/main/resources/alfresco/subsystems/Authentication/identity-service/identity-service-authentication.properties
+++ b/src/main/resources/alfresco/subsystems/Authentication/identity-service/identity-service-authentication.properties
@@ -7,7 +7,7 @@ identity-service.authentication.enable-username-password-authentication=true
 
 # Identity Service configuration
 identity-service.auth-server-url=http://localhost:8180/auth
-identity-service.realm=springboot
+identity-service.realm=alfresco
 identity-service.ssl-required=none
-identity-service.resource=activiti
+identity-service.resource=alfresco
 identity-service.public-client=true


### PR DESCRIPTION
The default values for `realm` and `resource` have been changed in the 1.0 release of AIS. The DBP Charts currently need to overwrite these values. See
https://github.com/Alfresco/alfresco-dbp-deployment/blob/177e0fb57cd39d2db0c14572843310fac6ffafeb/charts/incubator/alfresco-dbp/values.yaml#L52