### PR TITLE
MNT-20933: Does noderef exist before updating rendition (#865)

### DIFF
--- a/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -789,26 +789,33 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
     {
         if (isEnabled())
         {
-            logger.debug("onContentUpdate on " + sourceNodeRef);
-            List<ChildAssociationRef> childAssocs = getRenditionChildAssociations(sourceNodeRef);
-            for (ChildAssociationRef childAssoc : childAssocs)
+            if (nodeService.exists(sourceNodeRef))
             {
-                NodeRef renditionNodeRef = childAssoc.getChildRef();
-                // TODO: This check will not be needed once the original RenditionService is removed.
-                if (nodeService.hasAspect(renditionNodeRef, RenditionModel.ASPECT_RENDITION2))
+                logger.debug("onContentUpdate on " + sourceNodeRef);
+                List<ChildAssociationRef> childAssocs = getRenditionChildAssociations(sourceNodeRef);
+                for (ChildAssociationRef childAssoc : childAssocs)
                 {
-                    QName childAssocQName = childAssoc.getQName();
-                    String renditionName = childAssocQName.getLocalName();
-                    RenditionDefinition2 renditionDefinition = renditionDefinitionRegistry2.getRenditionDefinition(renditionName);
-                    if (renditionDefinition != null)
+                    NodeRef renditionNodeRef = childAssoc.getChildRef();
+                    // TODO: This check will not be needed once the original RenditionService is removed.
+                    if (nodeService.hasAspect(renditionNodeRef, RenditionModel.ASPECT_RENDITION2))
                     {
-                        render(sourceNodeRef, renditionName);
-                    }
-                    else
-                    {
-                        logger.debug("onContentUpdate rendition " + renditionName + " only exists in the original rendition service.");
+                        QName childAssocQName = childAssoc.getQName();
+                        String renditionName = childAssocQName.getLocalName();
+                        RenditionDefinition2 renditionDefinition = renditionDefinitionRegistry2.getRenditionDefinition(renditionName);
+                        if (renditionDefinition != null)
+                        {
+                            render(sourceNodeRef, renditionName);
+                        }
+                        else
+                        {
+                            logger.debug("onContentUpdate rendition " + renditionName + " only exists in the original rendition service.");
+                        }
                     }
                 }
+            }
+            else
+            {
+                logger.debug("onContentUpdate rendition " + sourceNodeRef + " does not exist.");
             }
         }
     }


### PR DESCRIPTION
* mnt-20933 Does noderef exist before updating rendition

In the context of creating renditions after updating nodes properties, a check of node's existence must be done because of the asynchronousity of renditions.

(cherry picked from commit 63b607770006c701ac6e2792276b8ef4b53c367e)