### PR TITLE
MNT-18895: Extension of Behaviour Filter for Smart Folders

### DIFF
--- a/src/main/java/org/alfresco/repo/policy/BehaviourFilter.java
+++ b/src/main/java/org/alfresco/repo/policy/BehaviourFilter.java
@@ -25,7 +25,7 @@
  */
 package org.alfresco.repo.policy;
 
-import org.alfresco.api.AlfrescoPublicApi;  
+import org.alfresco.api.AlfrescoPublicApi;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.namespace.QName;
 

--- a/src/main/java/org/alfresco/repo/policy/BehaviourFilterImpl.java
+++ b/src/main/java/org/alfresco/repo/policy/BehaviourFilterImpl.java
@@ -28,6 +28,8 @@ package org.alfresco.repo.policy;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.alfresco.repo.policy.traitextender.BehaviourFilterExtension;
+import org.alfresco.repo.policy.traitextender.BehaviourFilterTrait;
 import org.alfresco.repo.tenant.TenantService;
 import org.alfresco.repo.transaction.AlfrescoTransactionSupport;
 import org.alfresco.repo.transaction.TransactionalResourceHelper;
@@ -36,6 +38,11 @@ import org.alfresco.service.cmr.dictionary.DictionaryService;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.namespace.QName;
 import org.apache.commons.lang.mutable.MutableInt;
+import org.alfresco.traitextender.AJProxyTrait;
+import org.alfresco.traitextender.Extend;
+import org.alfresco.traitextender.ExtendedTrait;
+import org.alfresco.traitextender.Extensible;
+import org.alfresco.traitextender.Trait;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.extensions.surf.util.ParameterCheck;
@@ -50,7 +57,7 @@ import org.springframework.extensions.surf.util.ParameterCheck;
  * 
  * @author Derek Hulley
  */
