### PR TITLE
REPO-4886 - Remove library org.mybatis:mybatis from alfresco-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1035,6 +1035,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.mybatis</groupId>
+            <artifactId>mybatis</artifactId>
+            <version>3.3.0</version>
+        </dependency>        
 
         <!-- Transform dependencies -->
         <dependency>


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.