### PR TITLE
Mail action executor better html detection

### DIFF
--- a/src/main/java/org/alfresco/repo/action/executer/MailActionExecuter.java
+++ b/src/main/java/org/alfresco/repo/action/executer/MailActionExecuter.java
@@ -1632,6 +1632,12 @@ public class MailActionExecuter extends ActionExecuterAbstractBase
 
     public static boolean isHTML(String value)
     {
+        // Note: The usage of Apache Tika mimetype detection was considered, but the following cases are detected as text/html:
+        // "This is plain text with <html mention inside"
+        // "This is plain text\nOnly\nBut it mentions HTML and <html>"
+        //  And the following case is detected as "application/xhtml+xml"
+        //  "This is plain text with <html xmlns= mention inside"
+        // Therefore we decided to not use Tika for html detection.
         boolean result = false;
 
         // Note: only simplistic matching here - start of the text

--- a/src/main/java/org/alfresco/repo/action/executer/MailActionExecuter.java
+++ b/src/main/java/org/alfresco/repo/action/executer/MailActionExecuter.java
@@ -1634,11 +1634,18 @@ public class MailActionExecuter extends ActionExecuterAbstractBase
     {
         boolean result = false;
 
-        // Note: only simplistic match here - expects <html tag at the start of the text
+        // Note: only simplistic matching here - start of the text
+        // must be one of <html or <!DOCTYPE
         String htmlPrefix = "<html";
+        String dtPrefix = "<!DOCTYPE";
         String trimmedText = value.trim();
         if (trimmedText.length() >= htmlPrefix.length() &&
                 trimmedText.substring(0, htmlPrefix.length()).equalsIgnoreCase(htmlPrefix))
+        {
+            result = true;
+        }
+        else if (trimmedText.length() >= dtPrefix.length() &&
+                trimmedText.substring(0, dtPrefix.length()).equalsIgnoreCase(dtPrefix))
         {
             result = true;
         }

--- a/src/test/java/org/alfresco/repo/action/executer/AbstractMailActionExecuterTest.java
+++ b/src/test/java/org/alfresco/repo/action/executer/AbstractMailActionExecuterTest.java
@@ -256,13 +256,24 @@ public abstract class AbstractMailActionExecuterTest
 
     protected MimeMessage sendMessage(String from, String subject, String template, final Action mailAction)
     {
+        return sendMessage(from, subject, template, null, mailAction);
+    }
+    protected MimeMessage sendMessage(String from, String subject, String template, String bodyText, final Action mailAction)
+    {
         if (from != null)
         {
             mailAction.setParameterValue(MailActionExecuter.PARAM_FROM, from);
         }
         mailAction.setParameterValue(MailActionExecuter.PARAM_SUBJECT, subject);
-        mailAction.setParameterValue(MailActionExecuter.PARAM_TEMPLATE, template);
-        mailAction.setParameterValue(MailActionExecuter.PARAM_TEMPLATE_MODEL, getModel());
+        if (template != null)
+        {
+            mailAction.setParameterValue(MailActionExecuter.PARAM_TEMPLATE, template);
+            mailAction.setParameterValue(MailActionExecuter.PARAM_TEMPLATE_MODEL, getModel());
+        }
+        else
+        {
+            mailAction.setParameterValue(MailActionExecuter.PARAM_TEXT, bodyText);
+        }
 
         RetryingTransactionHelper txHelper = APP_CONTEXT_INIT.getApplicationContext().getBean("retryingTransactionHelper", RetryingTransactionHelper.class);
 

--- a/src/test/java/org/alfresco/repo/action/executer/AbstractMailActionExecuterTest.java
+++ b/src/test/java/org/alfresco/repo/action/executer/AbstractMailActionExecuterTest.java
@@ -263,7 +263,8 @@ public abstract class AbstractMailActionExecuterTest
 
         Assert.assertNotNull(message);
         Assert.assertEquals(text, (String) message.getContent());
-        Assert.assertEquals("text/plain", message.getContentType());
+        Assert.assertEquals("text/plain", // Ignore charset 
+                            message.getDataHandler().getContentType().substring(0, 10));
 
         // HTML opening tag
         text = "<html><body>HTML emails are great</body></html>";
@@ -271,7 +272,8 @@ public abstract class AbstractMailActionExecuterTest
 
         Assert.assertNotNull(message);
         Assert.assertEquals(text, (String) message.getContent());
-        Assert.assertEquals("text/html", message.getContentType());
+        Assert.assertEquals("text/html", // Ignore charset 
+                            message.getDataHandler().getContentType().substring(0, 9));
 
         // HTML Doctype
         text = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n<html xmlns=\"http://www.w3.org/1999/xhtml\">\n<body>More complex HTML</body></html>";
@@ -279,7 +281,8 @@ public abstract class AbstractMailActionExecuterTest
 
         Assert.assertNotNull(message);
         Assert.assertEquals(text, (String) message.getContent());
-        Assert.assertEquals("text/html", message.getContentType());
+        Assert.assertEquals("text/html", // Ignore charset 
+                            message.getDataHandler().getContentType().substring(0, 9));
     }
 
     protected MimeMessage sendMessage(String from, Serializable recipients, String subject, String template)

--- a/src/test/java/org/alfresco/repo/action/executer/AbstractMailActionExecuterTest.java
+++ b/src/test/java/org/alfresco/repo/action/executer/AbstractMailActionExecuterTest.java
@@ -246,6 +246,42 @@ public abstract class AbstractMailActionExecuterTest
         Assert.assertEquals("Bonjour 1 janv. 1970", (String) message.getContent());
     }
 
+    @Test
+    public void testHTMLDetection() throws IOException, MessagingException
+    {
+        String from = "some.body@example.com";
+        Serializable recipients = (Serializable) Arrays.asList(FRENCH_USER.getUsername());
+        String subject = "";
+
+        Action mailAction = ACTION_SERVICE.createAction(MailActionExecuter.NAME);
+        mailAction.setParameterValue(MailActionExecuter.PARAM_TO_MANY, recipients);
+
+        // First with plain text
+        String text = "This is plain text\nOnly\nBut it mentions HTML and <html>";
+
+        MimeMessage message = sendMessage(from, subject, null, text, mailAction);
+
+        Assert.assertNotNull(message);
+        Assert.assertEquals(text, (String) message.getContent());
+        Assert.assertEquals("text/plain", message.getContentType());
+
+        // HTML opening tag
+        text = "<html><body>HTML emails are great</body></html>";
+        message = sendMessage(from, subject, null, text, mailAction);
+
+        Assert.assertNotNull(message);
+        Assert.assertEquals(text, (String) message.getContent());
+        Assert.assertEquals("text/html", message.getContentType());
+
+        // HTML Doctype
+        text = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n<html xmlns=\"http://www.w3.org/1999/xhtml\">\n<body>More complex HTML</body></html>";
+        message = sendMessage(from, subject, null, text, mailAction);
+
+        Assert.assertNotNull(message);
+        Assert.assertEquals(text, (String) message.getContent());
+        Assert.assertEquals("text/html", message.getContentType());
+    }
+
     protected MimeMessage sendMessage(String from, Serializable recipients, String subject, String template)
     {
         Action mailAction = ACTION_SERVICE.createAction(MailActionExecuter.NAME);


### PR DESCRIPTION
In order to get the correct rendering in Outlook, we need to update some of our HTML email templates to include a doctype at the start. However, this causes Alfresco to send them as Plain Text instead of HTML, because the logic in `MailActionExecutor` to decide if a `FTL` template rendered into HTML or Plain Text only considers the opening HTML tag, not a HTML Doctype declaration

The logic in the `isHTML` method needs to consider this too. In addition, unit testing is required for all of the HTML detection logic, including this new check.

Also raised as ALF-22073