### PR TITLE
REPO-4811 - Remove library org.apache.ws.xmlschema:xmlschema-core fro…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -505,11 +505,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.ws.xmlschema</groupId>
-            <artifactId>xmlschema-core</artifactId>
-             <version>2.2.4</version>
-        </dependency>
-        <dependency>
             <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
             <artifactId>concurrentlinkedhashmap-lru</artifactId>
             <version>1.4.2</version>


### PR DESCRIPTION
…m alfresco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

