### PR TITLE
ALF-22056: onCopyComplete-Policy not called in order of copy-action

### DIFF
--- a/src/main/java/org/alfresco/repo/copy/CopyServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/copy/CopyServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -254,8 +255,8 @@ public class CopyServiceImpl extends AbstractBaseCopyService implements CopyServ
         // Clear out any record of copied associations
         TransactionalResourceHelper.getList(KEY_POST_COPY_ASSOCS).clear();
         
-        // Keep track of copied children
-        Map<NodeRef, NodeRef> copiesByOriginals = new HashMap<NodeRef, NodeRef>(17);
+        // Keep track of copied children in order of copying
+        Map<NodeRef, NodeRef> copiesByOriginals = new LinkedHashMap<NodeRef, NodeRef>(17);
         Set<NodeRef> copies = new HashSet<NodeRef>(17);
 
         NodeRef copiedNodeRef = copyImpl(


### PR DESCRIPTION
Changed implementation of map so that the insertion order is preserved, with this the onCopyComplete-Policy is called in the right order in case of an recursive copy.

The LinkedHashMap preserves the insertion order of the entries, so the Policy is called in the exact order of copy-operations.

I did not know how to extend CopyServiceImplTest for this, if anyone has an idea, let me know. Otherwise i would say that the change will have no effect to other components.
