### PR TITLE
REPO-4883 - Remove library xpp3:xpp3 from alfresco-data-model project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1035,7 +1035,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>xpp3</groupId>
+            <artifactId>xpp3</artifactId>
+            <version>1.1.4c</version>
+        </dependency>
+        
         <!-- Transform dependencies -->
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.