### PR TITLE
REPO-4803 - Remove library net.java.dev.stax-utils:stax-utils from al…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,17 +423,6 @@
             <version>1.1.3</version>
         </dependency>
         <dependency>
-            <groupId>net.java.dev.stax-utils</groupId>
-            <artifactId>stax-utils</artifactId>
-            <version>20070216</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.bea.xml</groupId>
-                    <artifactId>jsr173-ri</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
             <version>2.3.20-alfresco-patched</version>


### PR DESCRIPTION
…fresco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

