### PR TITLE
REPO-4284: MNT-20212:  Download as Zip temp content never gets cleaned up by Download Cleaner

### DIFF
--- a/src/main/java/org/alfresco/repo/download/DownloadServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/download/DownloadServiceImpl.java
@@ -109,22 +109,27 @@ public class DownloadServiceImpl implements DownloadService {
 		
 		return downloadStorage.getDownloadStatus(downloadNode);
     }
-	
+
     /*
      * @see org.alfresco.service.cmr.download.DownloadService#deleteDownloads(java.util.Date)
      */
     @Override
     public void deleteDownloads(Date before)
     {
-        List<List<DownloadEntity>> downloadPages = downloadStorage.getDownloadsCreatedBefore(before);
+        deleteDownloads(before, -1, false);
+    }
+
+    @Override
+    public void deleteDownloads(Date before, int batchSize, boolean cleanAllSysDownloadFolders)
+    {
+        List<List<DownloadEntity>> downloadPages = downloadStorage.getDownloadsCreatedBefore(before, batchSize, cleanAllSysDownloadFolders);
         for (List<DownloadEntity> page : downloadPages)
         {
-            for (DownloadEntity download : page) 
+            for (DownloadEntity download : page)
             {
                 downloadStorage.delete(download.getNodeRef());
             }
         }
-        
     }
 
     /*

--- a/src/main/java/org/alfresco/repo/download/DownloadsCleanupJob.java
+++ b/src/main/java/org/alfresco/repo/download/DownloadsCleanupJob.java
@@ -51,6 +51,8 @@ public class DownloadsCleanupJob implements Job
     private static final String KEY_DOWNLOAD_SERVICE = "downloadService";
     private static final String KEY_TENANT_ADMIN_SERVICE = "tenantAdminService";
     private static final String KEY_MAX_AGE = "maxAgeInMinutes";
+    private static final String BATCH_SIZE = "batchSize";
+    private static final String CLEAN_All_SYS_DOWNLOAD_FOLDERS = "cleanAllSysDownloadFolders";
     
 
     /*
@@ -65,6 +67,8 @@ public class DownloadsCleanupJob implements Job
         final DownloadService downloadService = (DownloadService)jobData.get(KEY_DOWNLOAD_SERVICE);
         final TenantAdminService tenantAdminService = (TenantAdminService)jobData.get(KEY_TENANT_ADMIN_SERVICE);
         final int maxAgeInMinutes = Integer.parseInt((String)jobData.get(KEY_MAX_AGE));
+        final int batchSize = Integer.parseInt((String)jobData.get(BATCH_SIZE));
+        final boolean cleanAllSysDownloadFolders = Boolean.parseBoolean((String)jobData.get(CLEAN_All_SYS_DOWNLOAD_FOLDERS));
         
         final DateTime before = new DateTime().minusMinutes(maxAgeInMinutes);
 
@@ -72,7 +76,7 @@ public class DownloadsCleanupJob implements Job
         {
             public Object doWork() throws Exception
             {
-                downloadService.deleteDownloads(before.toDate());
+                downloadService.deleteDownloads(before.toDate(), batchSize, cleanAllSysDownloadFolders);
                 return null;
             }
         }, AuthenticationUtil.getSystemUserName());
@@ -86,7 +90,7 @@ public class DownloadsCleanupJob implements Job
                 {
                     public Object doWork() throws Exception
                     {
-                        downloadService.deleteDownloads(before.toDate());
+                        downloadService.deleteDownloads(before.toDate(), batchSize, cleanAllSysDownloadFolders);
                         return null;
                     }
                 }, tenant.getTenantDomain());

--- a/src/main/java/org/alfresco/repo/node/SystemNodeUtils.java
+++ b/src/main/java/org/alfresco/repo/node/SystemNodeUtils.java
@@ -26,7 +26,10 @@
 
 package org.alfresco.repo.node;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.model.Repository;
@@ -56,6 +59,8 @@ public abstract class SystemNodeUtils
     
     private static QName SYSTEM_FOLDER_QNAME =
             QName.createQName(NamespaceService.SYSTEM_MODEL_1_0_URI, "system");
+    // change this to false only to test MNT-20212
+    public static boolean USE_SYSTEM_ACCOUNT_TO_GET_SYSTEM_LOCATIONS = true;
     
     /**
      * Returns the System Container for the current tenant
@@ -83,23 +88,75 @@ public abstract class SystemNodeUtils
      */
     public static NodeRef getSystemChildContainer(final QName childName, final NodeService nodeService, final Repository repositoryHelper)
     {
-        NodeRef system = getSystemContainer(nodeService, repositoryHelper);
-
-        // Find the container, under system
-        List<ChildAssociationRef> containerRefs = nodeService.getChildAssocs(
-                system, ContentModel.ASSOC_CHILDREN, childName);
+        List<ChildAssociationRef> containerRefs = getChildAssociationRefs(childName, nodeService, repositoryHelper);
 
         NodeRef container = null;
         if (containerRefs.size() > 0)
         {
             container = containerRefs.get(0).getChildRef();
-            if (containerRefs.size() > 1)
-                logger.warn("Duplicate Shared Credentials Containers found: " + containerRefs);
+            warnIfDuplicates(containerRefs);
         }
 
         return container;
     }
