### PR TITLE
REPO-4804 - Remove library org.apache.pdfbox:fontbox

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -432,11 +432,6 @@
             <version>${dependency.pdfbox.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>fontbox</artifactId>
-            <version>${dependency.pdfbox.version}</version>
-        </dependency>
-        <dependency>
             <!-- we need this for TextToPdfContentTransformer -->
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox-tools</artifactId>


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

