### PR TITLE
REPO-4712 AIS default AI rendition definitions (via XML) are lost aft…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
         <maven.build.sourceVersion>11</maven.build.sourceVersion>
 
-        <dependency.alfresco-data-model.version>8.50.1</dependency.alfresco-data-model.version>
+        <dependency.alfresco-data-model.version>8.50.2</dependency.alfresco-data-model.version>
         <dependency.alfresco-core.version>7.22</dependency.alfresco-core.version>
 
         <dependency.alfresco-legacy-lucene.version>6.2</dependency.alfresco-legacy-lucene.version>

--- a/src/main/java/org/alfresco/repo/content/transform/RemoteTransformerClient.java
+++ b/src/main/java/org/alfresco/repo/content/transform/RemoteTransformerClient.java
@@ -128,7 +128,7 @@ public class RemoteTransformerClient
 
     void request(Log logger, String sourceExtension, String targetExtension, HttpEntity reqEntity, ContentWriter writer, String args)
     {
-        String url = baseUrl + "/transform";
+        String url = baseUrl + (baseUrl.endsWith("/") ? "" : "/") + "transform";
         HttpPost httppost = new HttpPost(url);
         httppost.setEntity(reqEntity);
 

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerDebug.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerDebug.java
@@ -1691,7 +1691,7 @@ public class TransformerDebug implements ApplicationContextAware
             {
                 setStringBuilder(sb);
                 RenditionDefinition2 renditionDefinition = new RenditionDefinition2Impl(testRenditionName, targetMimetype,
-                        Collections.emptyMap(), renditionDefinitionRegistry2);
+                        Collections.emptyMap(), true, renditionDefinitionRegistry2);
 
                 sourceNodeRef = createSourceNode(sourceExtension, sourceMimetype);
                 ContentData contentData = (ContentData) nodeService.getProperty(sourceNodeRef, ContentModel.PROP_CONTENT);

--- a/src/main/java/org/alfresco/repo/rendition2/RenditionDefinition2Impl.java
+++ b/src/main/java/org/alfresco/repo/rendition2/RenditionDefinition2Impl.java
@@ -38,17 +38,36 @@ public class RenditionDefinition2Impl implements RenditionDefinition2
     private final String renditionName;
     private final String targetMimetype;
     private final Map<String, String> transformOptions;
+    private final boolean dynamicallyLoaded;
 
+    /**
+     * Constructor used by statically (e.g. XML Spring beans) defined renditions.
+     */
     public RenditionDefinition2Impl(String renditionName, String targetMimetype, Map<String, String> transformOptions,
                                     RenditionDefinitionRegistry2Impl registry)
+    {
+        this(renditionName, targetMimetype, transformOptions, false, registry);
+    }
+
+    /**
+     * Constructor used by dynamically defined renditions that may be changed without restarting.
+     */
+    public RenditionDefinition2Impl(String renditionName, String targetMimetype, Map<String, String> transformOptions,
+                                    boolean dynamicallyLoaded, RenditionDefinitionRegistry2Impl registry)
     {
         this.renditionName = renditionName;
         this.targetMimetype = targetMimetype;
         this.transformOptions = transformOptions;
+        this.dynamicallyLoaded = dynamicallyLoaded;
         if (registry != null)
         {
             registry.register(this);
         }
+    }
+
+    public boolean isDynamicallyLoaded()
+    {
+        return dynamicallyLoaded;
     }
 
     @Override

--- a/src/main/java/org/alfresco/transform/client/registry/CombinedConfig.java
+++ b/src/main/java/org/alfresco/transform/client/registry/CombinedConfig.java
@@ -62,8 +62,6 @@ import java.util.Set;
  */
 public class CombinedConfig
 {
-    private static final String TRANSFORM_CONFIG = "/transform/config";
-
     private final Log log;
 
     static class TransformAndItsOrigin
@@ -128,7 +126,7 @@ public class CombinedConfig
 
     private boolean addRemoteConfig(String baseUrl, String remoteType)
     {
-        String url = baseUrl + TRANSFORM_CONFIG;
+        String url = baseUrl + (baseUrl.endsWith("/") ? "" : "/") + "transform/config";
         HttpGet httpGet = new HttpGet(url);
         boolean successReadingConfig = true;
         try

--- a/src/test/java/org/alfresco/repo/rendition2/LocalTransformClientIntegrationTest.java
+++ b/src/test/java/org/alfresco/repo/rendition2/LocalTransformClientIntegrationTest.java
@@ -36,9 +36,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Map;
 
 import static org.alfresco.model.ContentModel.PROP_CONTENT;
 
@@ -81,7 +79,7 @@ public class LocalTransformClientIntegrationTest extends AbstractRenditionIntegr
     public void testLocalRenderPagesToJpeg() throws Exception
     {
         legacyTransformServiceRegistry.setEnabled(false);
-        new RenditionDefinition2Impl("pagesToJpeg", "image/jpeg", new HashMap<>(), renditionDefinitionRegistry2 );
+        new RenditionDefinition2Impl("pagesToJpeg", "image/jpeg", new HashMap<>(), true, renditionDefinitionRegistry2 );
         try
         {
             checkClientRendition("quick2009.pages", "pagesToJpeg", true);
@@ -90,6 +88,36 @@ public class LocalTransformClientIntegrationTest extends AbstractRenditionIntegr
         {
             // Remove rendition even if check throws an exception to not interfere with other tests
             renditionDefinitionRegistry2.unregister("pagesToJpeg");
+        }
+    }
+
+    @Test
+    public void testReloadOfStaticDefinitions() throws Exception
+    {
+        legacyTransformServiceRegistry.setEnabled(false);
+        new RenditionDefinition2Impl("dynamic1", "image/jpeg", new HashMap<>(), true, renditionDefinitionRegistry2 );
+        new RenditionDefinition2Impl("dynamic2", "image/jpeg", new HashMap<>(), true, renditionDefinitionRegistry2 );
+        new RenditionDefinition2Impl("static1", "image/jpeg", new HashMap<>(), false, renditionDefinitionRegistry2 );
+        new RenditionDefinition2Impl("static2", "image/jpeg", new HashMap<>(), false, renditionDefinitionRegistry2 );
+
+        try
+        {
+            assertNotNull(renditionDefinitionRegistry2.getRenditionDefinition("dynamic1"));
+            assertNotNull(renditionDefinitionRegistry2.getRenditionDefinition("dynamic2"));
+            assertNotNull(renditionDefinitionRegistry2.getRenditionDefinition("static1"));
+            assertNotNull(renditionDefinitionRegistry2.getRenditionDefinition("static2"));
+
+            renditionDefinitionRegistry2.reloadRegistry();
+
+            assertNull(renditionDefinitionRegistry2.getRenditionDefinition("dynamic1"));
+            assertNull(renditionDefinitionRegistry2.getRenditionDefinition("dynamic2"));
+            assertNotNull(renditionDefinitionRegistry2.getRenditionDefinition("static1"));
+            assertNotNull(renditionDefinitionRegistry2.getRenditionDefinition("static2"));
+        }
+        finally
+        {
+            renditionDefinitionRegistry2.unregister("static1");
+            renditionDefinitionRegistry2.unregister("static2");
         }
     }
 

--- a/src/test/java/org/alfresco/repo/rendition2/RenditionService2Test.java
+++ b/src/test/java/org/alfresco/repo/rendition2/RenditionService2Test.java
@@ -132,7 +132,7 @@ public class RenditionService2Test
         Map<String, String> options = new HashMap<>();
         options.put("width", "960");
         options.put("height", "1024");
-        new RenditionDefinition2Impl(TEST_RENDITION, JPEG, options, renditionDefinitionRegistry2);
+        new RenditionDefinition2Impl(TEST_RENDITION, JPEG, options, true, renditionDefinitionRegistry2);
     }
 
     private class RenditionRequestSchedulerMock extends PostTxnCallbackScheduler


### PR DESCRIPTION
…er startup (at **:30)

- Remember 'static' renditions created via spring beans.