### PR TITLE
REPO-4753: removing googlecode isoparser dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ branches:
   only:
     - master
     - /support\/.*/
+    - fix/REPO-4753_removing-googlecode-isoparser-dependency
 
 stages:
   - test
@@ -120,7 +121,7 @@ jobs:
       script: travis_wait 20 mvn test -B -Dtest=AllDBTestsTestSuite -Ddb.name=alfresco -Ddb.url=jdbc:mariadb://localhost:3307/alfresco?useUnicode=yes\&characterEncoding=UTF-8 -Ddb.username=alfresco -Ddb.password=alfresco -Ddb.driver=org.mariadb.jdbc.Driver
     - stage: release
       name: "Push to Nexus"
-      if: fork = false AND (branch = master OR branch =~ /support\/.*/) AND type != pull_request AND commit_message !~ /\[no-release\]/
+      if: fork = false AND (branch = fix/REPO-4753_removing-googlecode-isoparser-dependency) AND type != pull_request AND commit_message !~ /\[no-release\]/
       before_install:
         - "cp .travis.settings.xml $HOME/.m2/settings.xml"
       script:
@@ -129,4 +130,4 @@ jobs:
         # Add email to link commits to user
         - git config user.email "${GIT_EMAIL}"
         # Skip building of release commits
-        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform
+        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests -DreleaseVersion=repo-4753-1 -DdevelopmentVersion=8.94-SNAPSHOT release:clean release:prepare release:perform

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ branches:
   only:
     - master
     - /support\/.*/
-    - fix/REPO-4753_removing-googlecode-isoparser-dependency
 
 stages:
   - test
@@ -121,7 +120,7 @@ jobs:
       script: travis_wait 20 mvn test -B -Dtest=AllDBTestsTestSuite -Ddb.name=alfresco -Ddb.url=jdbc:mariadb://localhost:3307/alfresco?useUnicode=yes\&characterEncoding=UTF-8 -Ddb.username=alfresco -Ddb.password=alfresco -Ddb.driver=org.mariadb.jdbc.Driver
     - stage: release
       name: "Push to Nexus"
-      if: fork = false AND (branch = fix/REPO-4753_removing-googlecode-isoparser-dependency) AND type != pull_request AND commit_message !~ /\[no-release\]/
+      if: fork = false AND (branch = master OR branch =~ /support\/.*/) AND type != pull_request AND commit_message !~ /\[no-release\]/
       before_install:
         - "cp .travis.settings.xml $HOME/.m2/settings.xml"
       script:
@@ -130,4 +129,4 @@ jobs:
         # Add email to link commits to user
         - git config user.email "${GIT_EMAIL}"
         # Skip building of release commits
-        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests -DreleaseVersion=repo-4753-1 -DdevelopmentVersion=8.94-SNAPSHOT release:clean release:prepare release:perform
+        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform

--- a/pom.xml
+++ b/pom.xml
@@ -419,11 +419,6 @@
             <version>1.64</version>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.mp4parser</groupId>
-            <artifactId>isoparser</artifactId>
-            <version>1.1.22</version>
-        </dependency>
-        <dependency>
             <groupId>net.sf</groupId>
             <artifactId>bliki</artifactId>
             <version>3.0.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>repo-4753-1</version>
+    <version>8.94-SNAPSHOT</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.alfresco</groupId>
@@ -14,7 +14,7 @@
         <connection>scm:git:https://github.com/Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>alfresco-repository-repo-4753-1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-repository</artifactId>
     <name>Alfresco Repository</name>
-    <version>8.94-SNAPSHOT</version>
+    <version>repo-4753-1</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.alfresco</groupId>
@@ -14,7 +14,7 @@
         <connection>scm:git:https://github.com/Alfresco/alfresco-repository.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/alfresco-repository.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-repository</url>
-        <tag>HEAD</tag>
+        <tag>alfresco-repository-repo-4753-1</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
This dependency **com.googlecode.mp4parser.isoparser** is not required in [alfresco-repository](https://github.com/Alfresco/alfresco-repository) project and may be source of potential conflicts when used in [alfresco-tika](https://github.com/Alfresco/alfresco-tika) project as describe in the associated ticket [repo-4753](https://issues.alfresco.com/jira/browse/REPO-4753).  

The library has been removed from the pom file and the builds on other projects depending on it have been tested:
 * [alfresco-repository](https://travis-ci.com/Alfresco/alfresco-repository/builds/146581358)
 * [alfresco-remote-api](https://travis-ci.com/Alfresco/alfresco-remote-api/builds/1466148)
 * [alfresco-enterprise-repository](https://travis-ci.com/Alfresco/alfresco-enterprise-repository/builds/146616654)
 * [alfresco-enterprise-remote-api](https://travis-ci.com/Alfresco/alfresco-enterprise-remote-api/builds/146617558)
 * [acs-packaging](https://travis-ci.com/Alfresco/acs-packaging/builds/146598473)
 * [acs-community-packaging](https://travis-ci.com/Alfresco/acs-community-packaging/builds/146597219)