### PR TITLE
REPO-4753: removing googlecode isoparser dependency (#796)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,11 +466,6 @@
             <version>1.61</version>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.mp4parser</groupId>
-            <artifactId>isoparser</artifactId>
-            <version>1.1.22</version>
-        </dependency>
-        <dependency>
             <groupId>com.drewnoakes</groupId>
             <artifactId>metadata-extractor</artifactId>
             <version>2.10.1</version>


### PR DESCRIPTION
This dependency is not required in this project and triggers some conflicts in other projects (tika) due to the difference of versions.

(cherry picked from commit 77f08bd1430c6c867edfb0cb388b68e163a4cb54)