### PR TITLE
[SEARCH-1272] Set permissionService protected to be used by Extended …

### DIFF
--- a/src/main/java/org/alfresco/repo/search/impl/solr/SolrQueryHTTPClient.java
+++ b/src/main/java/org/alfresco/repo/search/impl/solr/SolrQueryHTTPClient.java
@@ -115,8 +115,6 @@ public class SolrQueryHTTPClient extends AbstractSolrQueryHTTPClient implements 
     private DictionaryService dictionaryService;
 
     private NodeService nodeService;
-
-    private PermissionService permissionService;
     
     private NodeDAO nodeDAO;
     
@@ -149,6 +147,8 @@ public class SolrQueryHTTPClient extends AbstractSolrQueryHTTPClient implements 
     private int defaultShardedFacetLimit = 20;
 
     private NamespaceDAO namespaceDAO;
+
+    protected PermissionService permissionService;
 
     public SolrQueryHTTPClient()
     {

--- a/src/main/java/org/alfresco/repo/search/impl/solr/SolrQueryHTTPClient.java
+++ b/src/main/java/org/alfresco/repo/search/impl/solr/SolrQueryHTTPClient.java
@@ -1180,10 +1180,6 @@ public class SolrQueryHTTPClient extends AbstractSolrQueryHTTPClient implements 
         return sortBuffer;
     }
 
-   
-
-
-
     /* (non-Javadoc)
      * @see org.springframework.beans.factory.BeanFactoryAware#setBeanFactory(org.springframework.beans.factory.BeanFactory)
      */

--- a/src/main/java/org/alfresco/repo/search/impl/solr/SolrQueryHTTPClient.java
+++ b/src/main/java/org/alfresco/repo/search/impl/solr/SolrQueryHTTPClient.java
@@ -115,11 +115,11 @@ public class SolrQueryHTTPClient extends AbstractSolrQueryHTTPClient implements 
     private DictionaryService dictionaryService;
 
     private NodeService nodeService;
-    
+
     private NodeDAO nodeDAO;
-    
+
     private TenantService tenantService;
-    
+
     private ShardRegistry shardRegistry;
 
     private Map<String, String> languageMappings;
@@ -148,7 +148,7 @@ public class SolrQueryHTTPClient extends AbstractSolrQueryHTTPClient implements 
 
     private NamespaceDAO namespaceDAO;
 
-    protected PermissionService permissionService;
+    private PermissionService permissionService;
 
     public SolrQueryHTTPClient()
     {
@@ -1341,5 +1341,78 @@ public class SolrQueryHTTPClient extends AbstractSolrQueryHTTPClient implements 
     }
 
 
+    public TenantService getTenantService()
+    {
+        return tenantService;
+    }
 
+    public DictionaryService getDictionaryService()
+    {
+        return dictionaryService;
+    }
+
+    public NodeService getNodeService()
+    {
+        return nodeService;
+    }
+
+    public ShardRegistry getShardRegistry()
+    {
+        return shardRegistry;
+    }
+
+    public RepositoryState getRepositoryState()
+    {
+        return repositoryState;
+    }
+
+    public boolean isUseDynamicShardRegistration()
+    {
+        return useDynamicShardRegistration;
+    }
+
+    public int getDefaultUnshardedFacetLimit()
+    {
+        return defaultUnshardedFacetLimit;
+    }
+
+    public int getDefaultShardedFacetLimit()
+    {
+        return defaultShardedFacetLimit;
+    }
+
+    public NamespaceDAO getNamespaceDAO()
+    {
+        return namespaceDAO;
+    }
+
+    public PermissionService getPermissionService()
+    {
+        return permissionService;
+    }
+
+    public Map<String, String> getLanguageMappings()
+    {
+        return languageMappings;
+    }
+
+    public boolean isAnyDenyDenies()
+    {
+        return anyDenyDenies;
+    }
+
+    public String getAlternativeDictionary()
+    {
+        return alternativeDictionary;
+    }
+
+    public boolean isIncludeGroupsForRoleAdmin()
+    {
+        return includeGroupsForRoleAdmin;
+    }
+
+    public int getMaximumResultsFromUnlimitedQuery()
+    {
+        return maximumResultsFromUnlimitedQuery;
+    }
 }

--- a/src/main/java/org/alfresco/repo/search/impl/solr/SolrSQLHttpClient.java
+++ b/src/main/java/org/alfresco/repo/search/impl/solr/SolrSQLHttpClient.java
@@ -78,7 +78,7 @@ public class SolrSQLHttpClient extends AbstractSolrQueryHTTPClient implements So
     private boolean useDynamicShardRegistration;
     private ShardRegistry shardRegistry;
     private TenantService tenantService;
-    protected PermissionService permissionService;
+    private PermissionService permissionService;
     
     public static final int DEFAULT_SAVEPOST_BUFFER = 4096;
     @Override
@@ -229,7 +229,7 @@ public class SolrSQLHttpClient extends AbstractSolrQueryHTTPClient implements So
         LOGGER.debug("Got: {} in {} ms", results.getNumberFound(), results.getQueryTime());
         return (ResultSet) results;
     }
-    
+
     
     public void setStoreMappings(List<SolrStoreMapping> storeMappings)
     {
@@ -278,6 +278,41 @@ public class SolrSQLHttpClient extends AbstractSolrQueryHTTPClient implements So
         this.shardRegistry = shardRegistry;
     }
 
+    public RepositoryState getRepositoryState()
+    {
+        return repositoryState;
+    }
+
+    public boolean isIncludeGroupsForRoleAdmin()
+    {
+        return includeGroupsForRoleAdmin;
+    }
+
+    public boolean isAnyDenyDenies()
+    {
+        return anyDenyDenies;
+    }
+
+    public boolean isUseDynamicShardRegistration()
+    {
+        return useDynamicShardRegistration;
+    }
+
+    public ShardRegistry getShardRegistry()
+    {
+        return shardRegistry;
+    }
+
+    public TenantService getTenantService()
+    {
+        return tenantService;
+    }
+
+    public PermissionService getPermissionService()
+    {
+        return permissionService;
+    }
+
     @Override
     public StatsResultSet executeStatsQuery(StatsParameters searchParameters)
     {
@@ -312,6 +347,7 @@ public class SolrSQLHttpClient extends AbstractSolrQueryHTTPClient implements So
         }
         
     }
+
     public void setTenantService(TenantService tenantService)
     {
         this.tenantService = tenantService;

--- a/src/main/java/org/alfresco/repo/search/impl/solr/SolrSQLHttpClient.java
+++ b/src/main/java/org/alfresco/repo/search/impl/solr/SolrSQLHttpClient.java
@@ -72,13 +72,13 @@ public class SolrSQLHttpClient extends AbstractSolrQueryHTTPClient implements So
     private HashMap<StoreRef, SolrStoreMappingWrapper> mappingLookup = new HashMap<StoreRef, SolrStoreMappingWrapper>();
     private List<SolrStoreMapping> storeMappings;
     private BeanFactory beanFactory;
-    private PermissionService permissionService;
     private RepositoryState repositoryState;
     private boolean includeGroupsForRoleAdmin = false;
     private boolean anyDenyDenies;
     private boolean useDynamicShardRegistration;
     private ShardRegistry shardRegistry;
     private TenantService tenantService;
+    protected PermissionService permissionService;
     
     public static final int DEFAULT_SAVEPOST_BUFFER = 4096;
     @Override


### PR DESCRIPTION
I needed to modify the modifier of permissionService field to be used in the subclasses defined in AGS.
Is it better to modify all the modifiers of the various Services from private to protected for future needs?
