### PR TITLE
REPO-4856 - Remove library bsf:bsf from alfresco-repository project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,11 +357,6 @@
             <version>0.6</version>
         </dependency>
         <dependency>
-            <groupId>bsf</groupId>
-            <artifactId>bsf</artifactId>
-            <version>2.4.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.beetstra.jutf7</groupId>
             <artifactId>jutf7</artifactId>
             <version>1.0.0</version>

--- a/src/main/java/org/alfresco/repo/template/XSLTProcessor.java
+++ b/src/main/java/org/alfresco/repo/template/XSLTProcessor.java
@@ -55,7 +55,6 @@ import org.alfresco.service.cmr.repository.TemplateException;
 import org.alfresco.service.cmr.repository.TemplateProcessor;
 import org.alfresco.service.namespace.QName;
 import org.alfresco.util.XMLUtil;
-import org.apache.bsf.BSFManager;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -141,7 +140,7 @@ public class XSLTProcessor extends BaseProcessor implements TemplateProcessor
         }
 
         XSLTemplateModel xsltModel = (XSLTemplateModel) model;
-        System.setProperty("org.apache.xalan.extensions.bsf.BSFManager", BSFManager.class.getName());
+        System.setProperty("org.apache.xalan.extensions.bsf.BSFManager", "org.apache.bsf.BSFManager");
 
         Document xslTemplate;
         try


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

