### PR TITLE
REPO-4504 upgrade cxf-rt-transports-http 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ jobs:
       script: travis_wait 20 mvn test -B -Dtest=AllDBTestsTestSuite -Ddb.url=jdbc:mariadb://localhost/alfresco?useUnicode=yes\&characterEncoding=UTF-8 -Ddb.name=alfresco -Ddb.url=jdbc:mariadb://localhost:3307/alfresco -Ddb.username=alfresco -Ddb.password=alfresco -Ddb.driver=org.mariadb.jdbc.Driver
     - stage: release
       name: "Push to Nexus"
-      if: fork = false AND (branch = fix/REPO-450_Upgrade_cxf-rt-transports-http_6.1) AND type != pull_request AND commit_message !~ /\[no-release\]/
+      if: fork = false AND (branch = fix/REPO-4504_Upgrade_cxf-rt-transports-http_6.1) AND type != pull_request AND commit_message !~ /\[no-release\]/
       before_install:
         - "cp .travis.settings.xml $HOME/.m2/settings.xml"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ branches:
   only:
     - master
     - /support\/.*/
+    - fix/REPO-450_Upgrade_cxf-rt-transports-http_6.1
 
 stages:
   - test
@@ -100,7 +101,7 @@ jobs:
       script: travis_wait 20 mvn test -B -Dtest=AllDBTestsTestSuite -Ddb.url=jdbc:mariadb://localhost/alfresco?useUnicode=yes\&characterEncoding=UTF-8 -Ddb.name=alfresco -Ddb.url=jdbc:mariadb://localhost:3307/alfresco -Ddb.username=alfresco -Ddb.password=alfresco -Ddb.driver=org.mariadb.jdbc.Driver
     - stage: release
       name: "Push to Nexus"
-      if: fork = false AND (branch = master OR branch =~ /support\/.*/) AND type != pull_request AND commit_message !~ /\[no-release\]/
+      if: fork = false AND (branch = fix/REPO-450_Upgrade_cxf-rt-transports-http_6.1) AND type != pull_request AND commit_message !~ /\[no-release\]/
       before_install:
         - "cp .travis.settings.xml $HOME/.m2/settings.xml"
       script:
@@ -109,4 +110,4 @@ jobs:
         # Add email to link commits to user
         - git config user.email "${GIT_EMAIL}"
         # Skip building of release commits
-        - mvn --batch-mode -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform
+        - mvn --batch-mode -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests -DreleaseVersion=repo-4504-repository-61-2 -DdevelopmentVersion=7.33.29-SNAPSHOT release:clean release:prepare release:perform

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ branches:
   only:
     - master
     - /support\/.*/
-    - fix/REPO-4504_Upgrade_cxf-rt-transports-http_6.1
 
 stages:
   - test
@@ -101,7 +100,7 @@ jobs:
       script: travis_wait 20 mvn test -B -Dtest=AllDBTestsTestSuite -Ddb.url=jdbc:mariadb://localhost/alfresco?useUnicode=yes\&characterEncoding=UTF-8 -Ddb.name=alfresco -Ddb.url=jdbc:mariadb://localhost:3307/alfresco -Ddb.username=alfresco -Ddb.password=alfresco -Ddb.driver=org.mariadb.jdbc.Driver
     - stage: release
       name: "Push to Nexus"
-      if: fork = false AND (branch = fix/REPO-4504_Upgrade_cxf-rt-transports-http_6.1) AND type != pull_request AND commit_message !~ /\[no-release\]/
+      if: fork = false AND (branch = master OR branch =~ /support\/.*/) AND type != pull_request AND commit_message !~ /\[no-release\]/
       before_install:
         - "cp .travis.settings.xml $HOME/.m2/settings.xml"
       script:
@@ -110,4 +109,4 @@ jobs:
         # Add email to link commits to user
         - git config user.email "${GIT_EMAIL}"
         # Skip building of release commits
-        - mvn --batch-mode -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests -DreleaseVersion=repo-4504-repository-61-2 -DdevelopmentVersion=7.33.29-SNAPSHOT release:clean release:prepare release:perform
+        - mvn --batch-mode -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ branches:
   only:
     - master
     - /support\/.*/
-    - fix/REPO-450_Upgrade_cxf-rt-transports-http_6.1
+    - fix/REPO-4504_Upgrade_cxf-rt-transports-http_6.1
 
 stages:
   - test

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <dependency.camel.version>2.24.0</dependency.camel.version>
         <dependency.activemq.version>5.15.7</dependency.activemq.version>
         <dependency.pdfbox.version>2.0.15</dependency.pdfbox.version>
+        <dependency.cxf.version>3.3.2</dependency.cxf.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency.alfresco-legacy-lucene.version>6.2</dependency.alfresco-legacy-lucene.version>
         <dependency.alfresco-core.version>7.5.6</dependency.alfresco-core.version>
         <dependency.alfresco-greenmail.version>6.1</dependency.alfresco-greenmail.version>
-        <dependency.alfresco-data-model.version>8.25.9</dependency.alfresco-data-model.version>
+        <dependency.alfresco-data-model.version>8.25.10</dependency.alfresco-data-model.version>
         <dependency.alfresco-jlan.version>7.1</dependency.alfresco-jlan.version>
         <dependency.alfresco-pdf-renderer.version>1.1</dependency.alfresco-pdf-renderer.version>
         <dependency.alfresco-hb-data-sender.version>1.0.10</dependency.alfresco-hb-data-sender.version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,12 @@
                 <artifactId>jsoup</artifactId>
                 <version>1.12.1</version>
             </dependency>
+            <!-- upgrade cxf libraries -->
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-frontend-jaxws</artifactId>
+                <version>${dependency.cxf.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <maven.build.sourceVersion>11</maven.build.sourceVersion>
 
         <dependency.alfresco-legacy-lucene.version>6.2</dependency.alfresco-legacy-lucene.version>
-        <dependency.alfresco-core.version>7.5.1</dependency.alfresco-core.version>
+        <dependency.alfresco-core.version>7.5.6</dependency.alfresco-core.version>
         <dependency.alfresco-greenmail.version>6.1</dependency.alfresco-greenmail.version>
         <dependency.alfresco-data-model.version>8.25.8</dependency.alfresco-data-model.version>
         <dependency.alfresco-jlan.version>7.1</dependency.alfresco-jlan.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>7.33.28</version>
+    <version>7.33.29-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -15,7 +15,7 @@
         <connection>scm:git:https://github.com/Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>alfresco-repository-7.33.28</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>7.33.28-SNAPSHOT</version>
+    <version>7.33.28</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -15,7 +15,7 @@
         <connection>scm:git:https://github.com/Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>HEAD</tag>
+        <tag>alfresco-repository-7.33.28</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
There is a dependency in data-model that uses cxf-rt-frontend-jaxws, which is at version 3.3.2. However, in the repository dependency tree it uses version 3.0.12, and has been causing failures in acs-packaging All amps validation in the 6.0.N line (multiple asm libraries). 

(cherry picked from commit 77509f085725e6fe700ba87863bdf7cf3ccd817e)