### PR TITLE
REPO-4525: Upgrade camel-jackson version (2.24.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -832,6 +832,10 @@
                     <groupId>org.apache.camel</groupId>
                     <artifactId>camel-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>camel-jackson</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -896,6 +900,11 @@
                     <artifactId>geronimo-jms_2.0_spec</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-jackson</artifactId>
+            <version>${dependency.camel.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>


### PR DESCRIPTION
Upgrade camel-jackson version (2.24.0) and exclude the dependency from gytheio.