### PR TITLE
REPO-4816 - Remove library edu.ucar:netcdf from alfresco-repository p…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -578,12 +578,6 @@
             <version>2.0.7</version>
         </dependency>
         <dependency>
-            <groupId>edu.ucar</groupId>
-            <artifactId>netcdf</artifactId>
-            <version>4.2.20</version>
-        </dependency>
-
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
             <version>1.2</version>


### PR DESCRIPTION
…roject
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

