### PR TITLE
ACE-5943 / REPO-4132: Rejecting a record in RM doesn't work with 6.1.0-RC4

### DIFF
--- a/src/main/java/org/alfresco/repo/jscript/app/UsernamePropertyDecorator.java
+++ b/src/main/java/org/alfresco/repo/jscript/app/UsernamePropertyDecorator.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2019 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -72,16 +72,17 @@ public class UsernamePropertyDecorator extends BasePropertyDecorator
             firstName = "";
             lastName = "";
         }
+        // Check for System before going to the PersonService
+        else if (username.equals("System") || username.startsWith("System@"))
+        {
+            firstName = "System";
+            lastName = "User";
+        }
         else if (this.personService.personExists(username))
         {
             NodeRef personRef = this.personService.getPerson(username, false);
             firstName = (String)this.nodeService.getProperty(personRef, ContentModel.PROP_FIRSTNAME);
             lastName = (String)this.nodeService.getProperty(personRef, ContentModel.PROP_LASTNAME);
-        }
-        else if (username.equals("System") || username.startsWith("System@"))
-        {
-            firstName = "System";
-            lastName = "User";
         }
         else
         {

--- a/src/main/java/org/alfresco/repo/security/person/PersonServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/security/person/PersonServiceImpl.java
@@ -493,6 +493,11 @@ public class PersonServiceImpl extends TransactionListenerAdapter implements Per
         {
             return null;
         }
+        if (EqualsHelper.nullSafeEquals(userName, AuthenticationUtil.getSystemUserName()))
+        {
+            return null;
+        }
+        
         final NodeRef personNode = getPersonOrNullImpl(userName);
         if (personNode == null)
         {

--- a/src/test/java/org/alfresco/repo/notification/NotificationServiceImplSystemTest.java
+++ b/src/test/java/org/alfresco/repo/notification/NotificationServiceImplSystemTest.java
@@ -33,6 +33,7 @@ import org.alfresco.model.ContentModel;
 import org.alfresco.repo.content.MimetypeMap;
 import org.alfresco.repo.model.Repository;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.repo.security.authentication.AuthenticationUtil.RunAsWork;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.service.cmr.model.FileFolderService;
 import org.alfresco.service.cmr.notification.NotificationContext;
@@ -197,19 +198,23 @@ public class NotificationServiceImplSystemTest extends BaseAlfrescoTestCase
         return true;
     }
     
-    public void testSimpleEmailNotification()
+    public void testSimpleEmailNotificationSystem()
     {
-        doTestInTransaction(new Test<Void>()
+        AuthenticationUtil.runAsSystem(new RunAsWork<Void>()
         {
             @Override
-            public Void run()
+            public Void doWork()
             {
                 NotificationContext context = new NotificationContext();
                 
                 context.setFrom(FROM_EMAIL);
                 context.addTo(TO_USER1);
                 context.setSubject(SUBJECT);
-                context.setBody(BODY);
+                context.setBodyTemplate(template.toString());
+                
+                Map<String, Serializable> templateArgs = new HashMap<String, Serializable>(1);
+                templateArgs.put("template", template);
+                context.setTemplateArgs(templateArgs);
                 
                 notificationService.sendNotification(EMailNotificationProvider.NAME, context);
                 
@@ -217,6 +222,8 @@ public class NotificationServiceImplSystemTest extends BaseAlfrescoTestCase
             }
         });
     }
+    
+    
     
     public void testTemplateEmailNotification()
     {

--- a/src/test/java/org/alfresco/repo/security/person/PersonTest.java
+++ b/src/test/java/org/alfresco/repo/security/person/PersonTest.java
@@ -47,6 +47,7 @@ import org.alfresco.query.PagingRequest;
 import org.alfresco.query.PagingResults;
 import org.alfresco.repo.policy.BehaviourFilter;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.repo.security.authentication.AuthenticationUtil.RunAsWork;
 import org.alfresco.repo.security.authentication.MutableAuthenticationDao;
 import org.alfresco.repo.transaction.AlfrescoTransactionSupport;
 import org.alfresco.repo.transaction.AlfrescoTransactionSupport.TxnReadState;
@@ -1787,5 +1788,21 @@ public class PersonTest extends TestCase
         {
             //  expect to go here
         }
+    }
+    
+    public void testBuitInSystemUser()
+    {
+
+        AuthenticationUtil.runAsSystem(new RunAsWork<Void>()
+        {
+            @Override
+            public Void doWork()
+            {
+                personService.getPerson(AuthenticationUtil.SYSTEM_USER_NAME);
+
+                return null;
+            }
+        });
+
     }
 }


### PR DESCRIPTION
The reject action in RM triggers an email notification from repo. Code in `EMailNotificationProvider.buildTemplateModel(...)` requests for the person associated with the current authenticated user.
Potentially another bug in `Repository.getPerson()` (next call in the stack trace), considers the current user to be `AuthenticationUtil.getRunAsUser()`, instead of the fully authenticated one. This calls, down the line, for the retrieval of the person for the username `System`, which ends up in trying to actually create the user System (which is not permitted), hence the exception.

The most simple (and safe) fix was to add a check for username System, in the low-level method `PersonServiceImpl.getPersonImpl(...)`, and return `null`.

2 tests were added, for the Person service and for the email notification generation.