### PR TITLE
REPO-4802 - Remove library cglib:cglib from alfresco-repository project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,11 +367,6 @@
             <version>1.0.0</version>
         </dependency>
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib</artifactId>
-            <version>3.3.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.29</version>


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

