### PR TITLE
REPO-4305: jmx dump password redaction inconsistent

### DIFF
--- a/src/main/java/org/alfresco/repo/management/JmxDumpUtil.java
+++ b/src/main/java/org/alfresco/repo/management/JmxDumpUtil.java
@@ -220,7 +220,7 @@ public class JmxDumpUtil
         String replacement = JmxDumpUtil.PROTECTED_VALUE;
         String output = input.replaceAll(pattern, replacement);
 
-        if(output.equals(input)) //If no string have been replaced it's possible password= could be end of sprint
+        if(output.equals(input)) //If nothing has been replaced it's possible password= could be end of string
         {
             // pattern to see if the string ends with "password=", "token=" or "pwd="
             Pattern passwordAtEnd = Pattern.compile("((password=)|(token=)|(pwd=))$");

--- a/src/main/java/org/alfresco/repo/management/JmxDumpUtil.java
+++ b/src/main/java/org/alfresco/repo/management/JmxDumpUtil.java
@@ -229,7 +229,7 @@ public class JmxDumpUtil
     static String cleanPasswordFromInputArgument(String input, Pattern redactedInputPattern)
     {
         //Replace the whole string with just capture group 1 to remove the desired value and concat the protected value.
-        String output = redactedInputPattern.matcher(input).replaceAll("$1"+PROTECTED_VALUE); //input.replaceAll(regex, "$1"+PROTECTED_VALUE);
+        String output = redactedInputPattern.matcher(input).replaceAll("$1"+PROTECTED_VALUE);
         return output;
     }
 

--- a/src/main/java/org/alfresco/repo/management/JmxDumpUtil.java
+++ b/src/main/java/org/alfresco/repo/management/JmxDumpUtil.java
@@ -202,7 +202,7 @@ public class JmxDumpUtil
     }
 
     /**
-     * Removes any characters the word/s provided in passwordArgs
+     * Removes any characters the word/s provided in redactedInputs
      * and replaces them with JmxDumpUtil.PROTECTED_VALUE
      * <p>
      * Example: 

--- a/src/main/java/org/alfresco/repo/management/JmxDumpUtil.java
+++ b/src/main/java/org/alfresco/repo/management/JmxDumpUtil.java
@@ -214,11 +214,11 @@ public class JmxDumpUtil
      * 
      * @param input String
      * @param redactedInputs String[]
-     * @return password redacted string
+     * @return password redacted string if input matches a string in redactedInputs, an un-altered string will be returned if it does not match.
      */
     static String cleanPasswordFromInputArgument(String input, String[] redactedInputs)
     {
-        //Selects the whole string, if one of the key words are preset with two groups, group 1 is the proceeding token ie. "password=" and group 2 will be all characters following the =.
+        //Selects the whole string, if one of the redactedInputs are present. It will have two capture groups, group 1 is the proceeding token ie. "password=" and group 2 will be all characters following the = (the vaule/password).
         String regex = createPasswordFindRegexString(redactedInputs); 
 
         //Replace the whole string with just capture group 1 to remove the desired value and concat the protected value.

--- a/src/test/java/org/alfresco/repo/management/JmxDumpUtilTest.java
+++ b/src/test/java/org/alfresco/repo/management/JmxDumpUtilTest.java
@@ -27,6 +27,8 @@ package org.alfresco.repo.management;
 
 import static org.junit.Assert.assertArrayEquals;
 
+import java.util.regex.Pattern;
+
 import org.alfresco.util.ApplicationContextHelper;
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
@@ -49,42 +51,32 @@ public class JmxDumpUtilTest extends TestCase
     @Test
     public void testCleanPasswordsFromInputArgument() throws Exception
     {
-        String[] argEndingsTypical = {"password", "token","pwd"};
+        Pattern pattern = Pattern.compile("(?i)(.*(password=|pwd=|token=))((?<=password=|pwd=|token=).*+)");
         String passwordArg = "-Ddb.password=I should be stars \"£$%^&*()@";
         String expected = "-Ddb.password="+JmxDumpUtil.PROTECTED_VALUE;
-        String actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg,argEndingsTypical);
+        String actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg,pattern);
         assertEquals("Expectected output: "+ expected +" Actual output: "+actual, expected, actual);
 
         passwordArg = "-Ddb.paSsword=@";
         expected = "-Ddb.paSsword="+JmxDumpUtil.PROTECTED_VALUE;
