### PR TITLE
REPO-4855 - Remove library com.beetstra.jutf7:jutf7 from alfresco-rep…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,11 +362,6 @@
             <version>2.4.0</version>
         </dependency>
         <dependency>
-            <groupId>com.beetstra.jutf7</groupId>
-            <artifactId>jutf7</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        <dependency>
             <groupId>cglib</groupId>
             <artifactId>cglib</artifactId>
             <version>3.3.0</version>

--- a/src/main/java/org/alfresco/util/Utf7.java
+++ b/src/main/java/org/alfresco/util/Utf7.java
@@ -29,8 +29,6 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 
-import com.beetstra.jutf7.CharsetProvider;
-
 /**
  * 
  * @author Mike Shavnev
@@ -56,8 +54,7 @@ public class Utf7
         {
             return string;
         }
-        CharsetProvider provider = new CharsetProvider();
-        Charset charset = provider.charsetForName(charsetName);
+        Charset charset = Charset.forName(charsetName);
         CharBuffer charBuffer = charset.decode(ByteBuffer.wrap(string.getBytes()));
         return charBuffer.toString();
     }
@@ -74,8 +71,7 @@ public class Utf7
         {
             return string;
         }
-        CharsetProvider provider = new CharsetProvider();
-        Charset charset = provider.charsetForName(charsetName);
+        Charset charset = Charset.forName(charsetName);
         ByteBuffer byteBuffer = charset.encode(string);
         return new String(byteBuffer.array()).substring(0, byteBuffer.limit());
     }


### PR DESCRIPTION
…ository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

