### PR TITLE
REPO-4805 - Remove library org.apache.pdfbox:jempbox from alfresco-re…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -460,11 +460,6 @@
             <version>${dependency.pdfbox.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>jempbox</artifactId>
-            <version>1.8.16</version>
-        </dependency>
-        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
             <version>1.64</version>


### PR DESCRIPTION
…pository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.