-    
+
+    /**
+     * MNT-20212
+     * Avoid using this method. It is meant only to fix that bug reported in the MNT
+     *
+     * Returns the list with all the NodeRef of a given Child Container within the current Tenant's
+     *  System Container, if found
+     */
+    public static List<NodeRef> getSystemChildContainers(final QName childName, final NodeService nodeService, final Repository repositoryHelper)
+    {
+        List<NodeRef> allChildContainers = new ArrayList<NodeRef>();
+
+        List<ChildAssociationRef> containerRefs = getChildAssociationRefs(childName, nodeService, repositoryHelper);
+
+        if (containerRefs.size() > 0)
+        {
+            for (ChildAssociationRef containerRef : containerRefs)
+            {
+                allChildContainers.add(containerRef.getChildRef());
+            }
+            warnIfDuplicates(containerRefs);
+        }
+
+        return allChildContainers;
+    }
+
+    private static void warnIfDuplicates(List<ChildAssociationRef> containerRefs)
+    {
+        if (containerRefs.size() > 1)
+        {
+            logger.warn("Duplicate system containers found: " + containerRefs);
+        }
+    }
+
+    private static List<ChildAssociationRef> getChildAssociationRefs(QName childName, NodeService nodeService, Repository repositoryHelper)
+    {
+        NodeRef system = getSystemContainer(nodeService, repositoryHelper);
+
+        // Find the container, under system
+        List<ChildAssociationRef> containerRefs = Collections.emptyList();
+        if (USE_SYSTEM_ACCOUNT_TO_GET_SYSTEM_LOCATIONS)
+        {
+            containerRefs = AuthenticationUtil.runAsSystem(new RunAsWork<List<ChildAssociationRef>>()
+            {
+                @Override
+                public List<ChildAssociationRef> doWork() throws Exception
+                {
+                    return nodeService.getChildAssocs(system, ContentModel.ASSOC_CHILDREN, childName);
+                }
+            });
+        }
+        else
+        {
+            containerRefs = nodeService.getChildAssocs(system, ContentModel.ASSOC_CHILDREN, childName);
+        }
+        return containerRefs;
+    }
+
     /**
      * Returns the NodeRef of a given Child Container within the current Tenant's System Container,
      *  creating the Container as System if required.

--- a/src/main/java/org/alfresco/repo/node/SystemNodeUtils.java
+++ b/src/main/java/org/alfresco/repo/node/SystemNodeUtils.java
@@ -59,9 +59,7 @@ public abstract class SystemNodeUtils
     
     private static QName SYSTEM_FOLDER_QNAME =
             QName.createQName(NamespaceService.SYSTEM_MODEL_1_0_URI, "system");
-    // change this to false only to test MNT-20212
-    public static boolean USE_SYSTEM_ACCOUNT_TO_GET_SYSTEM_LOCATIONS = true;
-    
+
     /**
      * Returns the System Container for the current tenant
      */
