### PR TITLE
REPO-4102: MNT-20213: Unable to run using Java 8

### DIFF
--- a/src/main/java/org/alfresco/repo/search/impl/lucene/index/IndexInfo.java
+++ b/src/main/java/org/alfresco/repo/search/impl/lucene/index/IndexInfo.java
@@ -36,6 +36,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.io.UnsupportedEncodingException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
@@ -2428,10 +2429,10 @@ public class IndexInfo implements IndexMonitor
             {
                 buffer = ByteBuffer.wrap(new byte[8]);
                 channel.read(buffer);
-                buffer.position(0);
+                ((Buffer) buffer).position(0);
             }
 
-            buffer.position(0);
+            ((Buffer) buffer).position(0);
             long onDiskVersion = buffer.getLong();
             return (version == onDiskVersion);
         }
@@ -2455,10 +2456,10 @@ public class IndexInfo implements IndexMonitor
             {
                 buffer = ByteBuffer.wrap(new byte[(int) channel.size()]);
                 channel.read(buffer);
-                buffer.position(0);
+                ((Buffer) buffer).position(0);
             }
 
-            buffer.position(0);
+            ((Buffer) buffer).position(0);
             long onDiskVersion = buffer.getLong();
             if (version != onDiskVersion)
             {
@@ -2604,7 +2605,7 @@ public class IndexInfo implements IndexMonitor
             buffer = ByteBuffer.wrap(new byte[(int) size]);
         }
 
-        buffer.position(0);
+        ((Buffer) buffer).position(0);
 
         buffer.putLong(version);
         CRC32 crc32 = new CRC32();
@@ -2647,7 +2648,7 @@ public class IndexInfo implements IndexMonitor
         }
         else
         {
-            buffer.rewind();
+            ((Buffer) buffer).rewind();
             channel.position(0);
             channel.write(buffer);
         }

--- a/src/main/java/org/alfresco/repo/transfer/HttpClientTransmitterImpl.java
+++ b/src/main/java/org/alfresco/repo/transfer/HttpClientTransmitterImpl.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
@@ -817,7 +818,7 @@ public class HttpClientTransmitterImpl implements TransferTransmitter
         while (src.read(buffer) != -1)
         {
             // prepare the buffer to be drained
-            buffer.flip();
+            ((Buffer) buffer).flip();
             // write to the channel, may block
              dest.write(buffer);
 
@@ -827,7 +828,7 @@ public class HttpClientTransmitterImpl implements TransferTransmitter
         }
 
         // EOF will leave buffer in fill state
-        buffer.flip();
+        ((Buffer) buffer).flip();
 
         // make sure the buffer is fully drained.
         while (buffer.hasRemaining())

--- a/src/test/java/org/alfresco/repo/content/AbstractWritableContentStoreTest.java
+++ b/src/test/java/org/alfresco/repo/content/AbstractWritableContentStoreTest.java
@@ -32,6 +32,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
@@ -731,7 +732,7 @@ public abstract class AbstractWritableContentStoreTest extends AbstractReadOnlyC
         int count = fileChannel.read(buffer);
         assertEquals("Incorrect number of bytes read", bytes.length, count);
         // transfer back to array
-        buffer.rewind();
+        ((Buffer) buffer).rewind();
         buffer.get(bytes);
         String checkContent = new String(bytes);
         assertEquals("Content read failure", content, checkContent);

--- a/src/test/java/org/alfresco/repo/content/filestore/FileIOTest.java
+++ b/src/test/java/org/alfresco/repo/content/filestore/FileIOTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.HashSet;
@@ -86,8 +87,10 @@ public class FileIOTest extends TestCase
         int countB = 0;
         do
         {
-            countA = channelA.read((ByteBuffer)bufferA.clear());
-            countB = channelB.read((ByteBuffer)bufferB.clear());
+            ((Buffer) bufferA).clear();
+            countA = channelA.read(bufferA);
+            ((Buffer) bufferB).clear();
+            countB = channelB.read(bufferB);
             assertEquals("Should read same number of bytes", countA, countB);
         } while (countA > 6);
         


### PR DESCRIPTION
   - explicit cast for compatibility with covariant return type on JDK 9's ByteBuffer