-        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, argEndingsTypical);
+        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, pattern);
         assertEquals("Expectected output: "+ expected +" Actual output: "+actual, expected, actual);
 
         passwordArg = "somePrefix.token=\"If i'm not replaced, something has gone very wrong\"";
         expected = "somePrefix.token="+JmxDumpUtil.PROTECTED_VALUE;
-        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, argEndingsTypical);
+        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, pattern);
         assertEquals("Expectected output: "+ expected +" Actual output: "+actual, expected, actual);
 
         passwordArg = "yetanotherpwd=";
         expected = "yetanotherpwd="+JmxDumpUtil.PROTECTED_VALUE;
-        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, argEndingsTypical);
+        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, pattern);
         assertEquals("Expectected output: "+ expected +" Actual output: "+actual, expected, actual);
 
         passwordArg = "AnyOtherArgument=\"I should still be here\"";
         expected = "AnyOtherArgument=\"I should still be here\"";
-        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, argEndingsTypical);
+        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, pattern);
         assertEquals("Expectected output :"+ expected +" Actual output :"+actual, expected, actual);
 
-        String[] argEndingsMeta = {"password","pass?"};
-        passwordArg = "AnyOtherPassword=\"I should still be here\"";
-        expected = "AnyOtherPassword="+JmxDumpUtil.PROTECTED_VALUE;
-        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, argEndingsMeta);
-        assertEquals("Expectected output :"+ expected +" Actual output :"+actual, expected, actual);
-
-        passwordArg = "AnyOtherPass?=\"I should still be here\"";
-        expected = "AnyOtherPass?="+JmxDumpUtil.PROTECTED_VALUE;
-        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, argEndingsMeta);
-        assertEquals("Expectected output :"+ expected +" Actual output :"+actual, expected, actual);
     }
     @Test
     public void testCleanPasswordsFromInputArguments() throws Exception
@@ -99,6 +91,9 @@ public class JmxDumpUtilTest extends TestCase
         expectedArray = new String[]{"-Ddb.port=1234", "-Ddb.user=alfresco", "-DtestArg=Test1234password"};
         actualArray = JmxDumpUtil.cleanPasswordsFromInputArguments(args, argEndingsTypical);
         assertArrayEquals("Expectected output:"+expectedArray+" Actual output:"+actualArray, expectedArray, actualArray);
+        
+        
+
     }
     @Test
     public void testCreatePasswordFindRegexString() throws Exception
@@ -111,9 +106,17 @@ public class JmxDumpUtilTest extends TestCase
         String[] argEndings2 = {"?", "\"£$%^&*"};
         expected = "(?i)(.*(\\?=|\"£$%^&\\*=))((?<=\\?=|\"£$%^&\\*=).*+)";
         actual = JmxDumpUtil.createPasswordFindRegexString(argEndings2);
-        assertEquals("Expectected output :"+expected+" Actual output :"+actual,expected, actual);
-
+        assertEquals("Expectected output :"+expected+" Actual output :"+actual,expected, actual);   
         
+        String[] emptyArgs = {};
+        try 
+        {
+            JmxDumpUtil.createPasswordFindRegexString(emptyArgs);
+            fail("expected exception was not occured.");
+        } catch(IllegalArgumentException e) 
+        {
+            
+        }
     }
     @Test
     public void testEscapeRegexMetaChars()

--- a/src/test/java/org/alfresco/repo/management/JmxDumpUtilTest.java
+++ b/src/test/java/org/alfresco/repo/management/JmxDumpUtilTest.java
@@ -85,6 +85,6 @@ public class JmxDumpUtilTest extends TestCase
         args = new String[]{"-Ddb.port=1234", "-Ddb.user=alfresco", "-DtestArg=Test1234password"};
         expectedArray = new String[]{"-Ddb.port=1234", "-Ddb.user=alfresco", "-DtestArg=Test1234password"};
         actualArray = JmxDumpUtil.cleanPasswordsFromInputArguments(args);
-        assertArrayEquals("Expectected output:"+expectedArray+" Actual output:"+actualArray,expectedArray,actualArray);
+        assertArrayEquals("Expectected output:"+expectedArray+" Actual output:"+actualArray, expectedArray, actualArray);
     }
 }

