### PR TITLE
REPO-4525 / MNT-2075: Multiple camel-jackson vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -791,7 +791,7 @@
         <dependency>
             <groupId>org.gytheio</groupId>
             <artifactId>gytheio-messaging-camel</artifactId>
-            <version>0.9.1</version>
+            <version>0.10</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>


### PR DESCRIPTION
- Updated gytheio-messaging-camel to version 0.10 which brings a newer version of camel-jackson (2.24.0)
see https://github.com/Alfresco/gytheio/releases/tag/v0.10