### PR TITLE
REPO-4867 - Remove library org.apache.activemq:activemq-pool from alf…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1026,21 +1026,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-pool</artifactId>
-            <version>${dependency.activemq.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
         <!-- Transform dependencies -->
         <dependency>

--- a/src/main/java/lib3party/org/apache/activemq/pool/PooledConnection.java
+++ b/src/main/java/lib3party/org/apache/activemq/pool/PooledConnection.java
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
+ * provided under the following open source license terms:
+ * 
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package lib3party.org.apache.activemq.pool;
+
+import javax.jms.JMSException;
+import org.apache.activemq.ActiveMQConnection;
+import org.apache.activemq.EnhancedConnection;
+import org.apache.activemq.advisory.DestinationSource;
+import org.apache.activemq.jms.pool.ConnectionPool;
+
+public class PooledConnection extends org.apache.activemq.jms.pool.PooledConnection implements EnhancedConnection {
+    public PooledConnection(ConnectionPool connection) {
+        super(connection);
+    }
+
+    @Override
+    public DestinationSource getDestinationSource() throws JMSException {
+        return ((ActiveMQConnection)getConnection()).getDestinationSource();
+    }
+}
+

--- a/src/main/java/lib3party/org/apache/activemq/pool/PooledConnectionFactory.java
+++ b/src/main/java/lib3party/org/apache/activemq/pool/PooledConnectionFactory.java
@@ -1,0 +1,173 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
+ * provided under the following open source license terms:
+ * 
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package lib3party.org.apache.activemq.pool;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Properties;
+
+import javax.jms.Connection;
+import javax.naming.NamingException;
+import javax.naming.Reference;
+
+import org.apache.activemq.ActiveMQConnection;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.Service;
+import org.apache.activemq.jms.pool.ConnectionPool;
+import org.apache.activemq.jndi.JNDIReferenceFactory;
+import org.apache.activemq.jndi.JNDIStorableInterface;
+import org.apache.activemq.transport.TransportListener;
+import org.apache.activemq.util.IntrospectionSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Add Service and Referenceable and TransportListener to @link{org.apache.activemq.jms.pool.PooledConnectionFactory}
+ *
+ * @org.apache.xbean.XBean element="pooledConnectionFactory"
+ */
+public class PooledConnectionFactory extends org.apache.activemq.jms.pool.PooledConnectionFactory implements JNDIStorableInterface, Service {
+    public static final String POOL_PROPS_PREFIX = "pool";
+
+    private static final transient Logger LOG = LoggerFactory.getLogger(org.apache.activemq.jms.pool.PooledConnectionFactory.class);
+
+    public PooledConnectionFactory() {
+        super();
+    }
+
+    public PooledConnectionFactory(ActiveMQConnectionFactory activeMQConnectionFactory) {
+        setConnectionFactory(activeMQConnectionFactory);
+    }
+
+    public PooledConnectionFactory(String brokerURL) {
+        setConnectionFactory(new ActiveMQConnectionFactory(brokerURL));
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    protected void buildFromProperties(Properties props) {
+        ActiveMQConnectionFactory activeMQConnectionFactory = new ActiveMQConnectionFactory();
+        activeMQConnectionFactory.buildFromProperties(props);
+        setConnectionFactory(activeMQConnectionFactory);
+        IntrospectionSupport.setProperties(this, new HashMap(props), POOL_PROPS_PREFIX);
+    }
+
+    @Override
+    protected void populateProperties(Properties props) {
+        ((ActiveMQConnectionFactory)getConnectionFactory()).populateProperties(props);
+        super.populateProperties(props);
+    }
+
+    @Override
+    public void setProperties(Properties properties) {
+        buildFromProperties(properties);
+    }
+
+    @Override
+    public Properties getProperties() {
+        Properties properties = new Properties();
+        populateProperties(properties);
+        return properties;
+    }
+
+    @Override
+    public Reference getReference() throws NamingException {
+        return JNDIReferenceFactory.createReference(this.getClass().getName(), this);
+    }
+
+    @Override
+    protected Connection newPooledConnection(ConnectionPool connection) {
+        return new PooledConnection(connection);
+    }
+
+    @Override
+    protected org.apache.activemq.jms.pool.ConnectionPool createConnectionPool(Connection connection) {
+        return new ConnectionPool(connection) {
+
+            @Override
+            protected Connection wrap(final Connection connection) {
+                // Add a transport Listener so that we can notice if this connection
+                // should be expired due to a connection failure.
+                ((ActiveMQConnection)connection).addTransportListener(new TransportListener() {
+                    @Override
+                    public void onCommand(Object command) {
+                    }
+
+                    @Override
+                    public void onException(IOException error) {
+                        synchronized (this) {
+                            setHasExpired(true);
+                            // only log if not stopped
+                            if (!stopped.get()) {
+                                LOG.info("Expiring connection " + connection + " on IOException: " + error.getMessage());
+                                // log stacktrace at debug level
+                                LOG.debug("Expiring connection " + connection + " on IOException: ", error);
+                            }
+                        }
+                    }
+
+                    @Override
+                    public void transportInterupted() {
+                    }
+
+                    @Override
+                    public void transportResumed() {
+                    }
+                });
+
+                // make sure that we set the hasFailed flag, in case the transport already failed
+                // prior to the addition of our new TransportListener
+                setHasExpired(((ActiveMQConnection)connection).isTransportFailed());
+
+                // may want to return an amq EnhancedConnection
+                return connection;
+            }
+
+            @Override
+            protected void unWrap(Connection connection) {
+                if (connection != null) {
+                    ((ActiveMQConnection)connection).cleanUpTempDestinations();
+                }
+            }
+        };
+    }
+}

--- a/src/main/resources/alfresco/subsystems/Messaging/default/messaging-context.xml
+++ b/src/main/resources/alfresco/subsystems/Messaging/default/messaging-context.xml
@@ -19,7 +19,7 @@
         <constructor-arg value="java.lang.Object" />
     </bean>
 
-    <bean id="pooledConnectionFactory" class="org.apache.activemq.pool.PooledConnectionFactory"
+    <bean id="pooledConnectionFactory" class="lib3party.org.apache.activemq.pool.PooledConnectionFactory"
         init-method="start" destroy-method="stop">
         <property name="maxConnections" value="${messaging.broker.connections.max}" />
         <property name="connectionFactory" ref="activeMqConnectionFactory" />


### PR DESCRIPTION
…resco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

