### PR TITLE
REPO-4828 - Remove library org.antlr:gunit from alfresco-repository p…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1125,12 +1125,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>gunit</artifactId>
-            <version>${dependency.antlr.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.alfresco.surf</groupId>
             <artifactId>spring-webscripts</artifactId>
             <version>${dependency.webscripts.version}</version>


### PR DESCRIPTION
…roject
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

