### PR TITLE
REPO-4910 - Remove library com.fasterxml.jackson.core:jackson-core:no…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1087,6 +1087,12 @@
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-data-model</artifactId>
             <version>${dependency.alfresco-data-model.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>                
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…ne from alfresc-data-model
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.