### PR TITLE
REPO-4262: HotFix: MNT-20383: Associations query takes a long time to run and consumes a lot of CPU on the DB side

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>7.56-SNAPSHOT</version>
+    <version>7.mnt20383.56</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -15,7 +15,7 @@
         <connection>scm:git:git@github.com:Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:git@github.com:Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>HEAD</tag>
+        <tag>alfresco-repository-7.mnt20383.56</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>7.mnt20383.56</version>
+    <version>7.56-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -15,7 +15,7 @@
         <connection>scm:git:git@github.com:Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:git@github.com:Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>alfresco-repository-7.mnt20383.56</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/node-common-SqlMap.xml
+++ b/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/node-common-SqlMap.xml
@@ -825,7 +825,7 @@
             join alf_node sourceNode on (sourceNode.id = assoc.source_node_id)
             join alf_store sourceStore on (sourceStore.id = sourceNode.store_id) 
             join alf_node targetNode on (targetNode.id = assoc.target_node_id)
-            join alf_store targetStore on (targetStore.id = targetNode.store_id)
+            left join alf_store targetStore on (targetStore.id = targetNode.store_id)
     </sql>
     <sql id="select_NodeAssoc_OrderBy">
         order by


### PR DESCRIPTION
adding a left join for alf_store targetStore, to improve the query time and the load on the DB server