### PR TITLE
REPO-4857 - Remove library org.apache.activemq:activemq-amqp from alf…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1013,21 +1013,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-amqp</artifactId>
-            <version>${dependency.activemq.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-pool</artifactId>
             <version>${dependency.activemq.version}</version>
             <exclusions>

--- a/src/main/java/org/alfresco/repo/rawevents/AbstractEventProducer.java
+++ b/src/main/java/org/alfresco/repo/rawevents/AbstractEventProducer.java
@@ -27,7 +27,6 @@ package org.alfresco.repo.rawevents;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.alfresco.error.AlfrescoRuntimeException;
-import org.apache.activemq.transport.amqp.message.AmqpMessageSupport;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.ProducerTemplate;
 import org.apache.commons.lang3.StringUtils;
@@ -52,6 +51,11 @@ import java.util.Map;
 public abstract class AbstractEventProducer
 {
     protected static final String ERROR_SENDING = "Could not send event";
+    public static final String JMS_AMQP_PREFIX = "JMS_AMQP_";
+
+    public static final String MESSAGE_FORMAT = "MESSAGE_FORMAT";
+    public static final String JMS_AMQP_MESSAGE_FORMAT = JMS_AMQP_PREFIX + MESSAGE_FORMAT;
+    public static final short AMQP_UNKNOWN = 0;
 
     protected ProducerTemplate producer;
     protected String endpoint;
@@ -79,7 +83,7 @@ public abstract class AbstractEventProducer
             origHeaders = new HashMap<>();
         }
 
-        origHeaders.put(AmqpMessageSupport.JMS_AMQP_MESSAGE_FORMAT, AmqpMessageSupport.AMQP_UNKNOWN);
+        origHeaders.put(JMS_AMQP_MESSAGE_FORMAT, AMQP_UNKNOWN);
         return origHeaders;
     }
 


### PR DESCRIPTION
…resco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

