### PR TITLE
REPO-4806 - Remove library org.bouncycastle:bcmail-jdk15on from alfre…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,11 +470,6 @@
             <version>1.64</version>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcmail-jdk15on</artifactId>
-            <version>1.64</version>
-        </dependency>
-        <dependency>
             <groupId>com.googlecode.mp4parser</groupId>
             <artifactId>isoparser</artifactId>
             <version>1.1.22</version>


### PR DESCRIPTION
…sco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.