### PR TITLE
REPO-4795 - Remove library commons.discovery:commons.discovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,11 +182,6 @@
             <version>1.4-DBCP330</version>
         </dependency>
         <dependency>
-            <groupId>commons-discovery</groupId>
-            <artifactId>commons-discovery</artifactId>
-            <version>0.5</version>
-        </dependency>
-        <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
             <version>1.4</version>


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.