--- a/src/test/java/org/alfresco/repo/management/JmxDumpUtilTest.java
+++ b/src/test/java/org/alfresco/repo/management/JmxDumpUtilTest.java
@@ -25,7 +25,10 @@
  */
 package org.alfresco.repo.management;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import org.alfresco.util.ApplicationContextHelper;
+import org.junit.Test;
 import org.springframework.context.ApplicationContext;
 
 import junit.framework.TestCase;
@@ -41,5 +44,47 @@ public class JmxDumpUtilTest extends TestCase
             String attr = JmxDumpUtil.updateOSNameAttributeForLinux(osName);
             assertTrue(attr.toLowerCase().startsWith("linux ("));
         }
+    }
+
+    @Test
+    public void testCleanPasswordsFromInputArgument() throws Exception
+    {
+        String passwordArg = "-Ddb.password=I should be stars \"£$%^&*()@";
+        String expected = "-Ddb.password="+JmxDumpUtil.PROTECTED_VALUE;
+        String actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg);
+        assertEquals("Expectected output:"+expected+" Actual output:"+actual,expected, actual);
+
+        passwordArg = "-Ddb.paSsword=@";
+        expected = "-Ddb.paSsword="+JmxDumpUtil.PROTECTED_VALUE;
+        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg);
+        assertEquals("Expectected output:"+expected+" Actual output:"+actual,expected, actual);
+
+        passwordArg = "somePrefix.token=\"If i'm not replaced, something has gone very wrong\"";
+        expected = "somePrefix.token="+JmxDumpUtil.PROTECTED_VALUE;
+        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg);
+        assertEquals("Expectected output:"+expected+" Actual output:"+actual,expected, actual);
+
+        passwordArg = "yetanotherpwd=";
+        expected = "yetanotherpwd="+JmxDumpUtil.PROTECTED_VALUE;
+        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg);
+        assertEquals("Expectected output:"+expected+" Actual output:"+actual,expected, actual);
+
+        passwordArg = "AnyOtherArgument=\"I should still be here\"";
+        expected = "AnyOtherArgument=\"I should still be here\"";
+        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg);
+        assertEquals("Expectected output:"+expected+" Actual output:"+actual,expected, actual);
+    }
+    @Test
+    public void testCleanPasswordsFromInputArguments() throws Exception
+    {
+        String[] args = {"-Ddb.password=alfresco", "-Ddb.user=alfresco", "-DtestToken=asdoij3ifiej22244ojpgkmkfpsi3j55643pojpdjoismvi4563625mposvsd"};
+        String[] expectedArray = {"-Ddb.password="+JmxDumpUtil.PROTECTED_VALUE, "-Ddb.user=alfresco", "-DtestToken="+JmxDumpUtil.PROTECTED_VALUE};
+        String[] actualArray = JmxDumpUtil.cleanPasswordsFromInputArguments(args);
+        assertArrayEquals("Expectected output:"+expectedArray+" Actual output:"+actualArray,expectedArray,actualArray);
+
+        args = new String[]{"-Ddb.port=1234", "-Ddb.user=alfresco", "-DtestArg=Test1234password"};
+        expectedArray = new String[]{"-Ddb.port=1234", "-Ddb.user=alfresco", "-DtestArg=Test1234password"};
+        actualArray = JmxDumpUtil.cleanPasswordsFromInputArguments(args);
+        assertArrayEquals("Expectected output:"+expectedArray+" Actual output:"+actualArray,expectedArray,actualArray);
     }
 }

--- a/src/test/java/org/alfresco/repo/management/JmxDumpUtilTest.java
+++ b/src/test/java/org/alfresco/repo/management/JmxDumpUtilTest.java
@@ -52,27 +52,27 @@ public class JmxDumpUtilTest extends TestCase
         String passwordArg = "-Ddb.password=I should be stars \"£$%^&*()@";
         String expected = "-Ddb.password="+JmxDumpUtil.PROTECTED_VALUE;
         String actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg);
-        assertEquals("Expectected output:"+expected+" Actual output:"+actual,expected, actual);
+        assertEquals("Expectected output: "+expected+" Actual output: "+actual,expected, actual);
 
         passwordArg = "-Ddb.paSsword=@";
         expected = "-Ddb.paSsword="+JmxDumpUtil.PROTECTED_VALUE;
         actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg);
