### PR TITLE
REPO-4800 - Remove library oro:oro

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,11 +251,6 @@
             <version>65.1</version>
         </dependency>
         <dependency>
-            <groupId>oro</groupId>
-            <artifactId>oro</artifactId>
-            <version>2.0.8</version>
-        </dependency>
-        <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
             <version>1.1.1</version>


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.