### PR TITLE
REPO-4808 - Remove library com.google.gdata:gdata-docs-meta-3.0 from …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -688,11 +688,6 @@
         </dependency>
         <dependency>
             <groupId>com.google.gdata</groupId>
-            <artifactId>gdata-docs-meta-3.0</artifactId>
-            <version>1.47.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.gdata</groupId>
             <artifactId>gdata-youtube-2.0</artifactId>
             <version>1.47.1</version>
         </dependency>


### PR DESCRIPTION
…alfresco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