-        assertEquals("Expectected output:"+expected+" Actual output:"+actual,expected, actual);
+        assertEquals("Expectected output: "+expected+" Actual output: "+actual,expected, actual);
 
         passwordArg = "somePrefix.token=\"If i'm not replaced, something has gone very wrong\"";
         expected = "somePrefix.token="+JmxDumpUtil.PROTECTED_VALUE;
         actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg);
-        assertEquals("Expectected output:"+expected+" Actual output:"+actual,expected, actual);
+        assertEquals("Expectected output: "+expected+" Actual output: "+actual,expected, actual);
 
         passwordArg = "yetanotherpwd=";
         expected = "yetanotherpwd="+JmxDumpUtil.PROTECTED_VALUE;
         actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg);
-        assertEquals("Expectected output:"+expected+" Actual output:"+actual,expected, actual);
+        assertEquals("Expectected output: "+expected+" Actual output: "+actual,expected, actual);
 
         passwordArg = "AnyOtherArgument=\"I should still be here\"";
         expected = "AnyOtherArgument=\"I should still be here\"";
         actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg);
-        assertEquals("Expectected output:"+expected+" Actual output:"+actual,expected, actual);
+        assertEquals("Expectected output :"+expected+" Actual output :"+actual,expected, actual);
     }
     @Test
     public void testCleanPasswordsFromInputArguments() throws Exception
@@ -86,5 +86,14 @@ public class JmxDumpUtilTest extends TestCase
         expectedArray = new String[]{"-Ddb.port=1234", "-Ddb.user=alfresco", "-DtestArg=Test1234password"};
         actualArray = JmxDumpUtil.cleanPasswordsFromInputArguments(args);
         assertArrayEquals("Expectected output:"+expectedArray+" Actual output:"+actualArray, expectedArray, actualArray);
+    }
+    @Test
+    public void testCreatePasswordFindRegexString() throws Exception
+    {
+        String[] argEndings = {"password", "any old ending :D", "token="};
+        String expected = "(?i)(?<=(password=))|(?<=(any old ending :D=))|(?<=(token=)).++";
+        String actual = JmxDumpUtil.createPasswordFindRegexString(argEndings);
+        assertEquals("Expectected output :"+expected+" Actual output :"+actual,expected, actual);
+        
     }
 }

--- a/src/test/java/org/alfresco/repo/management/JmxDumpUtilTest.java
+++ b/src/test/java/org/alfresco/repo/management/JmxDumpUtilTest.java
@@ -49,51 +49,83 @@ public class JmxDumpUtilTest extends TestCase
     @Test
     public void testCleanPasswordsFromInputArgument() throws Exception
     {
+        String[] argEndingsTypical = {"password", "token","pwd"};
         String passwordArg = "-Ddb.password=I should be stars \"£$%^&*()@";
         String expected = "-Ddb.password="+JmxDumpUtil.PROTECTED_VALUE;
-        String actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg);
-        assertEquals("Expectected output: "+expected+" Actual output: "+actual,expected, actual);
+        String actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg,argEndingsTypical);
+        assertEquals("Expectected output: "+ expected +" Actual output: "+actual, expected, actual);
 
         passwordArg = "-Ddb.paSsword=@";
         expected = "-Ddb.paSsword="+JmxDumpUtil.PROTECTED_VALUE;
-        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg);
-        assertEquals("Expectected output: "+expected+" Actual output: "+actual,expected, actual);
+        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, argEndingsTypical);
+        assertEquals("Expectected output: "+ expected +" Actual output: "+actual, expected, actual);
 
         passwordArg = "somePrefix.token=\"If i'm not replaced, something has gone very wrong\"";
         expected = "somePrefix.token="+JmxDumpUtil.PROTECTED_VALUE;
-        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg);
-        assertEquals("Expectected output: "+expected+" Actual output: "+actual,expected, actual);
+        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, argEndingsTypical);
+        assertEquals("Expectected output: "+ expected +" Actual output: "+actual, expected, actual);
 
         passwordArg = "yetanotherpwd=";
         expected = "yetanotherpwd="+JmxDumpUtil.PROTECTED_VALUE;
-        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg);
-        assertEquals("Expectected output: "+expected+" Actual output: "+actual,expected, actual);
+        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, argEndingsTypical);
+        assertEquals("Expectected output: "+ expected +" Actual output: "+actual, expected, actual);
 
         passwordArg = "AnyOtherArgument=\"I should still be here\"";
         expected = "AnyOtherArgument=\"I should still be here\"";
