### PR TITLE
REPO-4801 - Remove library org.springframework:spring-orm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,11 +278,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-orm</artifactId>
-            <version>${dependency.spring.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <version>${dependency.spring.version}</version>
         </dependency>


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

