### PR TITLE
REPO-4812 - Remove library org.apache.commons:commons-email from alfr…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-email</artifactId>
-                <version>1.5</version>
-            </dependency>
             <!-- upgrade dependency from TIKA -->
             <dependency>
                 <groupId>com.github.junrar</groupId>


### PR DESCRIPTION
…esco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

