### PR TITLE
REPO-4366 / REPO-4458: Update Tika to 1.21-alfresco-patched

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>7.75-SNAPSHOT</version>
+    <version>REPO-4458</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -15,7 +15,7 @@
         <connection>scm:git:git@github.com:Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:git@github.com:Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>HEAD</tag>
+        <tag>alfresco-repository-REPO-4458</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dependency.spring.version>5.1.8.RELEASE</dependency.spring.version>
         <dependency.httpcomponents.version>4.5.9</dependency.httpcomponents.version>
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
-        <dependency.poi.version>3.17</dependency.poi.version>
+        <dependency.poi.version>4.0.1</dependency.poi.version>
         <dependency.webscripts.version>7.2</dependency.webscripts.version>
         <dependency.opencmis.version>1.0.0</dependency.opencmis.version>
         <dependency.activiti-engine.version>5.22.0</dependency.activiti-engine.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency.alfresco-legacy-lucene.version>6.2</dependency.alfresco-legacy-lucene.version>
         <dependency.alfresco-core.version>7.17</dependency.alfresco-core.version>
         <dependency.alfresco-greenmail.version>6.1</dependency.alfresco-greenmail.version>
-        <dependency.alfresco-data-model.version>8.41</dependency.alfresco-data-model.version>
+        <dependency.alfresco-data-model.version>repo-4458-1</dependency.alfresco-data-model.version>
         <dependency.alfresco-jlan.version>7.1</dependency.alfresco-jlan.version>
         <dependency.alfresco-pdf-renderer.version>1.1</dependency.alfresco-pdf-renderer.version>
         <dependency.alfresco-hb-data-sender.version>1.0.11</dependency.alfresco-hb-data-sender.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>REPO-4458</version>
+    <version>7.75-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -15,7 +15,7 @@
         <connection>scm:git:git@github.com:Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:git@github.com:Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>alfresco-repository-REPO-4458</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency.alfresco-legacy-lucene.version>6.2</dependency.alfresco-legacy-lucene.version>
         <dependency.alfresco-core.version>7.17</dependency.alfresco-core.version>
         <dependency.alfresco-greenmail.version>6.1</dependency.alfresco-greenmail.version>
-        <dependency.alfresco-data-model.version>repo-4458-1</dependency.alfresco-data-model.version>
+        <dependency.alfresco-data-model.version>8.42</dependency.alfresco-data-model.version>
         <dependency.alfresco-jlan.version>7.1</dependency.alfresco-jlan.version>
         <dependency.alfresco-pdf-renderer.version>1.1</dependency.alfresco-pdf-renderer.version>
         <dependency.alfresco-hb-data-sender.version>1.0.11</dependency.alfresco-hb-data-sender.version>

--- a/src/main/java/org/alfresco/filesys/repo/CIFSContentComparator.java
+++ b/src/main/java/org/alfresco/filesys/repo/CIFSContentComparator.java
@@ -47,7 +47,7 @@ import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.poifs.filesystem.DirectoryEntry;
 import org.apache.poi.poifs.filesystem.EntryUtils;
 import org.apache.poi.poifs.filesystem.FilteringDirectoryNode;
-import org.apache.poi.poifs.filesystem.NPOIFSFileSystem;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 
 /**
  * Compares content for to see if content is equal.
@@ -153,7 +153,7 @@ public class CIFSContentComparator implements ContentComparator
         }
     }
 
-    private boolean isContentIdentical(NPOIFSFileSystem fs1, NPOIFSFileSystem fs2, Collection<String> excludes) throws IOException
+    private boolean isContentIdentical(POIFSFileSystem fs1, POIFSFileSystem fs2, Collection<String> excludes) throws IOException
     {
         DirectoryEntry de1 = fs1.getRoot();
         DirectoryEntry de2 = fs2.getRoot();
@@ -207,9 +207,9 @@ public class CIFSContentComparator implements ContentComparator
                 leftIs = existingContent.getContentInputStream();
 
                 // this call guarantees that leftIs is closed.
-                NPOIFSFileSystem fs2 = new NPOIFSFileSystem(leftIs);
+                POIFSFileSystem fs2 = new POIFSFileSystem(leftIs);
                 // this call keeps an open file handle and needs closing.
-                NPOIFSFileSystem fs1 = new NPOIFSFileSystem(newFile);  
+                POIFSFileSystem fs1 = new POIFSFileSystem(newFile);  
                 try
                 {
 
@@ -322,8 +322,8 @@ public class CIFSContentComparator implements ContentComparator
                 	os2.close();
                 }
                 
-                NPOIFSFileSystem fs1 = new NPOIFSFileSystem(tpm1);
-                NPOIFSFileSystem fs2 = new NPOIFSFileSystem(tpm2);
+                POIFSFileSystem fs1 = new POIFSFileSystem(tpm1);
+                POIFSFileSystem fs2 = new POIFSFileSystem(tpm2);
                 
                 return isContentIdentical(fs1, fs2, excludes);
             }
@@ -462,8 +462,8 @@ public class CIFSContentComparator implements ContentComparator
                             }
                         }
 
-                        NPOIFSFileSystem fs1 = new NPOIFSFileSystem(tpm1);
-                        NPOIFSFileSystem fs2 = new NPOIFSFileSystem(tpm2);
+                        POIFSFileSystem fs1 = new POIFSFileSystem(tpm1);
+                        POIFSFileSystem fs2 = new POIFSFileSystem(tpm2);
 
                         return isContentIdentical(fs1, fs2, excludes);
                     }


### PR DESCRIPTION
Updated `alfresco-data-model`, which depends on the patched tika -`1.21-20190624-alfresco-patched`.
`poi` library was updated to 4.0.1 to match the version in tika.