### PR TITLE
MNT-20933: Does noderef exist before updating rendition

### DIFF
--- a/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -787,7 +787,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
     @Override
     public void onContentUpdate(NodeRef sourceNodeRef, boolean newContent)
     {
-        if (isEnabled())
+        if (isEnabled() && nodeService.exists(sourceNodeRef))
         {
             logger.debug("onContentUpdate on " + sourceNodeRef);
             List<ChildAssociationRef> childAssocs = getRenditionChildAssociations(sourceNodeRef);

--- a/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -787,28 +787,35 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
     @Override
     public void onContentUpdate(NodeRef sourceNodeRef, boolean newContent)
     {
-        if (isEnabled() && nodeService.exists(sourceNodeRef))
+        if (isEnabled())
         {
-            logger.debug("onContentUpdate on " + sourceNodeRef);
-            List<ChildAssociationRef> childAssocs = getRenditionChildAssociations(sourceNodeRef);
-            for (ChildAssociationRef childAssoc : childAssocs)
+            if (nodeService.exists(sourceNodeRef))
             {
-                NodeRef renditionNodeRef = childAssoc.getChildRef();
-                // TODO: This check will not be needed once the original RenditionService is removed.
-                if (nodeService.hasAspect(renditionNodeRef, RenditionModel.ASPECT_RENDITION2))
+                logger.debug("onContentUpdate on " + sourceNodeRef);
+                List<ChildAssociationRef> childAssocs = getRenditionChildAssociations(sourceNodeRef);
+                for (ChildAssociationRef childAssoc : childAssocs)
                 {
-                    QName childAssocQName = childAssoc.getQName();
-                    String renditionName = childAssocQName.getLocalName();
-                    RenditionDefinition2 renditionDefinition = renditionDefinitionRegistry2.getRenditionDefinition(renditionName);
-                    if (renditionDefinition != null)
+                    NodeRef renditionNodeRef = childAssoc.getChildRef();
+                    // TODO: This check will not be needed once the original RenditionService is removed.
+                    if (nodeService.hasAspect(renditionNodeRef, RenditionModel.ASPECT_RENDITION2))
                     {
-                        render(sourceNodeRef, renditionName);
-                    }
-                    else
-                    {
-                        logger.debug("onContentUpdate rendition " + renditionName + " only exists in the original rendition service.");
+                        QName childAssocQName = childAssoc.getQName();
+                        String renditionName = childAssocQName.getLocalName();
+                        RenditionDefinition2 renditionDefinition = renditionDefinitionRegistry2.getRenditionDefinition(renditionName);
+                        if (renditionDefinition != null)
+                        {
+                            render(sourceNodeRef, renditionName);
+                        }
+                        else
+                        {
+                            logger.debug("onContentUpdate rendition " + renditionName + " only exists in the original rendition service.");
+                        }
                     }
                 }
+            }
+            else
+            {
+                logger.debug("onContentUpdate rendition " + sourceNodeRef + " does not exist.");
             }
         }
     }


### PR DESCRIPTION
In the context of creating renditions after updating nodes properties, a check of node's existence should be done because of the asynchronousity of renditions.

In the case of mnt-20933, after uploading a new version of the file:

- A new rendition is requested for the working copy because the properties of it have changed, the **request is asynchronous**.
- Then a check-in is processed which **deletes** the working copy noderef.
- Then the code for the new rendition is executed. At this stage, no working copy noderef and the message error _InvalidNodeRefException: Node does not exist_ is thrown.