### PR TITLE
REPO-3962: Remove context refresh from testOpenCloseOpenCloseFull

### DIFF
--- a/src/test/java/org/alfresco/RepositoryStartStopTest.java
+++ b/src/test/java/org/alfresco/RepositoryStartStopTest.java
@@ -190,6 +190,31 @@ public class RepositoryStartStopTest extends TestCase
        ApplicationContextHelper.closeApplicationContext();
        assertNoCachedApplicationContext();
     }
+
+    /**
+     *
+     * Enable test after this issue is resolved: https://issues.alfresco.com/jira/browse/REPO-4176
+     * @throws Exception
+     */
+    public void ignoreTestFullContextRefresh() throws Exception
+    {
+
+        assertNoCachedApplicationContext();
+
+        // Open it, and use it
+        ApplicationContext ctx = getFullContext();
+        assertNotNull(ctx);
+        doTestBasicWriteOperations(ctx);
+
+        // Refresh it, shouldn't break anything
+        ((AbstractApplicationContext)ctx).refresh();
+        assertNotNull(ctx);
+        doTestBasicWriteOperations(ctx);
+
+        // And finally close it
+        ApplicationContextHelper.closeApplicationContext();
+        assertNoCachedApplicationContext();
+    }
     
     /**
      * Tests that we can open a context, use it,

--- a/src/test/java/org/alfresco/RepositoryStartStopTest.java
+++ b/src/test/java/org/alfresco/RepositoryStartStopTest.java
@@ -164,8 +164,7 @@ public class RepositoryStartStopTest extends TestCase
      *  a context twice without error, using it
      *  when running. 
      */
-    // test ignored from 24 Oct 2018
-    public void ignoredTestOpenCloseOpenCloseFull() throws Exception
+    public void testOpenCloseOpenCloseFull() throws Exception
     {
        assertNoCachedApplicationContext();
 
@@ -186,9 +185,6 @@ public class RepositoryStartStopTest extends TestCase
        // Ask for it again, will be no change this time
        ctx = getFullContext();
        assertEquals(ctx, ctx2);
-       
-       // Refresh it, shouldn't break anything
-       ((AbstractApplicationContext)ctx).refresh();
        
        // And finally close it
        ApplicationContextHelper.closeApplicationContext();


### PR DESCRIPTION
* The refreshing of our core application context does not work with Spring version greater than 5.1.0
* We don't need to test refreshing the core application context as that never happens, only the subsystem application contexts are refreshed