### PR TITLE
REPO-4794 - Remove library com.benfante:JSlideShare from alfresco-rep…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,11 +352,6 @@
             <version>0.9.1-patched</version>
         </dependency>
         <dependency>
-            <groupId>com.benfante</groupId>
-            <artifactId>JSlideShare</artifactId>
-            <version>0.6</version>
-        </dependency>
-        <dependency>
             <groupId>bsf</groupId>
             <artifactId>bsf</artifactId>
             <version>2.4.0</version>


### PR DESCRIPTION
…ository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

