### PR TITLE
REPO-4791 Use Local transforms where Legacy transforms are called.

### DIFF
--- a/src/main/java/org/alfresco/repo/content/transform/AbstractContentTransformer2.java
+++ b/src/main/java/org/alfresco/repo/content/transform/AbstractContentTransformer2.java
@@ -239,7 +239,7 @@ public abstract class AbstractContentTransformer2 extends AbstractContentTransfo
             {
                 if (transformerDebug.isEnabled())
                 {
-                    transformerDebug.pushTransform(this, reader.getContentUrl(), sourceMimetype,
+                    ((LegacyTransformerDebug)transformerDebug).pushTransform(this, reader.getContentUrl(), sourceMimetype,
                             targetMimetype, reader.getSize(), options);
                 }
                 
@@ -441,7 +441,7 @@ public abstract class AbstractContentTransformer2 extends AbstractContentTransfo
 
             if (!transformerConfig.strictMimetypeCheck(sourceMimetype, differentType))
             {
-                String fileName = transformerDebug.getFileName(options, true, 0);
+                String fileName = ((LegacyTransformerDebug)transformerDebug).getFileName(options, true, 0);
                 String readerSourceMimetype = reader.getMimetype();
                 String message = "Transformation of ("+fileName+
                     ") has not taken place because the declared mimetype ("+
@@ -536,7 +536,7 @@ public abstract class AbstractContentTransformer2 extends AbstractContentTransfo
     /**
      * Gets the <code>ExecutorService</code> to be used for timeout-aware extraction.
      * <p>
-     * If no <code>ExecutorService</code> has been defined a default of <code>Executors.newCachedThreadPool()</code> is used during {@link AbstractMappingMetadataExtracter#init()}.
+     * If no <code>ExecutorService</code> has been defined a default of <code>Executors.newCachedThreadPool()</code> is used during {@link AbstractMappingMetadataExtracter}.
      * 
      * @return the defined or default <code>ExecutorService</code>
      */

--- a/src/main/java/org/alfresco/repo/content/transform/AbstractContentTransformerLimits.java
+++ b/src/main/java/org/alfresco/repo/content/transform/AbstractContentTransformerLimits.java
@@ -144,7 +144,7 @@ public abstract class AbstractContentTransformerLimits extends ContentTransforme
             sizeOkay = maxSourceSizeKBytes < 0 || (maxSourceSizeKBytes > 0 && sourceSize <= maxSourceSizeKBytes*1024);
             if (!sizeOkay && transformerDebug.isEnabled())
             {
-                transformerDebug.unavailableTransformer(this, sourceMimetype, targetMimetype, maxSourceSizeKBytes);
+                ((LegacyTransformerDebug)transformerDebug).unavailableTransformer(this, sourceMimetype, targetMimetype, maxSourceSizeKBytes);
             }
         }
         return sizeOkay;

--- a/src/main/java/org/alfresco/repo/content/transform/AdminUiTransformerDebug.java
+++ b/src/main/java/org/alfresco/repo/content/transform/AdminUiTransformerDebug.java
@@ -241,7 +241,7 @@ public class AdminUiTransformerDebug extends TransformerDebug implements Applica
 
     /**
      * Removes the final "Finished in..." message from a StringBuilder
-     * @param sb
+     * @param sb which contains the debug message.
      */
     void stripFinishedLine(StringBuilder sb)
     {
@@ -259,6 +259,7 @@ public class AdminUiTransformerDebug extends TransformerDebug implements Applica
 
     /**
      * Strips the leading number in a reference
+     * @param sb which contains the debug message.
      */
     String stripLeadingNumber(StringBuilder sb)
     {
@@ -339,18 +340,9 @@ public class AdminUiTransformerDebug extends TransformerDebug implements Applica
         final URL result;
 
         URL url = this.getClass().getClassLoader().getResource("quick/quick." + extension);
-        if (url == null)
-        {
-            result = null;
-        }
-        else
-        {
-            // Note that this URL may point to a file on the filesystem or to an entry in a jar file.
-            // The handling should be the same either way.
-            result = url;
-        }
-
-        return result;
+        // Note that this URL may point to a file on the filesystem or to an entry in a jar file.
+        // The handling should be the same either way.
+        return url == null ? null : url;
     }
 
     @Deprecated

--- a/src/main/java/org/alfresco/repo/content/transform/AdminUiTransformerDebug.java
+++ b/src/main/java/org/alfresco/repo/content/transform/AdminUiTransformerDebug.java
@@ -1,0 +1,476 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.content.transform;
+
+import org.alfresco.model.ContentModel;
+import org.alfresco.repo.content.filestore.FileContentWriter;
+import org.alfresco.repo.model.Repository;
+import org.alfresco.repo.rendition2.SynchronousTransformClient;
+import org.alfresco.repo.transaction.RetryingTransactionHelper;
+import org.alfresco.service.cmr.repository.ContentReader;
+import org.alfresco.service.cmr.repository.ContentService;
+import org.alfresco.service.cmr.repository.ContentWriter;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.namespace.NamespaceService;
+import org.alfresco.service.namespace.QName;
+import org.alfresco.service.transaction.TransactionService;
+import org.alfresco.util.PropertyCheck;
+import org.alfresco.util.TempFileProvider;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+import java.io.File;
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Provides methods to support the Admin UI Test Transform actions.
+ *
+ * @author adavis
+ */
+public class AdminUiTransformerDebug extends TransformerDebug implements ApplicationContextAware
+{
+    protected LocalTransformServiceRegistry localTransformServiceRegistryImpl;
+    private ApplicationContext applicationContext;
+    private ContentService contentService;
+    private SynchronousTransformClient synchronousTransformClient;
+    private Repository repositoryHelper;
+    private TransactionService transactionService;
+
+    public void setLocalTransformServiceRegistryImpl(LocalTransformServiceRegistry localTransformServiceRegistryImpl)
+    {
+        this.localTransformServiceRegistryImpl = localTransformServiceRegistryImpl;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException
+    {
+        this.applicationContext = applicationContext;
+    }
+
+    private ContentService getContentService()
+    {
+        if (contentService == null)
+        {
+            contentService = (ContentService) applicationContext.getBean("contentService");
+        }
+        return contentService;
+    }
+
+    public void setContentService(ContentService contentService)
+    {
+        this.contentService = contentService;
+    }
+
+    private SynchronousTransformClient getSynchronousTransformClient()
+    {
+        if (synchronousTransformClient == null)
+        {
+            synchronousTransformClient = (SynchronousTransformClient) applicationContext.getBean("legacySynchronousTransformClient");
+        }
+        return synchronousTransformClient;
+    }
+
+    public void setSynchronousTransformClient(SynchronousTransformClient transformClient)
+    {
+        this.synchronousTransformClient = transformClient;
+    }
+
+    public Repository getRepositoryHelper()
+    {
+        if (repositoryHelper == null)
+        {
+            repositoryHelper = (Repository) applicationContext.getBean("repositoryHelper");
+        }
+        return repositoryHelper;
+    }
+
+    public void setRepositoryHelper(Repository repositoryHelper)
+    {
+        this.repositoryHelper = repositoryHelper;
+    }
+
+    public TransactionService getTransactionService()
+    {
+        if (transactionService == null)
+        {
+            transactionService = (TransactionService) applicationContext.getBean("transactionService");
+        }
+        return transactionService;
+    }
+
+    public void setTransactionService(TransactionService transactionService)
+    {
+        this.transactionService = transactionService;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception
+    {
+        super.afterPropertiesSet();
+        PropertyCheck.mandatory(this, "localTransformServiceRegistryImpl", localTransformServiceRegistryImpl);
+    }
+
+    /**
+     * Returns a String and /or debug that provides a list of supported transformations
+     * sorted by source and target mimetype extension. Used in the Test Transforms Admin UI.
+     * @param sourceExtension restricts the list to one source extension. Unrestricted if null.
+     * @param targetExtension restricts the list to one target extension. Unrestricted if null.
+     * @param toString indicates that a String value should be returned in addition to any debug.
+     * @param format42 ignored
+     * @param onlyNonDeterministic ignored
+     * @param renditionName ignored
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    public String transformationsByExtension(String sourceExtension, String targetExtension, boolean toString,
+                                             boolean format42, boolean onlyNonDeterministic, String renditionName)
+    {
+        // Do not generate this type of debug if already generating other debug to a StringBuilder
+        // (for example a test transform).
+        if (getStringBuilder() != null)
+        {
+            return null;
+        }
+
+        Collection<String> sourceMimetypes = format42 || sourceExtension != null
+                ? getSourceMimetypes(sourceExtension)
+                : mimetypeService.getMimetypes();
+        Collection<String> targetMimetypes = format42 || targetExtension != null
+                ? getTargetMimetypes(sourceExtension, targetExtension, sourceMimetypes)
+                : mimetypeService.getMimetypes();
+
+        StringBuilder sb = null;
+        try
+        {
+            if (toString)
+            {
+                sb = new StringBuilder();
+                setStringBuilder(sb);
+            }
+            pushMisc();
+            for (String sourceMimetype: sourceMimetypes)
+            {
+                for (String targetMimetype: targetMimetypes)
+                {
+                    // Log the transformers
+                    LocalTransform localTransform = localTransformServiceRegistryImpl == null
+                            ? null
+                            : localTransformServiceRegistryImpl.getLocalTransform(sourceMimetype,
+                            -1, targetMimetype, Collections.emptyMap(), null);
+                    if (localTransform != null)
+                    {
+                        try
+                        {
+                            pushMisc();
+                            int transformerCount = 0;
+                            if (localTransform != null)
+                            {
+                                long maxSourceSizeKBytes = localTransformServiceRegistryImpl.findMaxSize(sourceMimetype,
+                                        targetMimetype, Collections.emptyMap(), null);
+                                String transformName = localTransform instanceof AbstractLocalTransform
+                                        ? "Local:" + ((AbstractLocalTransform) localTransform).getName()
+                                        : "";
+                                activeTransformer(sourceMimetype, targetMimetype, transformerCount, "  [0]",
+                                        transformName, maxSourceSizeKBytes, transformerCount++ == 0);
+                            }
+                        }
+                        finally
+                        {
+                            popMisc();
+                        }
+                    }
+                }
+            }
+        }
+        finally
+        {
+            popMisc();
+            setStringBuilder(null);
+        }
+        stripFinishedLine(sb);
+        return stripLeadingNumber(sb);
+    }
+
+    protected void activeTransformer(String sourceMimetype, String targetMimetype, int transformerCount,
+                                     String priority, String transformName, long maxSourceSizeKBytes,
+                                     boolean firstTransformer)
+    {
+        String mimetypes = firstTransformer
+                ? getMimetypeExt(sourceMimetype)+getMimetypeExt(targetMimetype)
+                : spaces(10);
+        char c = (char)('a'+transformerCount);
+        log(mimetypes+
+                "  "+c+") " + priority + ' '+transformName+' '+
+                fileSize((maxSourceSizeKBytes > 0) ? maxSourceSizeKBytes*1024 : maxSourceSizeKBytes)+
+                (maxSourceSizeKBytes == 0 ? " disabled" : ""));
+    }
+
+    /**
+     * Removes the final "Finished in..." message from a StringBuilder
+     * @param sb
+     */
+    void stripFinishedLine(StringBuilder sb)
+    {
+        if (sb != null)
+        {
+            int i = sb.lastIndexOf(FINISHED_IN);
+            if (i != -1)
+            {
+                sb.setLength(i);
+                i = sb.lastIndexOf("\n", i);
+                sb.setLength(i != -1 ? i : 0);
+            }
+        }
+    }
+
+    /**
+     * Strips the leading number in a reference
+     */
+    String stripLeadingNumber(StringBuilder sb)
+    {
+        return sb == null
+                ? null
+                : Pattern.compile("^\\d+\\.", Pattern.MULTILINE).matcher(sb).replaceAll("");
+    }
+
+    /**
+     * Returns a collection of mimetypes ordered by extension, but unlike the version in MimetypeService
+     * throws an exception if the sourceExtension is supplied but does not match a mimetype.
+     * @param sourceExtension to restrict the collection to one entry
+     * @throws IllegalArgumentException if there is no match. The message indicates this.
+     */
+    public Collection<String> getSourceMimetypes(String sourceExtension)
+    {
+        Collection<String> sourceMimetypes = mimetypeService.getMimetypes(sourceExtension);
+        if (sourceMimetypes.isEmpty())
+        {
+            throw new IllegalArgumentException("Unknown source extension "+sourceExtension);
+        }
+        return sourceMimetypes;
+    }
+
+    /**
+     * Identical to getSourceMimetypes for the target, but avoids doing the look up if the sourceExtension
+     * is the same as the tragetExtension, so will have the same result.
+     * @param sourceExtension used to restrict the sourceMimetypes
+     * @param targetExtension to restrict the collection to one entry
+     * @param sourceMimetypes that match the sourceExtension
+     * @throws IllegalArgumentException if there is no match. The message indicates this.
+     */
+    public Collection<String> getTargetMimetypes(String sourceExtension, String targetExtension,
+                                                 Collection<String> sourceMimetypes)
+    {
+        Collection<String> targetMimetypes =
+                (targetExtension == null && sourceExtension == null) ||
+                        (targetExtension != null && targetExtension.equals(sourceExtension))
+                        ? sourceMimetypes
+                        : mimetypeService.getMimetypes(targetExtension);
+        if (targetMimetypes.isEmpty())
+        {
+            throw new IllegalArgumentException("Unknown target extension "+targetExtension);
+        }
+        return targetMimetypes;
+    }
+
+
+    public String testTransform(String sourceExtension, String targetExtension, String renditionName)
+    {
+        return new TestTransform().run(sourceExtension, targetExtension, renditionName);
+    }
+
+    public String[] getTestFileExtensionsAndMimetypes()
+    {
+        List<String> sourceExtensions = new ArrayList<String>();
+        Collection<String> sourceMimetypes = mimetypeService.getMimetypes(null);
+        for (String sourceMimetype: sourceMimetypes)
+        {
+            String sourceExtension = mimetypeService.getExtension(sourceMimetype);
+            if (loadQuickTestFile(sourceExtension) != null)
+            {
+                sourceExtensions.add(sourceExtension+" - "+sourceMimetype);
+            }
+        }
+
+        return sourceExtensions.toArray(new String[sourceExtensions.size()]);
+    }
+
+    /**
+     * Load one of the "The quick brown fox" files from the classpath.
+     * @param extension required, eg <b>txt</b> for the file quick.txt
+     * @return Returns a test resource loaded from the classpath or <tt>null</tt> if
+     *      no resource could be found.
+     */
+    private URL loadQuickTestFile(String extension)
+    {
+        final URL result;
+
+        URL url = this.getClass().getClassLoader().getResource("quick/quick." + extension);
+        if (url == null)
+        {
+            result = null;
+        }
+        else
+        {
+            // Note that this URL may point to a file on the filesystem or to an entry in a jar file.
+            // The handling should be the same either way.
+            result = url;
+        }
+
+        return result;
+    }
+
+    @Deprecated
+    private class TestTransform
+    {
+        protected LinkedList<NodeRef> nodesToDeleteAfterTest = new LinkedList<NodeRef>();
+
+        String run(String sourceExtension, String targetExtension, String renditionName)
+        {
+            RetryingTransactionHelper.RetryingTransactionCallback<String> makeNodeCallback = new RetryingTransactionHelper.RetryingTransactionCallback<String>()
+            {
+                public String execute() throws Throwable
+                {
+                    return runWithinTransaction(sourceExtension, targetExtension);
+                }
+            };
+            return getTransactionService().getRetryingTransactionHelper().doInTransaction(makeNodeCallback, false, true);
+        }
+
+        private String runWithinTransaction(String sourceExtension, String targetExtension)
+        {
+            String targetMimetype = getMimetype(targetExtension, false);
+            String sourceMimetype = getMimetype(sourceExtension, true);
+            File tempFile = TempFileProvider.createTempFile(
+                    "TestTransform_" + sourceExtension + "_", "." + targetExtension);
+            ContentWriter writer = new FileContentWriter(tempFile);
+            writer.setMimetype(targetMimetype);
+
+            NodeRef sourceNodeRef = null;
+            StringBuilder sb = new StringBuilder();
+            try
+            {
+                setStringBuilder(sb);
+                sourceNodeRef = createSourceNode(sourceExtension, sourceMimetype);
+                ContentReader reader = contentService.getReader(sourceNodeRef, ContentModel.PROP_CONTENT);
+                SynchronousTransformClient synchronousTransformClient = getSynchronousTransformClient();
+                Map<String, String> actualOptions = Collections.emptyMap();
+                synchronousTransformClient.transform(reader, writer, actualOptions, null, sourceNodeRef);
+            }
+            catch (Exception e)
+            {
+                logger.debug("Unexpected test transform error", e);
+            }
+            finally
+            {
+                setStringBuilder(null);
+                deleteSourceNode(sourceNodeRef);
+            }
+            return sb.toString();
+        }
+
+        private String getMimetype(String extension, boolean isSource)
+        {
+            String mimetype = null;
+            if (extension != null)
+            {
+                Iterator<String> iterator = mimetypeService.getMimetypes(extension).iterator();
+                if (iterator.hasNext())
+                {
+                    mimetype = iterator.next();
+                }
+            }
+            if (mimetype == null)
+            {
+                throw new IllegalArgumentException("Unknown "+(isSource ? "source" : "target")+" extension: "+extension);
+            }
+            return mimetype;
+        }
+
+        public NodeRef createSourceNode(String extension, String sourceMimetype)
+        {
+            // Create a content node which will serve as test data for our transformations.
+            RetryingTransactionHelper.RetryingTransactionCallback<NodeRef> makeNodeCallback = new RetryingTransactionHelper.RetryingTransactionCallback<NodeRef>()
+            {
+                public NodeRef execute() throws Throwable
+                {
+                    // Create a source node loaded with a quick file.
+                    URL url = loadQuickTestFile(extension);
+                    URI uri = url.toURI();
+                    File sourceFile = new File(uri);
+
+                    final NodeRef companyHome = getRepositoryHelper().getCompanyHome();
+
+                    Map<QName, Serializable> props = new HashMap<QName, Serializable>();
+                    String localName = "TestTransform." + extension;
+                    props.put(ContentModel.PROP_NAME, localName);
+                    NodeRef node = nodeService.createNode(
+                            companyHome,
+                            ContentModel.ASSOC_CONTAINS,
+                            QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, localName),
+                            ContentModel.TYPE_CONTENT,
+                            props).getChildRef();
+
+                    ContentWriter writer = getContentService().getWriter(node, ContentModel.PROP_CONTENT, true);
+                    writer.setMimetype(sourceMimetype);
+                    writer.setEncoding("UTF-8");
+                    writer.putContent(sourceFile);
+
+                    return node;
+                }
+            };
+            NodeRef contentNodeRef = getTransactionService().getRetryingTransactionHelper().doInTransaction(makeNodeCallback);
+            this.nodesToDeleteAfterTest.add(contentNodeRef);
+            return contentNodeRef;
+        }
+
+        public void deleteSourceNode(NodeRef sourceNodeRef)
+        {
+            if (sourceNodeRef != null)
+            {
+                getTransactionService().getRetryingTransactionHelper().doInTransaction(
+                        (RetryingTransactionHelper.RetryingTransactionCallback<Void>) () ->
+                        {
+                            if (nodeService.exists(sourceNodeRef))
+                            {
+                                nodeService.deleteNode(sourceNodeRef);
+                            }
+                            return null;
+                        });
+            }
+        }
+    }
+}

--- a/src/main/java/org/alfresco/repo/content/transform/FailoverContentTransformer.java
+++ b/src/main/java/org/alfresco/repo/content/transform/FailoverContentTransformer.java
@@ -137,7 +137,7 @@ public class FailoverContentTransformer extends AbstractContentTransformer2 impl
                 {
                     try
                     {
-                        transformerDebug.pushIsTransformableSize(this);
+                        ((LegacyTransformerDebug)transformerDebug).pushIsTransformableSize(this);
                         if (ct.isTransformableSize(sourceMimetype, sourceSize, targetMimetype, options))
                         {
                             result = true;
@@ -146,7 +146,7 @@ public class FailoverContentTransformer extends AbstractContentTransformer2 impl
                     }
                     finally
                     {
-                        transformerDebug.popIsTransformableSize();
+                        ((LegacyTransformerDebug)transformerDebug).popIsTransformableSize();
                     }
                 }
             }

--- a/src/main/java/org/alfresco/repo/content/transform/LegacyTransformerDebug.java
+++ b/src/main/java/org/alfresco/repo/content/transform/LegacyTransformerDebug.java
@@ -212,7 +212,6 @@ public class LegacyTransformerDebug extends AdminUiTransformerDebug
             {
                 String name = getName(trans);
                 int padName = longestNameLength - name.length() + 1;
-                // TODO replace with call to RenditionService2 or leave as a deprecated method using ContentService.
                 TransformationOptions options = new TransformationOptions();
                 options.setUse(frame.renditionName);
                 options.setSourceNodeRef(frame.sourceNodeRef);
@@ -241,11 +240,10 @@ public class LegacyTransformerDebug extends AdminUiTransformerDebug
     private String gePriority(ContentTransformer transformer, String sourceMimetype, String targetMimetype)
     {
         String priority =
-                '[' +
-                        (isComponentTransformer(transformer)
-                                ? "---"
-                                : Integer.toString(transformerConfig.getPriority(transformer, sourceMimetype, targetMimetype))) +
-                        ']';
+            '[' + (isComponentTransformer(transformer)
+            ? "---"
+            : Integer.toString(transformerConfig.getPriority(transformer, sourceMimetype, targetMimetype))) +
+            ']';
         priority = spaces(5-priority.length())+priority;
         return priority;
     }

--- a/src/main/java/org/alfresco/repo/content/transform/LegacyTransformerDebug.java
+++ b/src/main/java/org/alfresco/repo/content/transform/LegacyTransformerDebug.java
@@ -1,0 +1,640 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.content.transform;
+
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.TransformationOptions;
+import org.alfresco.util.PropertyCheck;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * Debugs Legacy transformers selection and activity. Will be removed when Legacy transforms are removed.
+ *
+ * @author Alan Davis
+ */
+@Deprecated
+public class LegacyTransformerDebug extends AdminUiTransformerDebug
+{
+    private ContentTransformerRegistry transformerRegistry;
+    private TransformerConfig transformerConfig;
+
+    public void setTransformerRegistry(ContentTransformerRegistry transformerRegistry)
+    {
+        this.transformerRegistry = transformerRegistry;
+    }
+
+    public void setTransformerConfig(TransformerConfig transformerConfig)
+    {
+        this.transformerConfig = transformerConfig;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception
+    {
+        super.afterPropertiesSet();
+        PropertyCheck.mandatory(this, "transformerRegistry", transformerRegistry);
+        PropertyCheck.mandatory(this, "transformerConfig", transformerConfig);
+    }
+
+    @Deprecated
+    public void pushAvailable(String fromUrl, String sourceMimetype, String targetMimetype,
+                              TransformationOptions options)
+    {
+        String renditionName = options == null ? null : options.getUse();
+        NodeRef sourceNodeRef = options == null ? null : options.getSourceNodeRef();
+        pushAvailable(fromUrl, sourceMimetype, targetMimetype, renditionName, sourceNodeRef);
+    }
+
+    /**
+     * Called prior to working out what transformers are available.
+     */
+    @Deprecated
+    public void pushAvailable(String fromUrl, String sourceMimetype, String targetMimetype,
+                              String renditionName, NodeRef sourceNodeRef)
+    {
+        if (isEnabled())
+        {
+            push(null, fromUrl, sourceMimetype, targetMimetype, -1, renditionName,
+                    sourceNodeRef, Call.AVAILABLE);
+        }
+    }
+
+    /**
+     * Called when a transformer has been ignored because of a blacklist entry.
+     */
+    @Deprecated
+    public void blacklistTransform(ContentTransformer transformer, String sourceMimetype,
+                                   String targetMimetype, TransformationOptions options)
+    {
+        log("Blacklist "+getName(transformer)+" "+getMimetypeExt(sourceMimetype)+getMimetypeExt(targetMimetype));
+    }
+
+
+    @Deprecated
+    public void pushTransform(ContentTransformer transformer, String fromUrl, String sourceMimetype,
+                              String targetMimetype, long sourceSize, TransformationOptions options)
+    {
+        String renditionName = options == null ? null : options.getUse();
+        NodeRef sourceNodeRef = options == null ? null : options.getSourceNodeRef();
+        pushTransform(transformer, fromUrl, sourceMimetype, targetMimetype, sourceSize, renditionName, sourceNodeRef);
+    }
+
+    /**
+     * Called prior to performing a transform.
+     */
+    @Deprecated
+    public void pushTransform(ContentTransformer transformer, String fromUrl, String sourceMimetype,
+                              String targetMimetype, long sourceSize, String renditionName, NodeRef sourceNodeRef)
+    {
+        if (isEnabled())
+        {
+            push(getName(transformer), fromUrl, sourceMimetype, targetMimetype, sourceSize,
+                    renditionName, sourceNodeRef, Call.TRANSFORM);
+        }
+    }
+
+    /**
+     * Called prior to calling a nested isTransformable.
+     */
+    @Deprecated
+    public void pushIsTransformableSize(ContentTransformer transformer)
+    {
+        if (isEnabled())
+        {
+            ThreadInfo.getIsTransformableStack().push(getName(transformer));
+        }
+    }
+
+    /**
+     * Called to identify a transformer that cannot be used during working out
+     * available transformers.
+     */
+    @Deprecated
+    public void unavailableTransformer(ContentTransformer transformer, String sourceMimetype, String targetMimetype, long maxSourceSizeKBytes)
+    {
+        if (isEnabled())
+        {
+            Deque<Frame> ourStack = ThreadInfo.getStack();
+            Frame frame = ourStack.peek();
+
+            if (frame != null)
+            {
+                Deque<String> isTransformableStack = ThreadInfo.getIsTransformableStack();
+                String name = (!isTransformableStack.isEmpty())
+                        ? isTransformableStack.getFirst()
+                        : getName(transformer);
+                boolean debug = (maxSourceSizeKBytes != 0);
+                if (frame.unavailableTransformers == null)
+                {
+                    frame.unavailableTransformers = new TreeSet<UnavailableTransformer>();
+                }
+                String priority = gePriority(transformer, sourceMimetype, targetMimetype);
+                frame.unavailableTransformers.add(new UnavailableTransformer(name, priority, maxSourceSizeKBytes, debug));
+            }
+        }
+    }
+
+    @Deprecated
+    public void availableTransformers(List<ContentTransformer> transformers, long sourceSize,
+                                      TransformationOptions options, String calledFrom)
+    {
+        String renditionName = options == null ? null : options.getUse();
+        NodeRef sourceNodeRef = options == null ? null : options.getSourceNodeRef();
+        availableTransformers(transformers, sourceSize, renditionName, sourceNodeRef, calledFrom);
+    }
+
+    /**
+     * Called once all available transformers have been identified.
+     */
+    @Deprecated
+    public void availableTransformers(List<ContentTransformer> transformers, long sourceSize,
+                                      String renditionName, NodeRef sourceNodeRef, String calledFrom)
+    {
+        if (isEnabled())
+        {
+            Deque<Frame> ourStack = ThreadInfo.getStack();
+            Frame frame = ourStack.peek();
+            boolean firstLevel = ourStack.size() == 1;
+
+            // Override setDebugOutput(false) to allow debug when there are transformers but they are all unavailable
+            // Note once turned on we don't turn it off again.
+            if (transformers.size() == 0)
+            {
+                frame.setFailureReason(NO_TRANSFORMERS);
+                if (frame.unavailableTransformers != null &&
+                        frame.unavailableTransformers.size() != 0)
+                {
+                    ThreadInfo.setDebugOutput(true);
+                }
+            }
+            frame.setSourceSize(sourceSize);
+
+            // Log the basic info about this transformation
+            logBasicDetails(frame, sourceSize, renditionName,
+                    calledFrom + ((transformers.size() == 0) ? " NO transformers" : ""), firstLevel);
+
+            // Report available and unavailable transformers
+            char c = 'a';
+            int longestNameLength = getLongestTransformerNameLength(transformers, frame);
+            for (ContentTransformer trans : transformers)
+            {
+                String name = getName(trans);
+                int padName = longestNameLength - name.length() + 1;
+                // TODO replace with call to RenditionService2 or leave as a deprecated method using ContentService.
+                TransformationOptions options = new TransformationOptions();
+                options.setUse(frame.renditionName);
+                options.setSourceNodeRef(frame.sourceNodeRef);
+                long maxSourceSizeKBytes = trans.getMaxSourceSizeKBytes(frame.sourceMimetype, frame.targetMimetype, options);
+                String size = maxSourceSizeKBytes > 0 ? "< "+fileSize(maxSourceSizeKBytes*1024) : "";
+                int padSize = 10 - size.length();
+                String priority = gePriority(trans, frame.sourceMimetype, frame.targetMimetype);
+                log((c == 'a' ? "**" : "  ") + (c++) + ") " + priority + ' ' + name + spaces(padName) +
+                        size + spaces(padSize) + ms(trans.getTransformationTime(frame.sourceMimetype, frame.targetMimetype)));
+            }
+            if (frame.unavailableTransformers != null)
+            {
+                for (UnavailableTransformer unavailable: frame.unavailableTransformers)
+                {
+                    int pad = longestNameLength - unavailable.name.length();
+                    String reason = "> "+fileSize(unavailable.maxSourceSizeKBytes*1024);
+                    if (unavailable.debug || logger.isTraceEnabled())
+                    {
+                        log("--" + (c++) + ") " + unavailable.priority + ' ' + unavailable.name + spaces(pad+1) + reason, unavailable.debug);
+                    }
+                }
+            }
+        }
+    }
+
+    private String gePriority(ContentTransformer transformer, String sourceMimetype, String targetMimetype)
+    {
+        String priority =
+                '[' +
+                        (isComponentTransformer(transformer)
+                                ? "---"
+                                : Integer.toString(transformerConfig.getPriority(transformer, sourceMimetype, targetMimetype))) +
+                        ']';
+        priority = spaces(5-priority.length())+priority;
+        return priority;
+    }
+
+    @Deprecated
+    public void inactiveTransformer(ContentTransformer transformer)
+    {
+        log(getName(transformer)+' '+ms(transformer.getTransformationTime(null, null))+" INACTIVE");
+    }
+
+    @Deprecated
+    public void activeTransformer(int mimetypePairCount, ContentTransformer transformer, String sourceMimetype,
+                                  String targetMimetype, long maxSourceSizeKBytes, boolean firstMimetypePair)
+    {
+        if (firstMimetypePair)
+        {
+            log(getName(transformer)+' '+ms(transformer.getTransformationTime(sourceMimetype, targetMimetype)));
+        }
+        String i = Integer.toString(mimetypePairCount);
+        String priority = gePriority(transformer, sourceMimetype, targetMimetype);
+        log(spaces(5-i.length())+mimetypePairCount+") "+getMimetypeExt(sourceMimetype)+getMimetypeExt(targetMimetype)+
+                priority +
+                ' '+fileSize((maxSourceSizeKBytes > 0) ? maxSourceSizeKBytes*1024 : maxSourceSizeKBytes)+
+                (maxSourceSizeKBytes == 0 ? " disabled" : ""));
+    }
+
+    @Deprecated
+    public void activeTransformer(String sourceMimetype, String targetMimetype,
+                                  int transformerCount, ContentTransformer transformer, long maxSourceSizeKBytes,
+                                  boolean firstTransformer)
+    {
+        String priority = gePriority(transformer, sourceMimetype, targetMimetype);
+        activeTransformer(sourceMimetype, targetMimetype, transformerCount, priority, getName(transformer),
+                maxSourceSizeKBytes, firstTransformer);
+    }
+
+    private int getLongestTransformerNameLength(List<ContentTransformer> transformers,
+                                                Frame frame)
+    {
+        int longestNameLength = 0;
+        for (ContentTransformer trans : transformers)
+        {
+            int length = getName(trans).length();
+            if (longestNameLength < length)
+                longestNameLength = length;
+        }
+        if (frame != null && frame.unavailableTransformers != null)
+        {
+            for (UnavailableTransformer unavailable: frame.unavailableTransformers)
+            {
+                int length = unavailable.name.length();
+                if (longestNameLength < length)
+                    longestNameLength = length;
+            }
+        }
+        return longestNameLength;
+    }
+
+    /**
+     * Called after working out what transformers are available and any
+     * resulting transform has been called.
+     */
+    public void popAvailable()
+    {
+        if (isEnabled())
+        {
+            pop(Call.AVAILABLE, false, false);
+        }
+    }
+
+
+    /**
+     * Called after returning from a nested isTransformable.
+     */
+    public void popIsTransformableSize()
+    {
+        if (isEnabled())
+        {
+            ThreadInfo.getIsTransformableStack().pop();
+        }
+    }
+
+    /**
+     * Returns a String and /or debug that provides a list of supported transformations for each
+     * transformer.
+     * @param transformerName restricts the list to one transformer. Unrestricted if null.
+     * @param toString indicates that a String value should be returned in addition to any debug.
+     * @param format42 indicates the old 4.1.4 format should be used which did not order the transformers
+     *        and only included top level transformers.
+     * @param renditionName to which the transformation will be put (such as "Index", "Preview", null).
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
+    public String transformationsByTransformer(String transformerName, boolean toString, boolean format42, String renditionName)
+    {
+        // Do not generate this type of debug if already generating other debug to a StringBuilder
+        // (for example a test transform).
+        if (getStringBuilder() != null)
+        {
+            return null;
+        }
+
+        Collection<ContentTransformer> transformers = format42 || transformerName != null
+                ? sortTransformersByName(transformerName)
+                : transformerRegistry.getTransformers();
+        Collection<String> sourceMimetypes = format42
+                ? getSourceMimetypes(null)
+                : mimetypeService.getMimetypes();
+        Collection<String> targetMimetypes = format42
+                ? sourceMimetypes
+                : mimetypeService.getMimetypes();
+
+        TransformationOptions options = new TransformationOptions();
+        options.setUse(renditionName);
+        StringBuilder sb = null;
+        try
+        {
+            if (toString)
+            {
+                sb = new StringBuilder();
+                setStringBuilder(sb);
+            }
+            pushMisc();
+            for (ContentTransformer transformer: transformers)
+            {
+                try
+                {
+                    pushMisc();
+                    int mimetypePairCount = 0;
+                    boolean first = true;
+                    for (String sourceMimetype: sourceMimetypes)
+                    {
+                        for (String targetMimetype: targetMimetypes)
+                        {
+                            if (transformer.isTransformable(sourceMimetype, -1, targetMimetype, options))
+                            {
+                                long maxSourceSizeKBytes = transformer.getMaxSourceSizeKBytes(
+                                        sourceMimetype, targetMimetype, options);
+                                activeTransformer(++mimetypePairCount, transformer,
+                                        sourceMimetype, targetMimetype, maxSourceSizeKBytes, first);
+                                first = false;
+                            }
+                        }
+                    }
+                    if (first)
+                    {
+                        inactiveTransformer(transformer);
+                    }
+                }
+                finally
+                {
+                    popMisc();
+                }
+            }
+        }
+        finally
+        {
+            popMisc();
+            setStringBuilder(null);
+        }
+        stripFinishedLine(sb);
+        return stripLeadingNumber(sb);
+    }
+
+    /**
+     * Returns a String and /or debug that provides a list of supported transformations
+     * sorted by source and target mimetype extension.
+     * @param sourceExtension restricts the list to one source extension. Unrestricted if null.
+     * @param targetExtension restricts the list to one target extension. Unrestricted if null.
+     * @param toString indicates that a String value should be returned in addition to any debug.
+     * @param format42 indicates the new 4.2 rather than older 4.1.4 format should be used.
+     *        The 4.1.4 format did not order the transformers or mimetypes and only included top
+     *        level transformers.
+     * @param onlyNonDeterministic if true only report transformations where there is more than
+     *        one transformer available with the same priority.
+     * @param renditionName to which the transformation will be put (such as "Index", "Preview", null).
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
+    @Override
+    public String transformationsByExtension(String sourceExtension, String targetExtension, boolean toString,
+                                             boolean format42, boolean onlyNonDeterministic, String renditionName)
+    {
+        // Do not generate this type of debug if already generating other debug to a StringBuilder
+        // (for example a test transform).
+        if (getStringBuilder() != null)
+        {
+            return null;
+        }
+
+        Collection<ContentTransformer> transformers = format42 && !onlyNonDeterministic
+                ? sortTransformersByName(null)
+                : transformerRegistry.getTransformers();
+        Collection<String> sourceMimetypes = format42 || sourceExtension != null
+                ? getSourceMimetypes(sourceExtension)
+                : mimetypeService.getMimetypes();
+        Collection<String> targetMimetypes = format42 || targetExtension != null
+                ? getTargetMimetypes(sourceExtension, targetExtension, sourceMimetypes)
+                : mimetypeService.getMimetypes();
+
+        TransformationOptions options = new TransformationOptions();
+        options.setUse(renditionName);
+        StringBuilder sb = null;
+        try
+        {
+            if (toString)
+            {
+                sb = new StringBuilder();
+                setStringBuilder(sb);
+            }
+            pushMisc();
+            for (String sourceMimetype: sourceMimetypes)
+            {
+                for (String targetMimetype: targetMimetypes)
+                {
+                    // Find available transformers
+                    List<ContentTransformer> availableTransformer = new ArrayList<ContentTransformer>();
+                    for (ContentTransformer transformer: transformers)
+                    {
+                        if (transformer.isTransformable(sourceMimetype, -1, targetMimetype, options))
+                        {
+                            availableTransformer.add(transformer);
+                        }
+                    }
+
+                    // Sort by priority
+                    final String currSourceMimetype = sourceExtension;
+                    final String currTargetMimetype = targetExtension;
+                    Collections.sort(availableTransformer, new Comparator<ContentTransformer>()
+                    {
+                        @Override
+                        public int compare(ContentTransformer transformer1, ContentTransformer transformer2)
+                        {
+                            return transformerConfig.getPriority(transformer1, currSourceMimetype, currTargetMimetype) -
+                                    transformerConfig.getPriority(transformer2, currSourceMimetype, currTargetMimetype);
+                        }
+                    });
+
+                    // Do we need to produce any output?
+                    int size = availableTransformer.size();
+                    int priority = size >= 2
+                            ? transformerConfig.getPriority(availableTransformer.get(0), sourceMimetype, targetMimetype)
+                            : -1;
+                    if (!onlyNonDeterministic || (size >= 2 && priority ==
+                            transformerConfig.getPriority(availableTransformer.get(1), sourceMimetype, targetMimetype)))
+                    {
+                        // Log the transformers
+                        LocalTransform localTransform = localTransformServiceRegistryImpl == null
+                                ? null
+                                : localTransformServiceRegistryImpl.getLocalTransform(sourceMimetype,
+                                -1, targetMimetype, Collections.emptyMap(), null);
+                        if (localTransform != null || size >= 1)
+                        {
+                            try
+                            {
+                                pushMisc();
+                                int transformerCount = 0;
+                                if (localTransform != null)
+                                {
+                                    long maxSourceSizeKBytes = localTransformServiceRegistryImpl.findMaxSize(sourceMimetype,
+                                            targetMimetype, Collections.emptyMap(), null);
+                                    String transformName = localTransform instanceof AbstractLocalTransform
+                                            ? "Local:" + ((AbstractLocalTransform) localTransform).getName()
+                                            : "";
+                                    activeTransformer(sourceMimetype, targetMimetype, transformerCount, "  [0]",
+                                            transformName, maxSourceSizeKBytes, transformerCount++ == 0);
+                                }
+                                for (ContentTransformer transformer: availableTransformer)
+                                {
+                                    if (!onlyNonDeterministic || transformerCount < 2 ||
+                                            priority == transformerConfig.getPriority(transformer, sourceMimetype, targetMimetype))
+                                    {
+                                        long maxSourceSizeKBytes = transformer.getMaxSourceSizeKBytes(
+                                                sourceMimetype, targetMimetype, options);
+                                        activeTransformer(sourceMimetype, targetMimetype, transformerCount,
+                                                transformer, maxSourceSizeKBytes, transformerCount++ == 0);
+                                    }
+                                }
+                            }
+                            finally
+                            {
+                                popMisc();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        finally
+        {
+            popMisc();
+            setStringBuilder(null);
+        }
+        stripFinishedLine(sb);
+        return stripLeadingNumber(sb);
+    }
+
+    private String getName(ContentTransformer transformer)
+    {
+        String name =
+                transformer instanceof ContentTransformerHelper
+                        ? ContentTransformerHelper.getSimpleName(transformer)
+                        : transformer.getClass().getSimpleName();
+
+        String type =
+                ((transformer instanceof AbstractRemoteContentTransformer &&
+                        ((AbstractRemoteContentTransformer)transformer).remoteTransformerClientConfigured()) ||
+                        (transformer instanceof ProxyContentTransformer &&
+                                ((ProxyContentTransformer)transformer).remoteTransformerClientConfigured())
+                        ? "Remote" : "")+
+                        (transformer instanceof ComplexContentTransformer
+                                ? "Complex"
+                                : transformer instanceof FailoverContentTransformer
+                                ? "Failover"
+                                : transformer instanceof ProxyContentTransformer
+                                ? (((ProxyContentTransformer)transformer).getWorker() instanceof RuntimeExecutableContentTransformerWorker)
+                                ? "Runtime"
+                                : "Proxy"
+                                : "");
+
+        boolean componentTransformer = isComponentTransformer(transformer);
+
+        StringBuilder sb = new StringBuilder("Legacy:").append(name);
+        if (componentTransformer || type.length() > 0)
+        {
+            sb.append("<<");
+            sb.append(type);
+            if (componentTransformer)
+            {
+                sb.append("Component");
+            }
+            sb.append(">>");
+        }
+
+        return sb.toString();
+    }
+
+
+    private boolean isComponentTransformer(ContentTransformer transformer)
+    {
+        return !transformerRegistry.getTransformers().contains(transformer);
+    }
+
+    @Deprecated
+    public String getFileName(TransformationOptions options, boolean firstLevel, long sourceSize)
+    {
+        NodeRef sourceNodeRef = options == null ? null : options.getSourceNodeRef();
+        return getFileName(sourceNodeRef, firstLevel, sourceSize);
+    }
+
+    /**
+     * Returns a sorted list of all transformers sorted by name.
+     * @param transformerName to restrict the collection to one entry
+     * @return a new Collection of sorted transformers
+     * @throws IllegalArgumentException if transformerName is not found.
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
+    public Collection<ContentTransformer> sortTransformersByName(String transformerName)
+    {
+        return sortTransformersByName(transformerRegistry, transformerName);
+    }
+
+    public static Collection<ContentTransformer>  sortTransformersByName(
+            ContentTransformerRegistry transformerRegistry, String transformerName)
+    {
+        Collection<ContentTransformer> transformers = (transformerName != null)
+                ? Collections.singleton(transformerRegistry.getTransformer(transformerName))
+                : transformerRegistry.getAllTransformers();
+
+        SortedMap<String, ContentTransformer> map = new TreeMap<String, ContentTransformer>();
+        for (ContentTransformer transformer: transformers)
+        {
+            String name = transformer.getName();
+            map.put(name, transformer);
+        }
+        Collection<ContentTransformer> sorted = map.values();
+        return sorted;
+    }
+
+    /**
+     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
+     */
+    @Deprecated
+    public String testTransform(final String transformerName, String sourceExtension,
+                                String targetExtension, String renditionName)
+    {
+        logger.error("The testTransform operation for a specific transformer is no longer supported. " +
+                "Request redirected to the version of this method without a transformerName.");
+        return testTransform(sourceExtension, targetExtension, renditionName);
+    }
+}

--- a/src/main/java/org/alfresco/repo/content/transform/LegacyTransformerDebug.java
+++ b/src/main/java/org/alfresco/repo/content/transform/LegacyTransformerDebug.java
@@ -606,12 +606,6 @@ public class LegacyTransformerDebug extends AdminUiTransformerDebug
     @Deprecated
     public Collection<ContentTransformer> sortTransformersByName(String transformerName)
     {
-        return sortTransformersByName(transformerRegistry, transformerName);
-    }
-
-    public static Collection<ContentTransformer>  sortTransformersByName(
-            ContentTransformerRegistry transformerRegistry, String transformerName)
-    {
         Collection<ContentTransformer> transformers = (transformerName != null)
                 ? Collections.singleton(transformerRegistry.getTransformer(transformerName))
                 : transformerRegistry.getAllTransformers();

--- a/src/main/java/org/alfresco/repo/content/transform/OOoContentTransformerHelper.java
+++ b/src/main/java/org/alfresco/repo/content/transform/OOoContentTransformerHelper.java
@@ -57,7 +57,7 @@ public abstract class OOoContentTransformerHelper extends ContentTransformerHelp
 {
     private String documentFormatsConfiguration;
     private DocumentFormatRegistry formatRegistry;
-    protected TransformerDebug transformerDebug;
+    protected LegacyTransformerDebug transformerDebug;
     private static final int JODCONVERTER_TRANSFORMATION_ERROR_CODE = 3088;
 
     protected RemoteTransformerClient remoteTransformerClient;
@@ -86,7 +86,7 @@ public abstract class OOoContentTransformerHelper extends ContentTransformerHelp
      * Helper setter of the transformer debug. 
      * @param transformerDebug TransformerDebug
      */
-    public void setTransformerDebug(TransformerDebug transformerDebug)
+    public void setTransformerDebug(LegacyTransformerDebug transformerDebug)
     {
         this.transformerDebug = transformerDebug;
     }

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerConfigDynamicTransformers.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerConfigDynamicTransformers.java
@@ -312,7 +312,7 @@ public class TransformerConfigDynamicTransformers extends TransformerPropertyNam
         
         // unregisteredBaseContentTransformer
         transformer.setMimetypeService(mimetypeService);
-        transformer.setTransformerDebug(transformerDebug);
+        transformer.setTransformerDebug((LegacyTransformerDebug)transformerDebug);
         transformer.setTransformerConfig(transformerConfig);
         transformer.setRegistry(transformerRegistry);
 

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerConfigMBean.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerConfigMBean.java
@@ -52,6 +52,7 @@ public interface TransformerConfigMBean
      * @param use or context in which the transformation will be used ("doclib",
      *        "index", "webpreview", "syncRule", "asyncRule"...) or null for the default.
      */
+    @Deprecated
     public String getTransformationsByTransformer(String transformerName, String use);
 
     /**
@@ -69,6 +70,7 @@ public interface TransformerConfigMBean
      * @param sourceExtension to be checked. If null all source mimetypes are included.
      * @param targetExtension to be checked. If null all target mimetypes are included.
      */
+    @Deprecated
     public String getTransformationStatistics(String transformerName, String sourceExtension, String targetExtension);
     
     /**
@@ -86,6 +88,7 @@ public interface TransformerConfigMBean
      * @param listAll list both default and custom values, otherwise includes
      *        only custom values.
      */
+    @Deprecated
     public String getProperties(boolean listAll);
     
     /**
@@ -93,6 +96,7 @@ public interface TransformerConfigMBean
      * @param propertyNamesAndValues
      * @return a confirmation or failure message
      */
+    @Deprecated
     public String setProperties(String propertyNamesAndValues);
     
     /**
@@ -100,6 +104,7 @@ public interface TransformerConfigMBean
      * @param propertyNames to be removed. Any values after the property name are ignored.
      * @return a confirmation or failure message
      */
+    @Deprecated
     String removeProperties(String propertyNames);
     
     /**

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerConfigMBeanImpl.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerConfigMBeanImpl.java
@@ -85,7 +85,7 @@ public class TransformerConfigMBeanImpl implements TransformerConfigMBean
     public String[] getTransformerNames()
     {
         List<String> transformerNames = new ArrayList<String>();
-        Collection<ContentTransformer> transformers = LegacyTransformerDebug.sortTransformersByName(transformerRegistry, null);
+        Collection<ContentTransformer> transformers = ((LegacyTransformerDebug)transformerDebug).sortTransformersByName(null);
         for (ContentTransformer transformer: transformers)
         {
             String name = transformer.getName();
@@ -171,7 +171,7 @@ public class TransformerConfigMBeanImpl implements TransformerConfigMBean
             sourceExtension = nullDefaultLowerParam(sourceExtension);
             targetExtension = nullDefaultLowerParam(targetExtension);
 
-            Collection<ContentTransformer> transformers = LegacyTransformerDebug.sortTransformersByName(transformerRegistry, transformerName);
+            Collection<ContentTransformer> transformers = ((LegacyTransformerDebug)transformerDebug).sortTransformersByName(transformerName);
             Collection<String> sourceMimetypes = transformerDebug.getSourceMimetypes(sourceExtension);
             Collection<String> targetMimetypes = transformerDebug.getTargetMimetypes(sourceExtension, targetExtension, sourceMimetypes);
 

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerConfigMBeanImpl.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerConfigMBeanImpl.java
@@ -45,7 +45,7 @@ public class TransformerConfigMBeanImpl implements TransformerConfigMBean
 {
     private static final String NO_TRANSFORMATIONS_TO_REPORT = "No transformations to report";
     private ContentTransformerRegistry transformerRegistry;
-    private TransformerDebug transformerDebug;
+    private AdminUiTransformerDebug transformerDebug;
     private TransformerConfig transformerConfig;
     private MimetypeService mimetypeService;
     private LogEntries transformerLog;
@@ -56,7 +56,7 @@ public class TransformerConfigMBeanImpl implements TransformerConfigMBean
         this.transformerRegistry = transformerRegistry;
     }
 
-    public void setTransformerDebug(TransformerDebug transformerDebug)
+    public void setTransformerDebug(AdminUiTransformerDebug transformerDebug)
     {
         this.transformerDebug = transformerDebug;
     }
@@ -85,7 +85,7 @@ public class TransformerConfigMBeanImpl implements TransformerConfigMBean
     public String[] getTransformerNames()
     {
         List<String> transformerNames = new ArrayList<String>();
-        Collection<ContentTransformer> transformers = transformerDebug.sortTransformersByName(null);
+        Collection<ContentTransformer> transformers = LegacyTransformerDebug.sortTransformersByName(transformerRegistry, null);
         for (ContentTransformer transformer: transformers)
         {
             String name = transformer.getName();
@@ -118,8 +118,9 @@ public class TransformerConfigMBeanImpl implements TransformerConfigMBean
             // Need to be able to generate 4.1.4ish output to compare with previous
             // releases without too much effort cutting and pasting to change the order
             return "41".equals(simpleTransformerName)
-                ? transformerDebug.transformationsByTransformer(null, true, false, use)
-                : transformerDebug.transformationsByTransformer(
+                ? ((LegacyTransformerDebug)transformerDebug).transformationsByTransformer(
+                        null, true, false, use)
+                : ((LegacyTransformerDebug)transformerDebug).transformationsByTransformer(
                         getTransformerNameParam(simpleTransformerName), true, true, use);
         }
         catch (IllegalArgumentException e)
@@ -170,7 +171,7 @@ public class TransformerConfigMBeanImpl implements TransformerConfigMBean
             sourceExtension = nullDefaultLowerParam(sourceExtension);
             targetExtension = nullDefaultLowerParam(targetExtension);
 
-            Collection<ContentTransformer> transformers = transformerDebug.sortTransformersByName(transformerName);
+            Collection<ContentTransformer> transformers = LegacyTransformerDebug.sortTransformersByName(transformerRegistry, transformerName);
             Collection<String> sourceMimetypes = transformerDebug.getSourceMimetypes(sourceExtension);
             Collection<String> targetMimetypes = transformerDebug.getTargetMimetypes(sourceExtension, targetExtension, sourceMimetypes);
 
@@ -328,10 +329,7 @@ public class TransformerConfigMBeanImpl implements TransformerConfigMBean
         use = nullDefaultParam(use);
         try
         {
-            String transformerName = getTransformerNameParam(simpleTransformerName);
-            return transformerName == null 
-                    ? transformerDebug.testTransform(                 sourceExtension, targetExtension, use)
-                    : transformerDebug.testTransform(transformerName, sourceExtension, targetExtension, use);
+            return transformerDebug.testTransform( sourceExtension, targetExtension, use);
         }
         catch (IllegalArgumentException e)
         {

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerDebug.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerDebug.java
@@ -80,43 +80,30 @@ import java.util.regex.Pattern;
  * is used (such as {@code 123.1.2} indicating the second third level transformation
  * of the 123rd top level transformation).<p>
  * 
- * In order to track of the nesting of transforms, this class has a stack to represent
+ * In order to track the nesting of transforms, this class has a stack to represent
  * the Transformers. Each Transformer calls {@link #pushTransform} at the start of a
- * transform and {@link #popTransform} at the end. However the top level transform may
- * be selected from a list of available transformers. To record this activity,
- * {@link #pushAvailable}, {@link #unavailableTransformer} (to record the reason a
- * transformer is rejected), {@link #availableTransformers} (to record the available
- * transformers) and {@link #popAvailable} are called.<p>
+ * transform and {@link #popTransform} at the end.
  * 
  * @author Alan Davis
  */
-public class TransformerDebug implements ApplicationContextAware
+public class TransformerDebug
 {
-    private static final String FINISHED_IN = "Finished in ";
-    private static final String NO_TRANSFORMERS = "No transformers";
+    protected static final String FINISHED_IN = "Finished in ";
+    protected static final String NO_TRANSFORMERS = "No transformers";
 
     private Log info;
-    private Log logger;
-    private NodeService nodeService;
-    private MimetypeService mimetypeService;
-    private LocalTransformServiceRegistry localTransformServiceRegistryImpl;
-    private ContentTransformerRegistry transformerRegistry;
-    private TransformerConfig transformerConfig;
+    protected Log logger;
+    protected NodeService nodeService;
+    protected MimetypeService mimetypeService;
 
-    private ApplicationContext applicationContext;
-    private ContentService contentService;
-    private SynchronousTransformClient synchronousTransformClient;
-    private Repository repositoryHelper;
-    private TransactionService transactionService;
-
-    private enum Call
+    protected enum Call
     {
         AVAILABLE,
         TRANSFORM,
         AVAILABLE_AND_TRANSFORM
     };
 
-    private static class ThreadInfo
+    protected static class ThreadInfo
     {
         private static final ThreadLocal<ThreadInfo> threadInfo = new ThreadLocal<ThreadInfo>()
         {
@@ -166,23 +153,23 @@ public class TransformerDebug implements ApplicationContextAware
         }
     }
 
-    private static class Frame
+    protected static class Frame
     {
         private static final AtomicInteger uniqueId = new AtomicInteger(0);
 
         private int id;
         private final String fromUrl;
-        private final String sourceMimetype;
-        private final String targetMimetype;
-        private final NodeRef sourceNodeRef;
-        private final String renditionName;
+        protected final String sourceMimetype;
+        protected final String targetMimetype;
+        protected final NodeRef sourceNodeRef;
+        protected final String renditionName;
         private final boolean origDebugOutput;
         private long start;
 
         private Call callType;
         private Frame parent;
         private int childId;
-        private Set<UnavailableTransformer> unavailableTransformers;
+        protected Set<UnavailableTransformer> unavailableTransformers;
         private String failureReason;
         private long sourceSize;
         private String transformerName;
@@ -212,18 +199,18 @@ public class TransformerDebug implements ApplicationContextAware
             } 
             return id;
         }
-        
-        private void setFailureReason(String failureReason)
+
+        protected void setFailureReason(String failureReason)
         {
             this.failureReason = failureReason;
         }
 
-        private String getFailureReason()
+        protected String getFailureReason()
         {
             return failureReason;
         }
 
-        private void setSourceSize(long sourceSize)
+        protected void setSourceSize(long sourceSize)
         {
             this.sourceSize = sourceSize;
         }
@@ -245,12 +232,12 @@ public class TransformerDebug implements ApplicationContextAware
     }
 
     @Deprecated
-    private class UnavailableTransformer implements Comparable<UnavailableTransformer>
+    protected class UnavailableTransformer implements Comparable<UnavailableTransformer>
     {
-        private final String name;
-        private final String priority;
-        private final long maxSourceSizeKBytes;
-        private final transient boolean debug;
+        protected final String name;
+        protected final String priority;
+        protected final long maxSourceSizeKBytes;
+        protected final transient boolean debug;
         
         UnavailableTransformer(String name, String priority, long maxSourceSizeKBytes, boolean debug)
         {
@@ -315,147 +302,12 @@ public class TransformerDebug implements ApplicationContextAware
         this.mimetypeService = mimetypeService;
     }
 
-    public void setLocalTransformServiceRegistryImpl(LocalTransformServiceRegistry localTransformServiceRegistryImpl)
-    {
-        this.localTransformServiceRegistryImpl = localTransformServiceRegistryImpl;
-    }
-
-    public void setTransformerRegistry(ContentTransformerRegistry transformerRegistry)
-    {
-        this.transformerRegistry = transformerRegistry;
-    }
-
-    public void setTransformerConfig(TransformerConfig transformerConfig)
-    {
-        this.transformerConfig = transformerConfig;
-    }
-
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException
-    {
-        this.applicationContext = applicationContext;
-    }
-
-    private ContentService getContentService()
-    {
-        if (contentService == null)
-        {
-            contentService = (ContentService) applicationContext.getBean("contentService");
-        }
-        return contentService;
-    }
-
-    public void setContentService(ContentService contentService)
-    {
-        this.contentService = contentService;
-    }
-
-    private SynchronousTransformClient getSynchronousTransformClient()
-    {
-        if (synchronousTransformClient == null)
-        {
-            synchronousTransformClient = (SynchronousTransformClient) applicationContext.getBean("legacySynchronousTransformClient");
-        }
-        return synchronousTransformClient;
-    }
-
-    public void setSynchronousTransformClient(SynchronousTransformClient transformClient)
-    {
-        this.synchronousTransformClient = transformClient;
-    }
-
-    public Repository getRepositoryHelper()
-    {
-        if (repositoryHelper == null)
-        {
-            repositoryHelper = (Repository) applicationContext.getBean("repositoryHelper");
-        }
-        return repositoryHelper;
-    }
-
-    public void setRepositoryHelper(Repository repositoryHelper)
-    {
-        this.repositoryHelper = repositoryHelper;
-    }
-
-    public TransactionService getTransactionService()
-    {
-        if (transactionService == null)
-        {
-            transactionService = (TransactionService) applicationContext.getBean("transactionService");
-        }
-        return transactionService;
-    }
-
-    public void setTransactionService(TransactionService transactionService)
-    {
-        this.transactionService = transactionService;
-    }
-
     public void afterPropertiesSet() throws Exception
     {
-        PropertyCheck.mandatory(this, "transformerLog", info);
-        PropertyCheck.mandatory(this, "transformerDebugLog", logger);
         PropertyCheck.mandatory(this, "nodeService", nodeService);
         PropertyCheck.mandatory(this, "mimetypeService", mimetypeService);
-        PropertyCheck.mandatory(this, "transformerRegistry", transformerRegistry);
-        PropertyCheck.mandatory(this, "transformerConfig", transformerConfig);
-    }
-
-    @Deprecated
-    public void pushAvailable(String fromUrl, String sourceMimetype, String targetMimetype,
-                              TransformationOptions options)
-    {
-        String renditionName = options == null ? null : options.getUse();
-        NodeRef sourceNodeRef = options == null ? null : options.getSourceNodeRef();
-        pushAvailable(fromUrl, sourceMimetype, targetMimetype, renditionName, sourceNodeRef);
-    }
-
-    /**
-     * Called prior to working out what transformers are available.
-     */
-    @Deprecated
-    public void pushAvailable(String fromUrl, String sourceMimetype, String targetMimetype,
-                              String renditionName, NodeRef sourceNodeRef)
-    {
-        if (isEnabled())
-        {
-            push(null, fromUrl, sourceMimetype, targetMimetype, -1, renditionName,
-                    sourceNodeRef, Call.AVAILABLE);
-        }
-    }
-
-    /**
-     * Called when a transformer has been ignored because of a blacklist entry.
-     */
-    @Deprecated
-    public void blacklistTransform(ContentTransformer transformer, String sourceMimetype,
-            String targetMimetype, TransformationOptions options)
-    {
-        log("Blacklist "+getName(transformer)+" "+getMimetypeExt(sourceMimetype)+getMimetypeExt(targetMimetype));
-    }
-
-    @Deprecated
-    public void pushTransform(ContentTransformer transformer, String fromUrl, String sourceMimetype,
-            String targetMimetype, long sourceSize, TransformationOptions options)
-    {
-        String renditionName = options == null ? null : options.getUse();
-        NodeRef sourceNodeRef = options == null ? null : options.getSourceNodeRef();
-        pushTransform(transformer, fromUrl, sourceMimetype, targetMimetype, sourceSize, renditionName, sourceNodeRef);
-    }
-
-    /**
-     * Called prior to performing a transform.
-     */
-    @Deprecated
-    public void pushTransform(ContentTransformer transformer, String fromUrl, String sourceMimetype,
-                              String targetMimetype, long sourceSize, String renditionName, NodeRef sourceNodeRef)
-    {
-        if (isEnabled())
-        {
-            push(getName(transformer), fromUrl, sourceMimetype, targetMimetype, sourceSize,
-                    renditionName, sourceNodeRef, Call.TRANSFORM);
-        }
+        PropertyCheck.mandatory(this, "transformerLog", info);
+        PropertyCheck.mandatory(this, "transformerDebugLog", logger);
     }
 
     public void pushTransform(String transformerName, String fromUrl, String sourceMimetype,
@@ -480,21 +332,9 @@ public class TransformerDebug implements ApplicationContextAware
             push(null, null, null, null, -1, null, null, Call.AVAILABLE);
         }
     }
-    
-    /**
-     * Called prior to calling a nested isTransformable.
-     */
-    @Deprecated
-    public void pushIsTransformableSize(ContentTransformer transformer)
-    {
-        if (isEnabled())
-        {
-            ThreadInfo.getIsTransformableStack().push(getName(transformer));
-        }
-    }
-    
-    private void push(String transformerName, String fromUrl, String sourceMimetype, String targetMimetype,
-                      long sourceSize, String renditionName, NodeRef sourceNodeRef, Call callType)
+
+    void push(String transformerName, String fromUrl, String sourceMimetype, String targetMimetype,
+              long sourceSize, String renditionName, NodeRef sourceNodeRef, Call callType)
     {
         Deque<Frame> ourStack = ThreadInfo.getStack();
         Frame frame = ourStack.peek();
@@ -511,194 +351,15 @@ public class TransformerDebug implements ApplicationContextAware
         frame = new Frame(frame, transformerName, fromUrl, sourceMimetype, targetMimetype, sourceSize, renditionName,
                 sourceNodeRef, callType, origDebugOutput);
         ourStack.push(frame);
-            
+
         if (callType == Call.TRANSFORM)
         {
             // Log the basic info about this transformation
             logBasicDetails(frame, sourceSize, renditionName, transformerName, (ourStack.size() == 1));
         }
     }
-    
-    /**
-     * Called to identify a transformer that cannot be used during working out
-     * available transformers.
-     */
-    @Deprecated
-    public void unavailableTransformer(ContentTransformer transformer, String sourceMimetype, String targetMimetype, long maxSourceSizeKBytes)
-    {
-        if (isEnabled())
-        {
-            Deque<Frame> ourStack = ThreadInfo.getStack();
-            Frame frame = ourStack.peek();
 
-            if (frame != null)
-            {
-                Deque<String> isTransformableStack = ThreadInfo.getIsTransformableStack();
-                String name = (!isTransformableStack.isEmpty())
-                    ? isTransformableStack.getFirst()
-                    : getName(transformer);
-                boolean debug = (maxSourceSizeKBytes != 0);
-                if (frame.unavailableTransformers == null)
-                {
-                    frame.unavailableTransformers = new TreeSet<UnavailableTransformer>();
-                }
-                String priority = gePriority(transformer, sourceMimetype, targetMimetype);
-                frame.unavailableTransformers.add(new UnavailableTransformer(name, priority, maxSourceSizeKBytes, debug));
-            }
-        }
-    }
-
-    @Deprecated
-    public void availableTransformers(List<ContentTransformer> transformers, long sourceSize,
-                                      TransformationOptions options, String calledFrom)
-    {
-        String renditionName = options == null ? null : options.getUse();
-        NodeRef sourceNodeRef = options == null ? null : options.getSourceNodeRef();
-        availableTransformers(transformers, sourceSize, renditionName, sourceNodeRef, calledFrom);
-    }
-
-    /**
-     * Called once all available transformers have been identified.
-     */
-    @Deprecated
-    public void availableTransformers(List<ContentTransformer> transformers, long sourceSize, 
-            String renditionName, NodeRef sourceNodeRef, String calledFrom)
-    {
-        if (isEnabled())
-        {
-            Deque<Frame> ourStack = ThreadInfo.getStack();
-            Frame frame = ourStack.peek();
-            boolean firstLevel = ourStack.size() == 1;
-
-            // Override setDebugOutput(false) to allow debug when there are transformers but they are all unavailable
-            // Note once turned on we don't turn it off again.
-            if (transformers.size() == 0)
-            {
-                frame.setFailureReason(NO_TRANSFORMERS);
-                if (frame.unavailableTransformers != null &&
-                    frame.unavailableTransformers.size() != 0)
-                {
-                    ThreadInfo.setDebugOutput(true);
-                }
-            }
-            frame.setSourceSize(sourceSize);
-            
-            // Log the basic info about this transformation
-            logBasicDetails(frame, sourceSize, renditionName,
-                    calledFrom + ((transformers.size() == 0) ? " NO transformers" : ""), firstLevel);
-
-            // Report available and unavailable transformers
-            char c = 'a';
-            int longestNameLength = getLongestTransformerNameLength(transformers, frame);
-            for (ContentTransformer trans : transformers)
-            {
-                String name = getName(trans);
-                int padName = longestNameLength - name.length() + 1;
-                // TODO replace with call to RenditionService2 or leave as a deprecated method using ContentService.
-                TransformationOptions options = new TransformationOptions();
-                options.setUse(frame.renditionName);
-                options.setSourceNodeRef(frame.sourceNodeRef);
-                long maxSourceSizeKBytes = trans.getMaxSourceSizeKBytes(frame.sourceMimetype, frame.targetMimetype, options);
-                String size = maxSourceSizeKBytes > 0 ? "< "+fileSize(maxSourceSizeKBytes*1024) : "";
-                int padSize = 10 - size.length();
-                String priority = gePriority(trans, frame.sourceMimetype, frame.targetMimetype);
-                log((c == 'a' ? "**" : "  ") + (c++) + ") " + priority + ' ' + name + spaces(padName) + 
-                    size + spaces(padSize) + ms(trans.getTransformationTime(frame.sourceMimetype, frame.targetMimetype)));
-            }
-            if (frame.unavailableTransformers != null)
-            {
-                for (UnavailableTransformer unavailable: frame.unavailableTransformers)
-                {
-                    int pad = longestNameLength - unavailable.name.length();
-                    String reason = "> "+fileSize(unavailable.maxSourceSizeKBytes*1024);
-                    if (unavailable.debug || logger.isTraceEnabled())
-                    {
-                        log("--" + (c++) + ") " + unavailable.priority + ' ' + unavailable.name + spaces(pad+1) + reason, unavailable.debug);
-                    }
-                }
-            }
-        }
-    }
-
-    private String gePriority(ContentTransformer transformer, String sourceMimetype, String targetMimetype)
-    {
-        String priority =
-            '[' +
-             (isComponentTransformer(transformer)
-             ? "---"
-             : Integer.toString(transformerConfig.getPriority(transformer, sourceMimetype, targetMimetype))) +
-            ']';
-        priority = spaces(5-priority.length())+priority;
-        return priority;
-    }
-
-    @Deprecated
-    public void inactiveTransformer(ContentTransformer transformer)
-    {
-        log(getName(transformer)+' '+ms(transformer.getTransformationTime(null, null))+" INACTIVE");
-    }
-
-    @Deprecated
-    public void activeTransformer(int mimetypePairCount, ContentTransformer transformer, String sourceMimetype,
-            String targetMimetype, long maxSourceSizeKBytes, boolean firstMimetypePair)
-    {
-        if (firstMimetypePair)
-        {
-            log(getName(transformer)+' '+ms(transformer.getTransformationTime(sourceMimetype, targetMimetype)));
-        }
-        String i = Integer.toString(mimetypePairCount);
-        String priority = gePriority(transformer, sourceMimetype, targetMimetype);
-        log(spaces(5-i.length())+mimetypePairCount+") "+getMimetypeExt(sourceMimetype)+getMimetypeExt(targetMimetype)+
-                priority +
-                ' '+fileSize((maxSourceSizeKBytes > 0) ? maxSourceSizeKBytes*1024 : maxSourceSizeKBytes)+
-                (maxSourceSizeKBytes == 0 ? " disabled" : ""));
-    }
-
-    @Deprecated
-    public void activeTransformer(String sourceMimetype, String targetMimetype,
-            int transformerCount, ContentTransformer transformer, long maxSourceSizeKBytes,
-            boolean firstTransformer)
-    {
-        String priority = gePriority(transformer, sourceMimetype, targetMimetype);
-        activeTransformer(sourceMimetype, targetMimetype, transformerCount, priority, getName(transformer),
-                maxSourceSizeKBytes, firstTransformer);
-    }
-
-    private void activeTransformer(String sourceMimetype, String targetMimetype, int transformerCount, String priority, String transformName, long maxSourceSizeKBytes, boolean firstTransformer)
-    {
-        String mimetypes = firstTransformer
-                ? getMimetypeExt(sourceMimetype)+getMimetypeExt(targetMimetype)
-                : spaces(10);
-        char c = (char)('a'+transformerCount);
-        log(mimetypes+
-                "  "+c+") " + priority + ' '+transformName+' '+
-                fileSize((maxSourceSizeKBytes > 0) ? maxSourceSizeKBytes*1024 : maxSourceSizeKBytes)+
-                (maxSourceSizeKBytes == 0 ? " disabled" : ""));
-    }
-
-    private int getLongestTransformerNameLength(List<ContentTransformer> transformers,
-            Frame frame)
-    {
-        int longestNameLength = 0;
-        for (ContentTransformer trans : transformers)
-        {
-            int length = getName(trans).length();
-            if (longestNameLength < length)
-                longestNameLength = length;
-        }
-        if (frame != null && frame.unavailableTransformers != null)
-        {
-            for (UnavailableTransformer unavailable: frame.unavailableTransformers)
-            {
-                int length = unavailable.name.length();
-                if (longestNameLength < length)
-                    longestNameLength = length;
-            }
-        }
-        return longestNameLength;
-    }
-    
-    private void logBasicDetails(Frame frame, long sourceSize, String renditionName, String message, boolean firstLevel)
+    protected void logBasicDetails(Frame frame, long sourceSize, String renditionName, String message, boolean firstLevel)
     {
         // Log the source URL, but there is no point if the parent has logged it
         if (frame.fromUrl != null && (firstLevel || frame.id != 1))
@@ -733,18 +394,6 @@ public class TransformerDebug implements ApplicationContextAware
     }
 
     /**
-     * Called after working out what transformers are available and any
-     * resulting transform has been called.
-     */
-    public void popAvailable()
-    {
-        if (isEnabled())
-        {
-            pop(Call.AVAILABLE, false, false);
-        }
-    }
-    
-    /**
      * Called after performing a transform.
      */
     public void popTransform()
@@ -766,19 +415,8 @@ public class TransformerDebug implements ApplicationContextAware
             pop(Call.AVAILABLE, ThreadInfo.getStack().size() > 1, false);
         }
     }
-    
-    /**
-     * Called after returning from a nested isTransformable.
-     */
-    public void popIsTransformableSize()
-    {
-        if (isEnabled())
-        {
-            ThreadInfo.getIsTransformableStack().pop();
-        }
-    }
 
-    private int pop(Call callType, boolean suppressFinish, boolean suppressChecking)
+    protected int pop(Call callType, boolean suppressFinish, boolean suppressChecking)
     {
         int id = -1;
         Deque<Frame> ourStack = ThreadInfo.getStack();
@@ -981,12 +619,12 @@ public class TransformerDebug implements ApplicationContextAware
         return message;
     }
 
-    private void log(String message)
+    protected void log(String message)
     {
         log(message, true);
     }
     
-    private void log(String message, boolean debug)
+    protected void log(String message, boolean debug)
     {
         log(message, null, debug);
     }
@@ -1027,7 +665,7 @@ public class TransformerDebug implements ApplicationContextAware
     {
         return t;
     }
-    
+
     /**
      * Returns the current StringBuilder (if any) being used to capture debug
      * information for the current Thread.
@@ -1045,288 +683,7 @@ public class TransformerDebug implements ApplicationContextAware
     {
         ThreadInfo.setStringBuilder(sb);
     }
-    
-    /**
-     * Returns a String and /or debug that provides a list of supported transformations for each
-     * transformer.
-     * @param transformerName restricts the list to one transformer. Unrestricted if null.
-     * @param toString indicates that a String value should be returned in addition to any debug.
-     * @param format42 indicates the old 4.1.4 format should be used which did not order the transformers
-     *        and only included top level transformers.
-     * @param renditionName to which the transformation will be put (such as "Index", "Preview", null).
-     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
-     */
-    @Deprecated
-    public String transformationsByTransformer(String transformerName, boolean toString, boolean format42, String renditionName)
-    {
-        // Do not generate this type of debug if already generating other debug to a StringBuilder
-        // (for example a test transform). 
-        if (getStringBuilder() != null)
-        {
-            return null;
-        }
-        
-        Collection<ContentTransformer> transformers = format42 || transformerName != null
-                ? sortTransformersByName(transformerName)
-                : transformerRegistry.getTransformers();
-        Collection<String> sourceMimetypes = format42
-                ? getSourceMimetypes(null)
-                : mimetypeService.getMimetypes();
-        Collection<String> targetMimetypes = format42
-                ? sourceMimetypes
-                : mimetypeService.getMimetypes();
-        
-        TransformationOptions options = new TransformationOptions();
-        options.setUse(renditionName);
-        StringBuilder sb = null;
-        try
-        {
-            if (toString)
-            {
-                sb = new StringBuilder();
-                setStringBuilder(sb);
-            }
-            pushMisc();
-            for (ContentTransformer transformer: transformers)
-            {
-                try
-                {
-                    pushMisc();
-                    int mimetypePairCount = 0;
-                    boolean first = true;
-                    for (String sourceMimetype: sourceMimetypes)
-                    {
-                        for (String targetMimetype: targetMimetypes)
-                        {
-                            if (transformer.isTransformable(sourceMimetype, -1, targetMimetype, options))
-                            {
-                                long maxSourceSizeKBytes = transformer.getMaxSourceSizeKBytes(
-                                        sourceMimetype, targetMimetype, options);
-                                activeTransformer(++mimetypePairCount, transformer,
-                                        sourceMimetype, targetMimetype, maxSourceSizeKBytes, first);
-                                first = false;
-                            }
-                        }
-                    }
-                    if (first)
-                    {
-                        inactiveTransformer(transformer);
-                    }
-                }
-                finally
-                {
-                    popMisc();
-                }
-            }
-        }
-        finally
-        {
-            popMisc();
-            setStringBuilder(null);
-        }
-        stripFinishedLine(sb);
-        return stripLeadingNumber(sb);
-    }
 
-    /**
-     * Returns a String and /or debug that provides a list of supported transformations
-     * sorted by source and target mimetype extension.
-     * @param sourceExtension restricts the list to one source extension. Unrestricted if null. 
-     * @param targetExtension restricts the list to one target extension. Unrestricted if null.
-     * @param toString indicates that a String value should be returned in addition to any debug.
-     * @param format42 indicates the new 4.2 rather than older 4.1.4 format should be used.
-     *        The 4.1.4 format did not order the transformers or mimetypes and only included top
-     *        level transformers.
-     * @param onlyNonDeterministic if true only report transformations where there is more than
-     *        one transformer available with the same priority.
-     * @param renditionName to which the transformation will be put (such as "Index", "Preview", null).
-     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
-     */
-    @Deprecated
-    public String transformationsByExtension(String sourceExtension, String targetExtension, boolean toString,
-            boolean format42, boolean onlyNonDeterministic, String renditionName)
-    {
-        // Do not generate this type of debug if already generating other debug to a StringBuilder
-        // (for example a test transform). 
-        if (getStringBuilder() != null)
-        {
-            return null;
-        }
-
-        Collection<ContentTransformer> transformers = format42 && !onlyNonDeterministic
-                ? sortTransformersByName(null)
-                : transformerRegistry.getTransformers();
-        Collection<String> sourceMimetypes = format42 || sourceExtension != null
-                ? getSourceMimetypes(sourceExtension)
-                : mimetypeService.getMimetypes();
-        Collection<String> targetMimetypes = format42 || targetExtension != null
-                ? getTargetMimetypes(sourceExtension, targetExtension, sourceMimetypes)
-                : mimetypeService.getMimetypes();
-
-        TransformationOptions options = new TransformationOptions();
-        options.setUse(renditionName);
-        StringBuilder sb = null;
-        try
-        {
-            if (toString)
-            {
-                sb = new StringBuilder();
-                setStringBuilder(sb);
-            }
-            pushMisc();
-            for (String sourceMimetype: sourceMimetypes)
-            {
-                for (String targetMimetype: targetMimetypes)
-                {
-                    // Find available transformers
-                    List<ContentTransformer> availableTransformer = new ArrayList<ContentTransformer>();
-                    for (ContentTransformer transformer: transformers)
-                    {
-                        if (transformer.isTransformable(sourceMimetype, -1, targetMimetype, options))
-                        {
-                            availableTransformer.add(transformer);
-                        }
-                    }
-
-                    // Sort by priority
-                    final String currSourceMimetype = sourceExtension;
-                    final String currTargetMimetype = targetExtension;
-                    Collections.sort(availableTransformer, new Comparator<ContentTransformer>()
-                    {
-                        @Override
-                        public int compare(ContentTransformer transformer1, ContentTransformer transformer2)
-                        {
-                            return transformerConfig.getPriority(transformer1, currSourceMimetype, currTargetMimetype) -
-                                   transformerConfig.getPriority(transformer2, currSourceMimetype, currTargetMimetype);
-                        }
-                    });
-
-                    // Do we need to produce any output?
-                    int size = availableTransformer.size();
-                    int priority = size >= 2
-                            ? transformerConfig.getPriority(availableTransformer.get(0), sourceMimetype, targetMimetype)
-                            : -1;
-                    if (!onlyNonDeterministic || (size >= 2 && priority ==
-                         transformerConfig.getPriority(availableTransformer.get(1), sourceMimetype, targetMimetype)))
-                    {
-                        // Log the transformers
-                        LocalTransform localTransform = localTransformServiceRegistryImpl == null
-                                ? null
-                                : localTransformServiceRegistryImpl.getLocalTransform(sourceMimetype,
-                                -1, targetMimetype, Collections.emptyMap(), null);
-                        if (localTransform != null || size >= 1)
-                        {
-                            try
-                            {
-                                pushMisc();
-                                int transformerCount = 0;
-                                if (localTransform != null)
-                                {
-                                    long maxSourceSizeKBytes = localTransformServiceRegistryImpl.findMaxSize(sourceMimetype,
-                                            targetMimetype, Collections.emptyMap(), null);
-                                    String transformName = localTransform instanceof AbstractLocalTransform
-                                            ? "Local:" + ((AbstractLocalTransform) localTransform).getName()
-                                            : "";
-                                    activeTransformer(sourceMimetype, targetMimetype, transformerCount, "  [0]",
-                                            transformName, maxSourceSizeKBytes, transformerCount++ == 0);
-                                }
-                                for (ContentTransformer transformer: availableTransformer)
-                                {
-                                    if (!onlyNonDeterministic || transformerCount < 2 ||
-                                            priority == transformerConfig.getPriority(transformer, sourceMimetype, targetMimetype))
-                                    {
-                                        long maxSourceSizeKBytes = transformer.getMaxSourceSizeKBytes(
-                                                sourceMimetype, targetMimetype, options);
-                                        activeTransformer(sourceMimetype, targetMimetype, transformerCount,
-                                                transformer, maxSourceSizeKBytes, transformerCount++ == 0);
-                                    }
-                                }
-                            }
-                            finally
-                            {
-                                popMisc();
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        finally
-        {
-            popMisc();
-            setStringBuilder(null);
-        }
-        stripFinishedLine(sb);
-        return stripLeadingNumber(sb);
-    }
-    
-    /**
-     * Removes the final "Finished in..." message from a StringBuilder
-     * @param sb
-     */
-    private void stripFinishedLine(StringBuilder sb)
-    {
-        if (sb != null)
-        {
-            int i = sb.lastIndexOf(FINISHED_IN);
-            if (i != -1)
-            {
-                sb.setLength(i);
-                i = sb.lastIndexOf("\n", i);
-                sb.setLength(i != -1 ? i : 0);
-            }
-        }
-    }
-    
-    /**
-     * Strips the leading number in a reference
-     */
-    private String stripLeadingNumber(StringBuilder sb)
-    {
-        return sb == null
-            ? null
-            : Pattern.compile("^\\d+\\.", Pattern.MULTILINE).matcher(sb).replaceAll("");
-    }
-
-    /**
-     * Returns a collection of mimetypes ordered by extension, but unlike the version in MimetypeService
-     * throws an exception if the sourceExtension is supplied but does not match a mimetype.
-     * @param sourceExtension to restrict the collection to one entry
-     * @throws IllegalArgumentException if there is no match. The message indicates this.
-     */
-    public Collection<String> getSourceMimetypes(String sourceExtension)
-    {
-        Collection<String> sourceMimetypes = mimetypeService.getMimetypes(sourceExtension);
-        if (sourceMimetypes.isEmpty())
-        {
-            throw new IllegalArgumentException("Unknown source extension "+sourceExtension);
-        }
-        return sourceMimetypes;
-    }
-
-    /**
-     * Identical to getSourceMimetypes for the target, but avoids doing the look up if the sourceExtension
-     * is the same as the tragetExtension, so will have the same result.
-     * @param sourceExtension used to restrict the sourceMimetypes
-     * @param targetExtension to restrict the collection to one entry
-     * @param sourceMimetypes that match the sourceExtension
-     * @throws IllegalArgumentException if there is no match. The message indicates this.
-     */
-    public Collection<String> getTargetMimetypes(String sourceExtension, String targetExtension,
-            Collection<String> sourceMimetypes)
-    {
-        Collection<String> targetMimetypes =
-                (targetExtension == null && sourceExtension == null) ||
-                (targetExtension != null && targetExtension.equals(sourceExtension))
-                ? sourceMimetypes
-                : mimetypeService.getMimetypes(targetExtension);
-        if (targetMimetypes.isEmpty())
-        {
-            throw new IllegalArgumentException("Unknown target extension "+targetExtension);
-        }
-        return targetMimetypes;
-    }
-    
     /**
      * Returns a N.N.N style reference to the transformation.
      * @param firstLevelOnly indicates if only the top level should be included and no extra padding.
@@ -1383,59 +740,6 @@ public class TransformerDebug implements ApplicationContextAware
         return sb.toString();
     }
 
-    private String getName(ContentTransformer transformer)
-    {
-        String name =
-                transformer instanceof ContentTransformerHelper
-                ? ContentTransformerHelper.getSimpleName(transformer)
-                : transformer.getClass().getSimpleName();
-        
-        String type =
-                ((transformer instanceof AbstractRemoteContentTransformer &&
-                  ((AbstractRemoteContentTransformer)transformer).remoteTransformerClientConfigured()) ||
-                 (transformer instanceof ProxyContentTransformer &&
-                  ((ProxyContentTransformer)transformer).remoteTransformerClientConfigured())
-                ? "Remote" : "")+
-                (transformer instanceof ComplexContentTransformer
-                ? "Complex"
-                : transformer instanceof FailoverContentTransformer
-                ? "Failover"
-                : transformer instanceof ProxyContentTransformer
-                ? (((ProxyContentTransformer)transformer).getWorker() instanceof RuntimeExecutableContentTransformerWorker)
-                  ? "Runtime"
-                  : "Proxy"
-                : "");
-
-        boolean componentTransformer = isComponentTransformer(transformer);
-        
-        StringBuilder sb = new StringBuilder("Legacy:").append(name);
-        if (componentTransformer || type.length() > 0)
-        {
-            sb.append("<<");
-            sb.append(type);
-            if (componentTransformer)
-            {
-                sb.append("Component");
-            }
-            sb.append(">>");
-        }
-        
-        return sb.toString();
-    }
-    
-
-    private boolean isComponentTransformer(ContentTransformer transformer)
-    {
-        return !transformerRegistry.getTransformers().contains(transformer);
-    }
-
-    @Deprecated
-    public String getFileName(TransformationOptions options, boolean firstLevel, long sourceSize)
-    {
-        NodeRef sourceNodeRef = options == null ? null : options.getSourceNodeRef();
-        return getFileName(sourceNodeRef, firstLevel, sourceSize);
-    }
-
     public String getFileName(NodeRef sourceNodeRef, boolean firstLevel, long sourceSize)
     {
         return getFileNameOrNodeRef(sourceNodeRef, firstLevel, sourceSize, true);
@@ -1476,7 +780,7 @@ public class TransformerDebug implements ApplicationContextAware
         return result;
     }
 
-    private String getMimetypeExt(String mimetype)
+    protected String getMimetypeExt(String mimetype)
     {
         StringBuilder sb = new StringBuilder("");
         if (mimetypeService == null)
@@ -1493,7 +797,7 @@ public class TransformerDebug implements ApplicationContextAware
         return sb.toString();
     }
     
-    private String spaces(int i)
+    protected String spaces(int i)
     {
         StringBuilder sb = new StringBuilder("");
         while (--i >= 0)
@@ -1549,30 +853,6 @@ public class TransformerDebug implements ApplicationContextAware
 
         return sb.toString();
     }
-    
-    /**
-     * Returns a sorted list of all transformers sorted by name.
-     * @param transformerName to restrict the collection to one entry
-     * @return a new Collection of sorted transformers
-     * @throws IllegalArgumentException if transformerName is not found.
-     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
-     */
-    @Deprecated
-    public Collection<ContentTransformer> sortTransformersByName(String transformerName)
-    {
-        Collection<ContentTransformer> transformers = (transformerName != null)
-                ? Collections.singleton(transformerRegistry.getTransformer(transformerName))
-                : transformerRegistry.getAllTransformers();
-
-        SortedMap<String, ContentTransformer> map = new TreeMap<String, ContentTransformer>();
-        for (ContentTransformer transformer: transformers)
-        {
-            String name = transformer.getName();
-            map.put(name, transformer);
-        }
-        Collection<ContentTransformer> sorted = map.values();
-        return sorted;
-    }
 
     /**
      * Debugs a request to the Transform Service
@@ -1613,185 +893,5 @@ public class TransformerDebug implements ApplicationContextAware
         debug(msg);
         debug(sourceNodeRef.toString() + ' ' +contentHashcode);
         pop(Call.AVAILABLE, suppressFinish, true);
-    }
-
-    public String testTransform(String sourceExtension, String targetExtension, String renditionName)
-    {
-        return new TestTransform().run(sourceExtension, targetExtension, renditionName);
-    }
-
-    /**
-     * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
-     */
-    @Deprecated
-    public String testTransform(final String transformerName, String sourceExtension,
-            String targetExtension, String renditionName)
-    {
-        logger.error("The testTransform operation for a specific transformer is no longer supported. " +
-                "Direct transforms have been deprecated in favour of async renditions. " +
-                "Request redirected to the version of this method without a transformerName.");
-        return testTransform(sourceExtension, targetExtension, renditionName);
-    }
-    
-    public String[] getTestFileExtensionsAndMimetypes()
-    {
-        List<String> sourceExtensions = new ArrayList<String>();
-        Collection<String> sourceMimetypes = mimetypeService.getMimetypes(null);
-        for (String sourceMimetype: sourceMimetypes)
-        {
-            String sourceExtension = mimetypeService.getExtension(sourceMimetype);
-            if (loadQuickTestFile(sourceExtension) != null)
-            {
-                sourceExtensions.add(sourceExtension+" - "+sourceMimetype);
-            }
-        }
-
-        return sourceExtensions.toArray(new String[sourceExtensions.size()]);
-    }
-
-    /**
-     * Load one of the "The quick brown fox" files from the classpath.
-     * @param extension required, eg <b>txt</b> for the file quick.txt
-     * @return Returns a test resource loaded from the classpath or <tt>null</tt> if
-     *      no resource could be found.
-     */
-    private URL loadQuickTestFile(String extension)
-    {
-        final URL result;
-        
-        URL url = this.getClass().getClassLoader().getResource("quick/quick." + extension);
-        if (url == null)
-        {
-            result = null;
-        }
-        else
-        {
-            // Note that this URL may point to a file on the filesystem or to an entry in a jar file.
-            // The handling should be the same either way.
-            result = url;
-        }
-        
-        return result;
-    }
-
-    @Deprecated
-    private class TestTransform
-    {
-        protected LinkedList<NodeRef> nodesToDeleteAfterTest = new LinkedList<NodeRef>();
-
-        String run(String sourceExtension, String targetExtension, String renditionName)
-        {
-            RetryingTransactionHelper.RetryingTransactionCallback<String> makeNodeCallback = new RetryingTransactionHelper.RetryingTransactionCallback<String>()
-            {
-                public String execute() throws Throwable
-                {
-                    return runWithinTransaction(sourceExtension, targetExtension);
-                }
-            };
-            return getTransactionService().getRetryingTransactionHelper().doInTransaction(makeNodeCallback, false, true);
-        }
-
-        private String runWithinTransaction(String sourceExtension, String targetExtension)
-        {
-            String targetMimetype = getMimetype(targetExtension, false);
-            String sourceMimetype = getMimetype(sourceExtension, true);
-            File tempFile = TempFileProvider.createTempFile(
-                    "TestTransform_" + sourceExtension + "_", "." + targetExtension);
-            ContentWriter writer = new FileContentWriter(tempFile);
-            writer.setMimetype(targetMimetype);
-
-            NodeRef sourceNodeRef = null;
-            StringBuilder sb = new StringBuilder();
-            try
-            {
-                setStringBuilder(sb);
-                sourceNodeRef = createSourceNode(sourceExtension, sourceMimetype);
-                ContentReader reader = contentService.getReader(sourceNodeRef, ContentModel.PROP_CONTENT);
-                SynchronousTransformClient synchronousTransformClient = getSynchronousTransformClient();
-                Map<String, String> actualOptions = Collections.emptyMap();
-                synchronousTransformClient.transform(reader, writer, actualOptions, null, sourceNodeRef);
-            }
-            catch (Exception e)
-            {
-                logger.debug("Unexpected test transform error", e);
-            }
-            finally
-            {
-                setStringBuilder(null);
-                deleteSourceNode(sourceNodeRef);
-            }
-            return sb.toString();
-        }
-
-        private String getMimetype(String extension, boolean isSource)
-        {
-            String mimetype = null;
-            if (extension != null)
-            {
-                Iterator<String> iterator = mimetypeService.getMimetypes(extension).iterator();
-                if (iterator.hasNext())
-                {
-                    mimetype = iterator.next(); 
-                }
-            }
-            if (mimetype == null)
-            {
-                throw new IllegalArgumentException("Unknown "+(isSource ? "source" : "target")+" extension: "+extension);
-            }
-            return mimetype;
-        }
-
-        public NodeRef createSourceNode(String extension, String sourceMimetype)
-        {
-            // Create a content node which will serve as test data for our transformations.
-            RetryingTransactionHelper.RetryingTransactionCallback<NodeRef> makeNodeCallback = new RetryingTransactionHelper.RetryingTransactionCallback<NodeRef>()
-            {
-                public NodeRef execute() throws Throwable
-                {
-                    // Create a source node loaded with a quick file.
-                    URL url = loadQuickTestFile(extension);
-                    URI uri = url.toURI();
-                    File sourceFile = new File(uri);
-
-                    final NodeRef companyHome = getRepositoryHelper().getCompanyHome();
-
-                    Map<QName, Serializable> props = new HashMap<QName, Serializable>();
-                    String localName = "TestTransform." + extension;
-                    props.put(ContentModel.PROP_NAME, localName);
-                    NodeRef node = nodeService.createNode(
-                            companyHome,
-                            ContentModel.ASSOC_CONTAINS,
-                            QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, localName),
-                            ContentModel.TYPE_CONTENT,
-                            props).getChildRef();
-
-                    ContentWriter writer = getContentService().getWriter(node, ContentModel.PROP_CONTENT, true);
-                    writer.setMimetype(sourceMimetype);
-                    writer.setEncoding("UTF-8");
-                    writer.putContent(sourceFile);
-
-                    return node;
-                }
-            };
-            NodeRef contentNodeRef = getTransactionService().getRetryingTransactionHelper().doInTransaction(makeNodeCallback);
-            this.nodesToDeleteAfterTest.add(contentNodeRef);
-            return contentNodeRef;
-        }
-
-        public void deleteSourceNode(NodeRef sourceNodeRef)
-        {
-            if (sourceNodeRef != null)
-            {
-                getTransactionService().getRetryingTransactionHelper().doInTransaction(
-                        (RetryingTransactionHelper.RetryingTransactionCallback<Void>) () ->
-                        {
-                            if (nodeService.exists(sourceNodeRef))
-                            {
-                                nodeService.deleteNode(sourceNodeRef);
-                            }
-                            return null;
-                        });
-            }
-        }
     }
 }

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerDebug.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerDebug.java
@@ -495,14 +495,7 @@ public class TransformerDebug
                 // Use TRACE logging for all but the first TRANSFORM
                 debug = size == 1 || (size == 2 && ThreadInfo.getStack().peekLast().callType != Call.TRANSFORM);
             }
-// Comment out for the moment
-//            else if (firstLevel && frame.callType == Call.AVAILABLE)
-//            {
-//                level = "INFO";
-//                debug = true;
-//                failureReason = "checking availability";
-//            }
-            
+
             if (level != null)
             {
                 infoLog(getReference(debug, false), sourceExt, targetExt, level, fileName, sourceSize, transformerName, failureReason, ms, debug);
@@ -763,7 +756,7 @@ public class TransformerDebug
             }
             catch (RuntimeException e)
             {
-                ; // ignore (normally InvalidNodeRefException) but we should ignore other RuntimeExceptions too
+                // ignore (normally InvalidNodeRefException) but we should ignore other RuntimeExceptions too
             }
         }
         if (result == null)
@@ -883,12 +876,6 @@ public class TransformerDebug
         if (!suppressFinish)
         {
             frame.start = requested;
-// TODO Create a dummy (available == false) transformer for TransformService before we can record the TS's stats
-//            String sourceMimetype = mimetypeService.getMimetype(sourceExt);
-//            String targetMimetype = mimetypeService.getMimetype(targetExt);
-//            long ms = System.currentTimeMillis()-requested;
-//            AbstractContentTransformer2 transformer = null;
-//            transformer.recordTime(sourceMimetype, targetMimetype, ms);
         }
         debug(msg);
         debug(sourceNodeRef.toString() + ' ' +contentHashcode);

--- a/src/main/java/org/alfresco/repo/content/transform/TransformerSelectorImpl.java
+++ b/src/main/java/org/alfresco/repo/content/transform/TransformerSelectorImpl.java
@@ -56,7 +56,7 @@ public class TransformerSelectorImpl implements TransformerSelector
 {
     private TransformerConfig transformerConfig;
     private ContentTransformerRegistry contentTransformerRegistry;
-    private TransformerDebug transformerDebug;
+    private LegacyTransformerDebug transformerDebug;
 
     public void setTransformerConfig(TransformerConfig transformerConfig)
     {
@@ -68,7 +68,7 @@ public class TransformerSelectorImpl implements TransformerSelector
         this.contentTransformerRegistry = contentTransformerRegistry;
     }
 
-    public void setTransformerDebug(TransformerDebug transformerDebug)
+    public void setTransformerDebug(LegacyTransformerDebug transformerDebug)
     {
         this.transformerDebug = transformerDebug;
     }

--- a/src/main/java/org/alfresco/repo/rendition2/ContentTransformServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/rendition2/ContentTransformServiceImpl.java
@@ -30,7 +30,7 @@ import org.alfresco.repo.content.MimetypeMap;
 import org.alfresco.repo.content.filestore.FileContentWriter;
 import org.alfresco.repo.content.transform.ContentTransformer;
 import org.alfresco.repo.content.transform.ContentTransformerRegistry;
-import org.alfresco.repo.content.transform.TransformerDebug;
+import org.alfresco.repo.content.transform.LegacyTransformerDebug;
 import org.alfresco.repo.content.transform.UnimportantTransformException;
 import org.alfresco.repo.content.transform.UnsupportedTransformationException;
 import org.alfresco.service.cmr.repository.ContentIOException;
@@ -48,7 +48,6 @@ import org.springframework.beans.factory.InitializingBean;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Contains deprecated code originally from {@link org.alfresco.repo.content.ContentServiceImpl} that is used to perform
@@ -63,7 +62,7 @@ public abstract class ContentTransformServiceImpl implements InitializingBean
 
     private MimetypeService mimetypeService;
     private ContentTransformerRegistry transformerRegistry;
-    private TransformerDebug transformerDebug;
+    private LegacyTransformerDebug transformerDebug;
 
     private boolean transformerFailover = true;
 
@@ -77,7 +76,7 @@ public abstract class ContentTransformServiceImpl implements InitializingBean
         this.transformerRegistry = transformerRegistry;
     }
 
-    public void setTransformerDebug(TransformerDebug transformerDebug)
+    public void setTransformerDebug(LegacyTransformerDebug transformerDebug)
     {
         this.transformerDebug = transformerDebug;
     }

--- a/src/main/java/org/alfresco/repo/rendition2/LegacyTransformServiceRegistry.java
+++ b/src/main/java/org/alfresco/repo/rendition2/LegacyTransformServiceRegistry.java
@@ -26,13 +26,13 @@
 package org.alfresco.repo.rendition2;
 
 import org.alfresco.repo.content.transform.TransformerDebug;
-import org.alfresco.service.cmr.repository.ContentService;
 import org.alfresco.service.cmr.repository.TransformationOptions;
 import org.alfresco.transform.client.registry.TransformServiceRegistry;
 import org.alfresco.util.PropertyCheck;
 import org.springframework.beans.factory.InitializingBean;
 
 import java.util.Map;
+
 
 /**
  * Implements {@link TransformServiceRegistry} providing a mechanism of validating if a legacy transformation

--- a/src/main/java/org/alfresco/repo/rendition2/LocalSynchronousTransformClient.java
+++ b/src/main/java/org/alfresco/repo/rendition2/LocalSynchronousTransformClient.java
@@ -27,7 +27,6 @@ package org.alfresco.repo.rendition2;
 
 import org.alfresco.repo.content.transform.LocalTransform;
 import org.alfresco.repo.content.transform.LocalTransformServiceRegistry;
-import org.alfresco.repo.content.transform.TransformerDebug;
 import org.alfresco.repo.content.transform.UnsupportedTransformationException;
 import org.alfresco.service.cmr.repository.ContentReader;
 import org.alfresco.service.cmr.repository.ContentWriter;

--- a/src/main/resources/alfresco/content-services-context.xml
+++ b/src/main/resources/alfresco/content-services-context.xml
@@ -338,7 +338,7 @@
    </bean>
 
    <!-- Transformation Debug -->
-    <bean id="transformerDebug" class="org.alfresco.repo.content.transform.TransformerDebug">
+    <bean id="transformerDebug" class="org.alfresco.repo.content.transform.LegacyTransformerDebug">
        <property name="nodeService" ref="nodeService" />
        <property name="mimetypeService" ref="mimetypeService" />
        <property name="transformerRegistry" ref="contentTransformerRegistry" />

--- a/src/test/java/org/alfresco/repo/content/transform/LegacyTransformerDebugTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/LegacyTransformerDebugTest.java
@@ -46,11 +46,12 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.mockito.Mockito.when;
 
 /**
- * Test class for TransformerDebug.
+ * Test class for LegacyTransformerDebugTest.
  *
  * @author Alan Davis
  */
-public class TransformerDebugTest
+@Deprecated
+public class LegacyTransformerDebugTest
 {
     @Mock
     private NodeService nodeService;
@@ -79,7 +80,7 @@ public class TransformerDebugTest
     @Mock
     private AbstractContentTransformerLimits transformer4;
 
-    private TransformerDebug transformerDebug;
+    private LegacyTransformerDebug transformerDebug;
 
     private TransformerLog log;
 
@@ -105,7 +106,7 @@ public class TransformerDebugTest
         when(transformer3.getName()).thenReturn("transformer3");
         when(transformer4.getName()).thenReturn("transformer4");
 
-        transformerDebug = new TransformerDebug();
+        transformerDebug = new LegacyTransformerDebug();
         transformerDebug.setNodeService(nodeService);
         transformerDebug.setMimetypeService(mimetypeService);
         transformerDebug.setTransformerRegistry(transformerRegistry);

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerConfigDynamicTransformersTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerConfigDynamicTransformersTest.java
@@ -67,7 +67,7 @@ public class TransformerConfigDynamicTransformersTest
     private LegacySynchronousTransformClient legacySynchronousTransformClient;
     
     @Mock
-    private TransformerDebug transformerDebug;
+    private LegacyTransformerDebug transformerDebug;
     
     @Mock
     ModuleService moduleService;

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerConfigMBeanImplTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerConfigMBeanImplTest.java
@@ -59,7 +59,7 @@ public class TransformerConfigMBeanImplTest
     private ContentTransformerRegistry transformerRegistry;
 
     @Mock
-    private AdminUiTransformerDebug transformerDebug;
+    private LegacyTransformerDebug transformerDebug;
 
     @Mock
     private TransformerConfig transformerConfig;
@@ -235,9 +235,9 @@ public class TransformerConfigMBeanImplTest
         ContentTransformer transformer1 = (ContentTransformer) new DummyContentTransformer("transformer.transformer1");
         ContentTransformer transformer2 = (ContentTransformer) new DummyContentTransformer("transformer.transformer2");
 
-        when(LegacyTransformerDebug.sortTransformersByName(transformerRegistry, "transformer.transformer1")).thenReturn(
+        when(transformerDebug.sortTransformersByName("transformer.transformer1")).thenReturn(
                 Arrays.asList(new ContentTransformer[] {transformer1}));
-        when(LegacyTransformerDebug.sortTransformersByName(transformerRegistry, null)).thenReturn(
+        when(transformerDebug.sortTransformersByName(null)).thenReturn(
                 Arrays.asList(new ContentTransformer[] {transformer1, transformer2}));
 
         when(transformerDebug.getSourceMimetypes("pdf")).thenReturn(Collections.singletonList("application/pdf"));

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerConfigMBeanImplTest.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerConfigMBeanImplTest.java
@@ -59,7 +59,7 @@ public class TransformerConfigMBeanImplTest
     private ContentTransformerRegistry transformerRegistry;
 
     @Mock
-    private TransformerDebug transformerDebug;
+    private AdminUiTransformerDebug transformerDebug;
 
     @Mock
     private TransformerConfig transformerConfig;
@@ -113,23 +113,6 @@ public class TransformerConfigMBeanImplTest
     }
 
     @Test
-    // Just testing that the transformer names have the "transformer." prefix stripped.
-    public void getTransformerNamesTest()
-    {
-        when(transformerDebug.sortTransformersByName(null)).thenReturn(
-                Arrays.asList(new ContentTransformer[]
-                {
-                            (ContentTransformer) new DummyContentTransformer("transformer.transformer1"),
-                            (ContentTransformer) new DummyContentTransformer("transformer2"),
-                            (ContentTransformer) new DummyContentTransformer("transformer.transformer3")
-                }));
-        
-        String[] actual = mbean.getTransformerNames();
-        String[] expected = new String[] { "transformer1", "transformer2", "transformer3" };
-        assertArrayEquals(expected, actual);
-    }
-
-    @Test
     public void getExtensionsAndMimetypesTest()
     {
         when(mimetypeService.getMimetypes(null)).thenReturn(Arrays.asList(new String[] { "application/pdf", "image/png" }));
@@ -139,52 +122,6 @@ public class TransformerConfigMBeanImplTest
         String[] actual = mbean.getExtensionsAndMimetypes();
         String[] expected = new String[] { "pdf - application/pdf", "png - image/png" };
         assertArrayEquals(expected, actual);
-    }
-    
-    @Test
-    public void getTransformationsByTransformerTest()
-    {
-        setupForGetTransformationsBtTransformer();
-        assertEquals("One result", mbean.getTransformationsByTransformer("transformer1", null));
-    }
-    
-    @Test
-    public void getTransformationsByTransformerBadNameTest()
-    {
-        setupForGetTransformationsBtTransformer();
-        assertEquals("unknown transformer", mbean.getTransformationsByTransformer("TRANSFORMER1", null));
-    }
-    
-    @Test
-    public void getTransformationsByTransformerNullTest()
-    {
-        setupForGetTransformationsBtTransformer();
-        assertEquals("Lots of results", mbean.getTransformationsByTransformer(null, null));
-    }
-
-    @Test
-    public void getTransformationsByTransformerJConsoleStringTest()
-    {
-        // "String" (the default JConsole value) is mapped to null
-        setupForGetTransformationsBtTransformer();
-        assertEquals("Lots of results", mbean.getTransformationsByTransformer("String", null));
-    }
-
-    @Test
-    public void getTransformationsByTransformerJConsoleBlankTest()
-    {
-        // "" is mapped to null - Can't set a null in JConsole
-        setupForGetTransformationsBtTransformer();
-        assertEquals("Lots of results", mbean.getTransformationsByTransformer("", null));
-    }
-
-    private void setupForGetTransformationsBtTransformer()
-    {
-        when(transformerDebug.transformationsByTransformer("transformer.transformer1", true, true, null)).thenReturn("One result");
-        when(transformerDebug.transformationsByTransformer(null, true, true, null)).thenReturn("Lots of results");
-        when(transformerRegistry.getTransformer("transformer.transformer1")).thenReturn(new DummyContentTransformer("transformer.transformer1"));
-        when(transformerRegistry.getTransformer(null)).thenReturn(null);
-        when(transformerRegistry.getTransformer("transformer.TRANSFORMER1")).thenThrow(new IllegalArgumentException("unknown transformer"));
     }
     
     @Test
@@ -298,9 +235,9 @@ public class TransformerConfigMBeanImplTest
         ContentTransformer transformer1 = (ContentTransformer) new DummyContentTransformer("transformer.transformer1");
         ContentTransformer transformer2 = (ContentTransformer) new DummyContentTransformer("transformer.transformer2");
 
-        when(transformerDebug.sortTransformersByName("transformer.transformer1")).thenReturn(
+        when(LegacyTransformerDebug.sortTransformersByName(transformerRegistry, "transformer.transformer1")).thenReturn(
                 Arrays.asList(new ContentTransformer[] {transformer1}));
-        when(transformerDebug.sortTransformersByName(null)).thenReturn(
+        when(LegacyTransformerDebug.sortTransformersByName(transformerRegistry, null)).thenReturn(
                 Arrays.asList(new ContentTransformer[] {transformer1, transformer2}));
 
         when(transformerDebug.getSourceMimetypes("pdf")).thenReturn(Collections.singletonList("application/pdf"));
@@ -412,19 +349,5 @@ public class TransformerConfigMBeanImplTest
     {
         when(transformerDebug.testTransform("bad", "png", null)).thenThrow(new IllegalArgumentException("Unknown source extension: bad"));
         assertEquals("Unknown source extension: bad", mbean.testTransform(null, "bad", "png", null));
-    }
-    
-    @Test
-    public void testTransformTest()
-    {
-        when(transformerDebug.testTransform("transformer.transformer1", "pdf", "png", null)).thenReturn("debug output");
-        assertEquals("debug output", mbean.testTransform("transformer1", "pdf", "png", null));
-    }
-    
-    @Test
-    public void testTransformBadExtensionTest()
-    {
-        when(transformerDebug.testTransform("transformer.transformer1", "bad", "png", null)).thenThrow(new IllegalArgumentException("Unknown source extension: bad"));
-        assertEquals("Unknown source extension: bad", mbean.testTransform("transformer1", "bad", "png", null));
     }
 }

--- a/src/test/java/org/alfresco/repo/content/transform/TransformerConfigTestSuite.java
+++ b/src/test/java/org/alfresco/repo/content/transform/TransformerConfigTestSuite.java
@@ -52,7 +52,7 @@ import org.junit.runners.Suite.SuiteClasses;
     TransformerLoggerTest.class,
     TransformerLogTest.class,
     TransformerDebugLogTest.class,
-    TransformerDebugTest.class,
+    LegacyTransformerDebugTest.class,
     
     TransformerConfigImplTest.class,
     TransformerConfigMBeanImplTest.class,


### PR DESCRIPTION
- Re factored TransformerDebug so the Legacy transform code has been extracted into
  LegacyTransformerDebug and code used by the Admin console's Test Transform that is
  not being deprecated has been extracted into AdminUiTransformerDebug
- Removed a few tests for a method that no longer supports specifying a transform name.
- All other changes are to handle the fact that the transformerDebug bean is now a
  LegacyTransformerDebug class and methods have been moved to sub classes.  