### PR TITLE
REPO-4813 - Remove library org.livetribe:livetribe-jsr223 from alfres…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -572,11 +572,6 @@
             <version>${dependency.poi.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.livetribe</groupId>
-            <artifactId>livetribe-jsr223</artifactId>
-            <version>2.0.7</version>
-        </dependency>
-        <dependency>
             <groupId>edu.ucar</groupId>
             <artifactId>netcdf</artifactId>
             <version>4.2.20</version>


### PR DESCRIPTION
…co-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