-public class BehaviourFilterImpl implements BehaviourFilter
+public class BehaviourFilterImpl implements BehaviourFilter, Extensible
 {
     private static final String KEY_FILTER_COUNT = "BehaviourFilterImpl.filterCount";
     private static final String KEY_GLOBAL_FILTERS = "BehaviourFilterImpl.globalFilters";
@@ -62,7 +69,15 @@ public class BehaviourFilterImpl implements BehaviourFilter
     
     private DictionaryService dictionaryService;
     private TenantService tenantService;
-    
+
+    private final ExtendedTrait<BehaviourFilterTrait> behaviourFilterTrait;
+
+    public BehaviourFilterImpl()
+    {
+        super();
+        this.behaviourFilterTrait = new ExtendedTrait<>(AJProxyTrait.create(this, BehaviourFilterTrait.class));
+    }
+
     /**
      * @param dictionaryService  dictionary service
      */    
@@ -82,6 +97,7 @@ public class BehaviourFilterImpl implements BehaviourFilter
     @Deprecated
     @Override
     // TODO
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public void enableBehaviours(NodeRef nodeRef)
     {
         enableBehaviour(nodeRef);
@@ -90,6 +106,7 @@ public class BehaviourFilterImpl implements BehaviourFilter
     @Deprecated
     @Override
     // TODO
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public void disableAllBehaviours()
     {
         disableBehaviour();
@@ -98,12 +115,14 @@ public class BehaviourFilterImpl implements BehaviourFilter
     @Deprecated
     @Override
     // TODO
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public void enableAllBehaviours()
     {
         enableBehaviour();
     }
 
     @Override
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public void disableBehaviour()
     {
         if (logger.isDebugEnabled())
@@ -122,12 +141,14 @@ public class BehaviourFilterImpl implements BehaviourFilter
     }
 
     @Override
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public void disableBehaviour(QName className)
     {
         disableBehaviour(className, false);
     }
 
     @Override
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public void disableBehaviour(QName className, boolean includeSubClasses)
     {
         if (logger.isDebugEnabled())
@@ -155,6 +176,7 @@ public class BehaviourFilterImpl implements BehaviourFilter
     }
 
     @Override
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public void disableBehaviour(NodeRef nodeRef, QName className)
     {
         ParameterCheck.mandatory("nodeRef",  nodeRef);
@@ -191,6 +213,7 @@ public class BehaviourFilterImpl implements BehaviourFilter
     }
 
     @Override
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public void disableBehaviour(NodeRef nodeRef)
     {
         ParameterCheck.mandatory("nodeRef",  nodeRef);
@@ -219,6 +242,7 @@ public class BehaviourFilterImpl implements BehaviourFilter
     }
 
     @Override
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public void enableBehaviour()
     {
         if (logger.isDebugEnabled())
@@ -237,6 +261,7 @@ public class BehaviourFilterImpl implements BehaviourFilter
     }
 
     @Override
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public void enableBehaviour(QName className)
     {
         ParameterCheck.mandatory("className", className);
@@ -284,6 +309,7 @@ public class BehaviourFilterImpl implements BehaviourFilter
     }
 
     @Override
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public void enableBehaviour(NodeRef nodeRef, QName className)
     {
         ParameterCheck.mandatory("nodeRef",  nodeRef);
@@ -332,6 +358,7 @@ public class BehaviourFilterImpl implements BehaviourFilter
     }
 
     @Override
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public void enableBehaviour(NodeRef nodeRef)
     {
         ParameterCheck.mandatory("nodeRef",  nodeRef);
@@ -373,6 +400,7 @@ public class BehaviourFilterImpl implements BehaviourFilter
     }
 
     @Override
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public boolean isEnabled()
     {
         return TransactionalResourceHelper.getCount(KEY_GLOBAL_FILTERS) <= 0;
@@ -395,6 +423,7 @@ public class BehaviourFilterImpl implements BehaviourFilter
     }
 
     @Override
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public boolean isEnabled(QName className)
     {
         ParameterCheck.mandatory("className", className);
@@ -475,6 +504,7 @@ public class BehaviourFilterImpl implements BehaviourFilter
     }
 
     @Override
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public boolean isEnabled(NodeRef nodeRef, QName className)
     {
         ParameterCheck.mandatory("nodeRef",  nodeRef);
@@ -518,6 +548,7 @@ public class BehaviourFilterImpl implements BehaviourFilter
     }
 
     @Override
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public boolean isEnabled(NodeRef nodeRef)
     {
         ParameterCheck.mandatory("nodeRef",  nodeRef);
@@ -546,8 +577,15 @@ public class BehaviourFilterImpl implements BehaviourFilter
     }
 
     @Override
+    @Extend(traitAPI = BehaviourFilterTrait.class, extensionAPI = BehaviourFilterExtension.class)
     public boolean isActivated()
     {
         return TransactionalResourceHelper.getCount(KEY_FILTER_COUNT) > 0;
+    }
+
+    @Override
+    public <M extends Trait> ExtendedTrait<M> getTrait(Class<? extends M> traitAPI)
+    {
+        return (ExtendedTrait<M>) behaviourFilterTrait;
     }
 }

--- a/src/main/java/org/alfresco/repo/policy/traitextender/BehaviourFilterExtension.java
+++ b/src/main/java/org/alfresco/repo/policy/traitextender/BehaviourFilterExtension.java
@@ -1,0 +1,36 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.repo.policy.traitextender;
+
+import org.alfresco.repo.policy.BehaviourFilter;
+
+/**
+ * @author Oussama Messeguem
+ */
+public interface BehaviourFilterExtension extends BehaviourFilter
+{
+}

--- a/src/main/java/org/alfresco/repo/policy/traitextender/BehaviourFilterTrait.java
+++ b/src/main/java/org/alfresco/repo/policy/traitextender/BehaviourFilterTrait.java
@@ -1,0 +1,37 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.repo.policy.traitextender;
+
+import org.alfresco.repo.policy.BehaviourFilter;
+import org.alfresco.traitextender.Trait;
+
+/**
+ * @author Oussama Messeguem
+ */
+public interface BehaviourFilterTrait extends Trait, BehaviourFilter
+{
+}

--- a/src/main/java/org/alfresco/repo/virtual/bundle/VirtualBehaviourFilterExtension.java
+++ b/src/main/java/org/alfresco/repo/virtual/bundle/VirtualBehaviourFilterExtension.java
@@ -1,0 +1,163 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.repo.virtual.bundle;
+
+import org.alfresco.repo.policy.traitextender.BehaviourFilterExtension;
+import org.alfresco.repo.policy.traitextender.BehaviourFilterTrait;
+import org.alfresco.repo.virtual.store.VirtualStore;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.namespace.QName;
+import org.alfresco.traitextender.SpringBeanExtension;
+
+/**
+ * Extends the disabling/enabling service when it comes to virtual nodes.
+ *
+ * @author Oussama Messeguem
+ */
+public class VirtualBehaviourFilterExtension
+        extends SpringBeanExtension<BehaviourFilterExtension, BehaviourFilterTrait>
+        implements BehaviourFilterExtension
+{
+
+    private VirtualStore smartStore;
+
+    public VirtualBehaviourFilterExtension()
+    {
+        super(BehaviourFilterTrait.class);
+    }
+
+    public void setSmartStore(VirtualStore smartStore)
+    {
+        this.smartStore = smartStore;
+    }
+
+    @Override
+    public void disableBehaviour(NodeRef nodeRef, QName className)
+    {
+        getTrait().disableBehaviour(smartStore.materializeIfPossible(nodeRef), className);
+    }
+
+    @Override
+    public void disableBehaviour(NodeRef nodeRef)
+    {
+        getTrait().disableBehaviour(smartStore.materializeIfPossible(nodeRef));
+    }
+
+    @Override
+    public void enableBehaviour(NodeRef nodeRef, QName className)
+    {
+        getTrait().enableBehaviour(smartStore.materializeIfPossible(nodeRef), className);
+    }
+
+    @Override
+    public void enableBehaviour(NodeRef nodeRef)
+    {
+        getTrait().enableBehaviour(smartStore.materializeIfPossible(nodeRef));
+    }
+
+    @Override
+    public boolean isEnabled(NodeRef nodeRef, QName className)
+    {
+        return getTrait().isEnabled(smartStore.materializeIfPossible(nodeRef), className);
+    }
+
+    @Override
+    public boolean isEnabled(NodeRef nodeRef)
+    {
+        return getTrait().isEnabled(smartStore.materializeIfPossible(nodeRef));
+    }
+
+    @Override
+    public void disableBehaviour()
+    {
+        getTrait().disableBehaviour();
+    }
+
+    @Override
+    public void disableBehaviour(QName className)
+    {
+        getTrait().disableBehaviour(className);
+    }
+
+    @Override
+    public void disableBehaviour(QName className, boolean includeSubClasses)
+    {
+        getTrait().disableBehaviour(className, includeSubClasses);
+    }
+
+    @Override
+    public void enableBehaviour()
+    {
+        getTrait().enableBehaviour();
+    }
+
+    @Override
+    public void enableBehaviour(QName className)
+    {
+        getTrait().enableBehaviour(className);
+    }
+
+    @Override
+    public boolean isEnabled()
+    {
+        return getTrait().isEnabled();
+    }
+
+    @Override
+    public boolean isEnabled(QName className)
+    {
+        return getTrait().isEnabled(className);
+    }
+
+    @Override
+    public boolean isActivated()
+    {
+        return getTrait().isActivated();
+    }
+
+    @Deprecated
+    @Override
+    public void enableBehaviours(NodeRef nodeRef)
+    {
+        getTrait().enableBehaviours(smartStore.materializeIfPossible(nodeRef));
+    }
+
+    @Deprecated
+    @Override
+    public void disableAllBehaviours()
+    {
+        getTrait().disableAllBehaviours();
+    }
+
+    @Deprecated
+    @Override
+    public void enableAllBehaviours()
+    {
+        getTrait().enableAllBehaviours();
+    }
+
+}

--- a/src/main/resources/alfresco/smartfolder-context.xml
+++ b/src/main/resources/alfresco/smartfolder-context.xml
@@ -234,6 +234,11 @@
       <property name="extensionPoint" ref="defaultCopyBehaviourCallbackExtensionPoint" />
    </bean>
 
+   <bean id="behaviourFilterExtension" class="org.alfresco.repo.virtual.bundle.VirtualBehaviourFilterExtension">
+      <property name="smartStore" ref="smartStore" />
+      <property name="extensionPoint" ref="behaviourFilterExtensionPoint" />
+   </bean>
+
    <!-- BUNDLE -->
 
    <bean id="smartFoldersBundle" class="org.alfresco.traitextender.SpringExtensionBundle">
@@ -252,6 +257,7 @@
             <ref bean="lockableAspectInterceptorExtension" />
             <ref bean="workflowPackageExtension" />
             <ref bean="defaultCopyBehaviourCallbackExtension" />
+            <ref bean="behaviourFilterExtension" />
          </list>
       </property>
    </bean>
@@ -311,6 +317,11 @@
    <bean id="defaultCopyBehaviourCallbackExtensionPoint" class="org.alfresco.traitextender.SpringExtensionPoint">
       <property name="extension" value="org.alfresco.repo.copy.traitextender.DefaultCopyBehaviourCallbackExtension" />
       <property name="trait" value="org.alfresco.repo.copy.traitextender.DefaultCopyBehaviourCallbackTrait" />
+   </bean>
+
+   <bean id="behaviourFilterExtensionPoint" class="org.alfresco.traitextender.SpringExtensionPoint">
+      <property name="extension" value="org.alfresco.repo.policy.traitextender.BehaviourFilterExtension" />
+      <property name="trait" value="org.alfresco.repo.policy.traitextender.BehaviourFilterTrait" />
    </bean>
 
 </beans>

--- a/src/test/java/org/alfresco/AppContextExtraTestSuite.java
+++ b/src/test/java/org/alfresco/AppContextExtraTestSuite.java
@@ -139,6 +139,7 @@ import org.junit.runners.Suite;
     org.alfresco.repo.virtual.config.NodeRefPathExpressionTest.class,
     org.alfresco.repo.virtual.template.TemplateFilingRuleTest.class,
     org.alfresco.repo.virtual.bundle.FileInfoPropsComparatorTest.class,
+    org.alfresco.repo.virtual.bundle.VirtualBehaviourFilterExtensionTest.class,
 
     // ----------------------------------------------------------------------
     // testSubscriptionsContext  [classpath:alfresco/application-context.xml, classpath:test/alfresco/test-subscriptions-context.xml]

--- a/src/test/java/org/alfresco/repo/virtual/VirtualizationIntegrationTest.java
+++ b/src/test/java/org/alfresco/repo/virtual/VirtualizationIntegrationTest.java
@@ -202,7 +202,7 @@ public abstract class VirtualizationIntegrationTest implements VirtualizationTes
     @Before
     public void setUp() throws Exception
     {
-        ctx = ApplicationContextHelper.getApplicationContext(CONFIG_LOCATIONS);
+        ctx = ApplicationContextHelper.getApplicationContext(CONFIG_LOCATIONS);;
         
         virtualizationConfigTestBootstrap = ctx.getBean(VIRTUALIZATION_CONFIG_TEST_BOOTSTRAP_BEAN_ID,
                                                         VirtualizationConfigTestBootstrap.class);

--- a/src/test/java/org/alfresco/repo/virtual/bundle/VirtualBehaviourFilterExtensionTest.java
+++ b/src/test/java/org/alfresco/repo/virtual/bundle/VirtualBehaviourFilterExtensionTest.java
@@ -1,0 +1,129 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.repo.virtual.bundle;
+
+import org.alfresco.model.ContentModel;
+import org.alfresco.repo.content.MimetypeMap;
+import org.alfresco.repo.policy.BehaviourFilter;
+import org.alfresco.repo.virtual.VirtualizationIntegrationTest;
+import org.alfresco.repo.virtual.ref.Reference;
+import org.alfresco.repo.virtual.store.VirtualStoreImpl;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class VirtualBehaviourFilterExtensionTest extends VirtualizationIntegrationTest
+{
+
+    NodeRef virtualNodeRef;
+    BehaviourFilter behaviourFilter;
+    VirtualStoreImpl smartStore;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        super.setUp();
+
+        behaviourFilter = ctx.getBean("policyBehaviourFilter", BehaviourFilter.class);
+        smartStore = ctx.getBean("smartStore", VirtualStoreImpl.class);
+
+        NodeRef nodeRef = nodeService.getChildByName(
+                virtualFolder1NodeRef,
+                ContentModel.ASSOC_CONTAINS,
+                "Node1");
+
+        virtualNodeRef = createContent(
+                nodeRef,
+                "actualContentName",
+                "0",
+                MimetypeMap.MIMETYPE_TEXT_PLAIN,
+                "UTF-8").getChildRef();
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        super.tearDown();
+    }
+
+    /**
+     * Checks the aspect auditable is enabled when asking for both actual and virtual nodes
+     */
+    @Test
+    public void auditableAspectOfActualNodesShouldBeEnableByDefault()
+    {
+        NodeRef actualNodeRef = smartStore.materialize(Reference.fromNodeRef(virtualNodeRef));
+
+        assertTrue("The auditable aspect for the actual node must be enabled by default",
+                behaviourFilter.isEnabled(actualNodeRef, ContentModel.ASPECT_AUDITABLE));
+
+        assertTrue("The auditable aspect must be enabled by default even when the virtual node is used",
+                behaviourFilter.isEnabled(virtualNodeRef, ContentModel.ASPECT_AUDITABLE));
+    }
+
+    /**
+     * Checks the disabling for a specific aspect
+     */
+    @Test
+    public void shouldDisbaleAuditableAspectForTheActualNode()
+    {
+        assertTrue("The auditable aspect must be enabled by default even when the virtual node is used, since it hasn't been disabled yet",
+                behaviourFilter.isEnabled(virtualNodeRef, ContentModel.ASPECT_AUDITABLE));
+
+        NodeRef actualNodeRef = smartStore.materialize(Reference.fromNodeRef(virtualNodeRef));
+
+        // Disable the aspect auditable using the virtual node
+        behaviourFilter.disableBehaviour(virtualNodeRef, ContentModel.ASPECT_AUDITABLE);
+
+        assertFalse("The auditable aspect for the actual node must not be enable since it has been disabled",
+                behaviourFilter.isEnabled(actualNodeRef, ContentModel.ASPECT_AUDITABLE));
+    }
+
+    /**
+     * Checks the disabling for the entire node
+     */
+    @Test
+    public void shouldDisableTheActualNode()
+    {
+        assertTrue("The node must be enabled by default even when the virtual node is used, since it hasn't been disabled yet",
+                behaviourFilter.isEnabled(virtualNodeRef));
+
+        NodeRef actualNodeRef = smartStore.materialize(Reference.fromNodeRef(virtualNodeRef));
+        assertTrue("The actual node must be enable since it hasn't been disabled yet",
+                behaviourFilter.isEnabled(actualNodeRef));
+
+        // Disabling the aspect auditable for the virtual node
+        behaviourFilter.disableBehaviour(virtualNodeRef);
+
+        assertFalse("The actual node must not be enable since it has been disabled",
+                behaviourFilter.isEnabled(actualNodeRef));
+    }
+}


### PR DESCRIPTION
The MNT-18895 ticket has highlighted the fact that behaviour filter service did not have an extension when it comes to smart folders.

The issue had to do with the creation of renditions as children of documents, when a document hasn't got any rendition yet, and the rendition is created as a new node from a smart folder, it is only the virtual node that gets its aspect cm:auditable disbaled and not the actual node linked to it.
The cm:auditable is responsible for certain updates of node's properties, in particular the properties cm:modifier and cm:modified.

This merge delivers an extension for behaviour filter service as it is the case already for other services (node, coci, lock, fileFolder..)

* Extension of the BehaviourFilter service for smart folders:
   - VirtualBehaviourFilterExtension: specific implementation of BehaviourFilter service, executed in smart folder context
   - BehaviourFilterExtension/BehaviourFilterTrait/annotations on top of override BehaviourFilterImpl methods: allow AOP mechanism
   - smartfolder-context: declaration of the new beans and injection into the virtualisation bundle
   - VirtualBehaviourFilterExtensionTest and AppContextExtraTestSuite: to ensure that the extension is used instead of the original implementation

(cherry picked from commit 9399a743fdae9d3be5fe688e7cca8a1249701d0a)