### PR TITLE
Cannot subclass TransformationOptionsConverter

### DIFF
--- a/src/main/java/org/alfresco/repo/rendition2/TransformationOptionsConverter.java
+++ b/src/main/java/org/alfresco/repo/rendition2/TransformationOptionsConverter.java
@@ -128,7 +128,7 @@ public class TransformationOptionsConverter implements InitializingBean
                     TIMEOUT, MAX_SOURCE_SIZE_K_BYTES
             }));
 
-    private interface Setter
+    protected interface Setter
     {
         void set(String s);
     }
@@ -313,7 +313,7 @@ public class TransformationOptionsConverter implements InitializingBean
         return transformationOptions;
     }
 
-    private <T> void ifSet(Map<String, String> options, String key, TransformationOptionsConverter.Setter setter)
+    protected <T> void ifSet(Map<String, String> options, String key, TransformationOptionsConverter.Setter setter)
     {
         String value = options.get(key);
         if (value != null)


### PR DESCRIPTION
   Change access modifier from private to protected for TransformationOptionsConverter#Setter interface and TransformationOptionsConverter#ifSet as TransformationOptionsConverter is required to be sub-classed by custom legacy Transformers.