### PR TITLE
REPO-4331: Refactor transformers as legacy transformers

### DIFF
--- a/src/main/java/org/alfresco/repo/content/transform/StringExtractingContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/StringExtractingContentTransformer.java
@@ -47,7 +47,7 @@ import org.apache.commons.logging.LogFactory;
  * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
 @Deprecated
-public class StringExtractingContentTransformer extends AbstractContentTransformer2
+public class StringExtractingContentTransformer extends AbstractRemoteContentTransformer
 {
     public static final String PREFIX_TEXT = "text/";
     
@@ -98,6 +98,12 @@ public class StringExtractingContentTransformer extends AbstractContentTransform
         return sb.toString();
     }
 
+    @Override
+    protected Log getLogger()
+    {
+        return logger;
+    }
+
     /**
      * Text to text conversions are done directly using the content reader and writer string
      * manipulation methods.
@@ -107,13 +113,13 @@ public class StringExtractingContentTransformer extends AbstractContentTransform
      * be unformatted but valid. 
      */
     @Override
-    public void transformInternal(ContentReader reader, ContentWriter writer,  TransformationOptions options)
+    public void transformLocal(ContentReader reader, ContentWriter writer,  TransformationOptions options)
             throws Exception
     {
         // is this a straight text-text transformation
         transformText(reader, writer, options);
     }
-    
+
     /**
      * Transformation optimized for text-to-text conversion
      */
@@ -163,5 +169,20 @@ public class StringExtractingContentTransformer extends AbstractContentTransform
             }
         }
         // done
+    }
+
+    @Override
+    protected void transformRemote(RemoteTransformerClient remoteTransformerClient, ContentReader reader, ContentWriter writer, TransformationOptions options, String sourceMimetype, String targetMimetype, String sourceExtension, String targetExtension, String targetEncoding) throws Exception
+    {
+        String sourceEncoding = reader.getEncoding();
+        long timeoutMs = options.getTimeoutMs();
+
+        remoteTransformerClient.request(reader, writer, sourceMimetype, sourceExtension, targetExtension,
+                timeoutMs, logger,
+                "sourceMimetype", sourceMimetype,
+                "targetMimetype", targetMimetype,
+                "sourceEncoding", sourceEncoding,
+                "targetEncoding", targetEncoding);
+
     }
 }

--- a/src/main/resources/alfresco/content-services-context.xml
+++ b/src/main/resources/alfresco/content-services-context.xml
@@ -470,6 +470,19 @@
        </property>
    </bean>
 
+    <bean name="miscRemoteTransformerClient"
+          class="org.alfresco.repo.content.transform.RemoteTransformerClient">
+        <constructor-arg>
+            <value>MiscellaneousTransformers</value>
+        </constructor-arg>
+        <constructor-arg>
+            <value>${miscellaneous-transformers.url}</value>
+        </constructor-arg>
+        <property name="startupRetryPeriodSeconds">
+            <value>${miscellaneous-transformers.startupRetryPeriodSeconds}</value>
+        </property>
+    </bean>
+
    <bean id="baseTikaContentTransformer"
          class="org.alfresco.repo.content.transform.TikaPoweredContentTransformer"
          abstract="true"
@@ -483,7 +496,12 @@
     <!-- Content Transformations -->
     <bean id="transformer.StringExtracter"
           class="org.alfresco.repo.content.transform.StringExtractingContentTransformer"
-          parent="baseContentTransformer" />
+          parent="baseContentTransformer" >
+        <property name="enabled" value="${legacy.local.transform.service.enabled}" />
+        <property name="remoteTransformerClient">
+            <ref bean="miscRemoteTransformerClient" />
+        </property>
+    </bean>
 
    <bean id="transformer.BinaryPassThrough"
          class="org.alfresco.repo.content.transform.BinaryPassThroughContentTransformer"
@@ -492,6 +510,10 @@
    <bean id="transformer.iWorksQuicklooks"
          class="org.alfresco.repo.content.transform.AppleIWorksContentTransformer"
          parent="baseContentTransformer" >
+       <property name="enabled" value="${legacy.local.transform.service.enabled}" />
+       <property name="remoteTransformerClient">
+           <ref bean="miscRemoteTransformerClient" />
+       </property>
    </bean>
 
    <bean id="transformer.OOXMLThumbnail"
@@ -546,8 +568,12 @@
    <bean id="transformer.HtmlParser"
          class="org.alfresco.repo.content.transform.HtmlParserContentTransformer"
          parent="baseContentTransformer" >
+       <property name="enabled" value="${legacy.local.transform.service.enabled}" />
+       <property name="remoteTransformerClient">
+           <ref bean="miscRemoteTransformerClient" />
+       </property>
    </bean>
-   
+
    <bean id="transformer.MediaWikiParser"
          class="org.alfresco.repo.content.transform.MediaWikiContentTransformer"
          parent="baseContentTransformer">

--- a/src/main/resources/alfresco/repository.properties
+++ b/src/main/resources/alfresco/repository.properties
@@ -616,6 +616,7 @@ pdfrenderer.url=
 imagemagick.url=
 libreoffice.url=
 tika.url=
+miscellaneous-transformers.url=http://localhost:8094/
 
 # Local T-engines (docker container) url used to service transform requests via http.
 localTransformer.imageMagick.url=
@@ -629,6 +630,7 @@ pdfrenderer.startupRetryPeriodSeconds=60
 imagemagick.startupRetryPeriodSeconds=60
 libreoffice.startupRetryPeriodSeconds=60
 tika.startupRetryPeriodSeconds=60
+miscellaneous-transformers.startupRetryPeriodSeconds=60
 
 #
 content.metadataExtracter.pdf.maxDocumentSizeMB=10

--- a/src/test/java/org/alfresco/repo/content/transform/AppleIWorksContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/AppleIWorksContentTransformerTest.java
@@ -51,6 +51,7 @@ public class AppleIWorksContentTransformerTest extends AbstractContentTransforme
         transformer.setMimetypeService(mimetypeService);
         transformer.setTransformerDebug(transformerDebug);
         transformer.setTransformerConfig(transformerConfig);
+        transformer.afterPropertiesSet();
     }
     
     @Override

--- a/src/test/java/org/alfresco/repo/content/transform/HtmlParserContentTransformerTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/HtmlParserContentTransformerTest.java
@@ -53,6 +53,7 @@ public class HtmlParserContentTransformerTest extends AbstractContentTransformer
         transformer.setMimetypeService(mimetypeService);
         transformer.setTransformerDebug(transformerDebug);
         transformer.setTransformerConfig(transformerConfig);
+        transformer.afterPropertiesSet();
     }
     
     protected ContentTransformer getTransformer(String sourceMimetype, String targetMimetype)


### PR DESCRIPTION
The following transformers now extend AbstractRemoteContentTransformer:
* HtmlParserContentTransformer
* AppleIWorksContentTransformer
* StringExtractingContentTransformer