@@ -133,27 +131,19 @@ public abstract class SystemNodeUtils
         }
     }
 
-    private static List<ChildAssociationRef> getChildAssociationRefs(QName childName, NodeService nodeService, Repository repositoryHelper)
+    private static List<ChildAssociationRef> getChildAssociationRefs(final QName childName, final NodeService nodeService,
+        final Repository repositoryHelper)
     {
-        NodeRef system = getSystemContainer(nodeService, repositoryHelper);
+        final NodeRef system = getSystemContainer(nodeService, repositoryHelper);
 
-        // Find the container, under system
-        List<ChildAssociationRef> containerRefs = Collections.emptyList();
-        if (USE_SYSTEM_ACCOUNT_TO_GET_SYSTEM_LOCATIONS)
+        List<ChildAssociationRef> containerRefs = AuthenticationUtil.runAsSystem(new RunAsWork<List<ChildAssociationRef>>()
         {
-            containerRefs = AuthenticationUtil.runAsSystem(new RunAsWork<List<ChildAssociationRef>>()
+            @Override
+            public List<ChildAssociationRef> doWork() throws Exception
             {
-                @Override
-                public List<ChildAssociationRef> doWork() throws Exception
-                {
-                    return nodeService.getChildAssocs(system, ContentModel.ASSOC_CHILDREN, childName);
-                }
-            });
-        }
-        else
-        {
-            containerRefs = nodeService.getChildAssocs(system, ContentModel.ASSOC_CHILDREN, childName);
-        }
+                return nodeService.getChildAssocs(system, ContentModel.ASSOC_CHILDREN, childName);
+            }
+        });
         return containerRefs;
     }
 

--- a/src/main/java/org/alfresco/service/cmr/download/DownloadService.java
+++ b/src/main/java/org/alfresco/service/cmr/download/DownloadService.java
@@ -66,7 +66,18 @@ public interface DownloadService
      * @param before Date
      */
     public void deleteDownloads(Date before);
-    
+
+    /**
+     * Delete downloads created before the specified date.
+     *
+     * It also limits the number of deleted files for this batch of work to
+     * the specified batchSize;
+     *
+     * It can also look into deleting downloads files from all sys:Download folders
+     * affected by MNT-20212
+     */
+    void deleteDownloads(Date before, int batchSize, boolean cleanAllSysDownloadFolders);
+
     /**
      * Cancel a download request
      * 

--- a/src/main/resources/alfresco/download-services-context.xml
+++ b/src/main/resources/alfresco/download-services-context.xml
@@ -131,6 +131,8 @@
                                     <entry key="downloadService" value-ref="DownloadService" />
                                     <entry key="tenantAdminService" value-ref="tenantAdminService"/>
                                     <entry key="maxAgeInMinutes" value="${download.cleaner.maxAgeMins}"/>
+                                    <entry key="batchSize" value="${download.cleaner.batchSize}"/>
+                                    <entry key="cleanAllSysDownloadFolders" value="${download.cleaner.cleanAllSysDownloadFolders}"/>
                                 </map>
                             </property>
                         </bean>

--- a/src/main/resources/alfresco/repository.properties
+++ b/src/main/resources/alfresco/repository.properties
@@ -956,6 +956,12 @@ download.cleaner.startDelayMilliseconds=3600000
 # 1 hour
 download.cleaner.repeatIntervalMilliseconds=3600000
 download.cleaner.maxAgeMins=60
+# -1 or 0 for not using batches
+download.cleaner.batchSize=1000
+
+# you could set this to false for new installations greater then ACS 6.2
+# see MNT-20212
+download.cleaner.cleanAllSysDownloadFolders=true
 
 #
 # Download Service Limits, in bytes


### PR DESCRIPTION
Modified the SystemNodeUtils to run as system when access to the "sys:download" folder is required. 
This will prevent other "sys:download" (with differnt GUID) to be created, as it was the case in the past for non admin users;
I also added code to the DownloadService and DownloadStorage classes to handle the deletion of the old download zip files that were not deleted by the DownloadsCleanupJob because of this bug.
I added support for batching for this deletion, since old repositories may potentially contain a lot of these old files that were not deleted for years.