### PR TITLE
REPO-4807 - Remove library net.sf.javamusictag:jid3lib from alfresco-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -532,11 +532,6 @@
             <version>3.0.1.1</version>
         </dependency>
         <dependency>
-            <groupId>net.sf.javamusictag</groupId>
-            <artifactId>jid3lib</artifactId>
-            <version>0.5.4</version>
-        </dependency>
-        <dependency>
             <groupId>jmagick</groupId>
             <artifactId>jmagick</artifactId>
             <version>6.6.9</version>


### PR DESCRIPTION
…repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

