### PR TITLE
MM-811: Update Gytheio (Messaging Camel) from 0.9.1 to 0.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -839,7 +839,7 @@
         <dependency>
             <groupId>org.gytheio</groupId>
             <artifactId>gytheio-messaging-camel</artifactId>
-            <version>0.9.1</version>
+            <version>0.11</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>


### PR DESCRIPTION
**Gytheio 0.11**:  [https://github.com/Alfresco/gytheio/releases/tag/v0.11](https://github.com/Alfresco/gytheio/releases/tag/v0.11)

I'm not sure if this can/should be merged (yet), seeing as how the previous Gytheio upgrade ([#PR483](https://github.com/Alfresco/alfresco-repository/pull/483)) was reverted, but I've opened the PR just in case.