### PR TITLE
REPO-4132: After upgrade the repository is empty

### DIFF
--- a/src/main/java/org/alfresco/repo/jscript/app/UsernamePropertyDecorator.java
+++ b/src/main/java/org/alfresco/repo/jscript/app/UsernamePropertyDecorator.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2019 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -72,16 +72,17 @@ public class UsernamePropertyDecorator extends BasePropertyDecorator
             firstName = "";
             lastName = "";
         }
+        // Check for System before going to the PersonService
+        else if (username.equals("System") || username.startsWith("System@"))
+        {
+            firstName = "System";
+            lastName = "User";
+        }
         else if (this.personService.personExists(username))
         {
             NodeRef personRef = this.personService.getPerson(username, false);
             firstName = (String)this.nodeService.getProperty(personRef, ContentModel.PROP_FIRSTNAME);
             lastName = (String)this.nodeService.getProperty(personRef, ContentModel.PROP_LASTNAME);
-        }
-        else if (username.equals("System") || username.startsWith("System@"))
-        {
-            firstName = "System";
-            lastName = "User";
         }
         else
         {


### PR DESCRIPTION
The source of the bug is a change in the `PersonServiceImpl.personExists` method which considers now built-in authorities (system, guest) as existing by default.

The System case was dealt with after checking on the person existence, so I switched between the two `ifs`. 
I checked for similar usages in the code and it doesn't seem to be any other left.