### PR TITLE
SEARCH-799 filtered results db (#290)

### DIFF
--- a/src/main/java/org/alfresco/repo/security/permissions/impl/acegi/WeakFilteringResultSet.java
+++ b/src/main/java/org/alfresco/repo/security/permissions/impl/acegi/WeakFilteringResultSet.java
@@ -1,0 +1,55 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.security.permissions.impl.acegi;
+
+import org.alfresco.service.cmr.search.ResultSet;
+
+import java.util.BitSet;
+
+/**
+ * WeakFilteringResultSet allows to add a filter to results without hiding the numberOfFound before filter is applied.
+ *
+ * @author eliaporciani
+ *
+ */
+public class WeakFilteringResultSet extends FilteringResultSet {
+    public WeakFilteringResultSet(ResultSet unfiltered) {
+        super(unfiltered);
+    }
+
+    public WeakFilteringResultSet(ResultSet unfiltered, BitSet inclusionMask) {
+        super(unfiltered, inclusionMask);
+    }
+
+    /**
+     * returns the total number of results found before the filter is applied.
+     */
+    @Override
+    public long getNumberFound()
+    {
+        return getUnFilteredResultSet().getNumberFound();
+    }
+}


### PR DESCRIPTION
* [SEARCH-799] Added WeakFilteringSetResult class. This type of filtering does not concerns permissions and allows to access to the tolal number of elements.

* [SEARCH-799] Added nested filter in. The inner one is for permission filtering and the outer one if for count filtering.
The change concerns the case of optimisePermissionsCheck=true.

* [SEARCH-799] Implemented double filtering when optimizePermission=false. Code refactoring.

* [SEARCH-799] Fix problem in resultSet.length() resulted in org.alfresco.opencmis.CMISTest#testQueryNodesWithCorruptedIndexes test.

* [SEARCH-799] Added unit test for pagination result.

* Syntax fixes.

* Removed import *.

* Set back system user as current user.

* [SEARCH-799] added Javadoc and some useful description in test methods.

* [SEARCH-799] Added javadoc

* [SEARCH-799] Code refactoring and some comments.

* [SEARCH-799] Code refactoring.

(cherry picked from commit 4ce947ab053d9b1fb0ecdd011d6e5628011473c4)