### PR TITLE
Remove unused tagsoup and metadata-extractor libs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -429,16 +429,6 @@
             <version>1.1.22</version>
         </dependency>
         <dependency>
-            <groupId>com.drewnoakes</groupId>
-            <artifactId>metadata-extractor</artifactId>
-            <version>2.12.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.ccil.cowan.tagsoup</groupId>
-            <artifactId>tagsoup</artifactId>
-            <version>1.2.1</version>
-        </dependency>
-        <dependency>
             <groupId>net.sf</groupId>
             <artifactId>bliki</artifactId>
             <version>3.0.2</version>


### PR DESCRIPTION
Those libs come from TIKA anyways.