### PR TITLE
REPO-4798 - Remove library org.apache.httpcomponents:httpclient-cache…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,11 +237,6 @@
             <version>1.6</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient-cache</artifactId>
-            <version>${dependency.httpcomponents.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20090211</version>


### PR DESCRIPTION
… from alfresco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