-        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg);
-        assertEquals("Expectected output :"+expected+" Actual output :"+actual,expected, actual);
+        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, argEndingsTypical);
+        assertEquals("Expectected output :"+ expected +" Actual output :"+actual, expected, actual);
+
+        String[] argEndingsMeta = {"password","pass?"};
+        passwordArg = "AnyOtherPassword=\"I should still be here\"";
+        expected = "AnyOtherPassword="+JmxDumpUtil.PROTECTED_VALUE;
+        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, argEndingsMeta);
+        assertEquals("Expectected output :"+ expected +" Actual output :"+actual, expected, actual);
+
+        passwordArg = "AnyOtherPass?=\"I should still be here\"";
+        expected = "AnyOtherPass?="+JmxDumpUtil.PROTECTED_VALUE;
+        actual = JmxDumpUtil.cleanPasswordFromInputArgument(passwordArg, argEndingsMeta);
+        assertEquals("Expectected output :"+ expected +" Actual output :"+actual, expected, actual);
     }
     @Test
     public void testCleanPasswordsFromInputArguments() throws Exception
     {
+        String[] argEndingsTypical = {"password", "token","pwd"};
         String[] args = {"-Ddb.password=alfresco", "-Ddb.user=alfresco", "-DtestToken=asdoij3ifiej22244ojpgkmkfpsi3j55643pojpdjoismvi4563625mposvsd"};
         String[] expectedArray = {"-Ddb.password="+JmxDumpUtil.PROTECTED_VALUE, "-Ddb.user=alfresco", "-DtestToken="+JmxDumpUtil.PROTECTED_VALUE};
-        String[] actualArray = JmxDumpUtil.cleanPasswordsFromInputArguments(args);
+        String[] actualArray = JmxDumpUtil.cleanPasswordsFromInputArguments(args, argEndingsTypical);
         assertArrayEquals("Expectected output:"+expectedArray+" Actual output:"+actualArray,expectedArray,actualArray);
 
         args = new String[]{"-Ddb.port=1234", "-Ddb.user=alfresco", "-DtestArg=Test1234password"};
         expectedArray = new String[]{"-Ddb.port=1234", "-Ddb.user=alfresco", "-DtestArg=Test1234password"};
-        actualArray = JmxDumpUtil.cleanPasswordsFromInputArguments(args);
+        actualArray = JmxDumpUtil.cleanPasswordsFromInputArguments(args, argEndingsTypical);
         assertArrayEquals("Expectected output:"+expectedArray+" Actual output:"+actualArray, expectedArray, actualArray);
     }
     @Test
     public void testCreatePasswordFindRegexString() throws Exception
     {
-        String[] argEndings = {"password", "any old ending :D", "token="};
-        String expected = "(?i)(?<=(password=))|(?<=(any old ending :D=))|(?<=(token=)).++";
+        String[] argEndings = {"password", "any old ending :D", "token"};
+        String expected = "(?i)(.*(password=|any old ending :D=|token=))((?<=password=|any old ending :D=|token=).*+)";
         String actual = JmxDumpUtil.createPasswordFindRegexString(argEndings);
         assertEquals("Expectected output :"+expected+" Actual output :"+actual,expected, actual);
+
+        String[] argEndings2 = {"?", "\"£$%^&*"};
+        expected = "(?i)(.*(\\?=|\"£$%^&\\*=))((?<=\\?=|\"£$%^&\\*=).*+)";
+        actual = JmxDumpUtil.createPasswordFindRegexString(argEndings2);
+        assertEquals("Expectected output :"+expected+" Actual output :"+actual,expected, actual);
+
         
+    }
+    @Test
+    public void testEscapeRegexMetaChars()
+    {
+        String input = "|?*+.";
+        String expected = "\\|\\?\\*\\+\\.";
+        String actual = JmxDumpUtil.escapeRegexMetaChars(input);
+        assertEquals("Expectected output :" + expected + " Actual output :" + actual, expected, actual);
+
+        input = "Let's.Add++,*complexity?!\"";
+        expected = "Let's\\.Add\\+\\+,\\*complexity\\?!\"";
+        actual = JmxDumpUtil.escapeRegexMetaChars(input);
+        assertEquals("Expectected output :" + expected + " Actual output :" + actual, expected, actual);
     }
 }


### PR DESCRIPTION
Added new methods to parse the InputArguments section of the JMXDump, in order to redact any instances of plain text passwords.