### PR TITLE
REPO-4829 - Remove library org.apache.activemq:activemq-kahadb-store …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1142,12 +1142,6 @@
             <artifactId>aspectjrt</artifactId>
             <version>1.9.5</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-kahadb-store</artifactId>
-            <version>${dependency.activemq.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
…from alfresco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

