### PR TITLE
MNT-19773 : Marker aspects are not copied to the version store

### DIFF
--- a/src/main/java/org/alfresco/repo/version/VersionServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/version/VersionServiceImpl.java
@@ -1370,12 +1370,17 @@ public abstract class VersionServiceImpl extends AbstractVersionServiceImpl impl
             boolean wasMLAware = MLPropertyInterceptor.setMLAware(true);
             try
             {
-                // Copy the properties
+                // Copy the properties (along with their aspect)
                 Map<QName,PropertyDefinition> propertyDefinitions = classDefinition.getProperties();
                 for (QName propertyName : propertyDefinitions.keySet()) 
                 {
                     Serializable propValue = this.nodeService.getProperty(nodeRef, propertyName);
                     nodeDetails.addProperty(classRef, propertyName, propValue);
+                }
+                // Also copy the aspect with no properties in its definition
+                if (classDefinition.isAspect() && !nodeDetails.getAspects().contains(classRef))
+                {
+                    nodeDetails.addAspect(classRef);
                 }
             }
             finally

--- a/src/test/java/org/alfresco/repo/version/BaseVersionStoreTest.java
+++ b/src/test/java/org/alfresco/repo/version/BaseVersionStoreTest.java
@@ -110,6 +110,7 @@ public abstract class BaseVersionStoreTest extends BaseSpringTest
     protected static final QName TEST_TYPE_QNAME = QName.createQName(TEST_NAMESPACE, "testtype");
     protected static final QName TEST_TYPE_WITH_MANDATORY_ASPECT_QNAME = QName.createQName(TEST_NAMESPACE, "contentWithMandatoryAspect");
     protected static final QName TEST_MANDATORY_ASPECT_QNAME = QName.createQName(TEST_NAMESPACE, "mandatoryAspect");
+    protected static final QName TEST_MARKER_ASPECT_QNAME = QName.createQName(TEST_NAMESPACE, "markerAspect");
     protected static final QName TEST_ASPECT_QNAME = QName.createQName(TEST_NAMESPACE, "testaspect");
     protected static final QName PROP_1 = QName.createQName(TEST_NAMESPACE, "prop1");
     protected static final QName PROP_2 = QName.createQName(TEST_NAMESPACE, "prop2");

--- a/src/test/java/org/alfresco/repo/version/VersionServiceImplTest.java
+++ b/src/test/java/org/alfresco/repo/version/VersionServiceImplTest.java
@@ -680,6 +680,8 @@ public class VersionServiceImplTest extends BaseVersionStoreTest
     {
        // Create a versionable node
        NodeRef versionableNode = createNewVersionableNode();
+       // Add marker aspect on node
+       this.dbNodeService.addAspect(versionableNode, TEST_MARKER_ASPECT_QNAME, null);
 
        // Store the node details for later
        Set<QName> origAspects = this.dbNodeService.getAspects(versionableNode);
@@ -754,7 +756,9 @@ public class VersionServiceImplTest extends BaseVersionStoreTest
        // Check that the aspects have been reverted correctly
        Set<QName> aspects1 = this.dbNodeService.getAspects(versionableNode);
        assertEquals(aspects1.size(), origAspects2.size());
-       
+       // Verify marker aspect still exists on node after revert (MNT-19773)
+       assertTrue(aspects1.contains(TEST_MARKER_ASPECT_QNAME));
+
        // Check that the history is back how it was
        history = versionService.getVersionHistory(versionableNode);
        assertEquals(version2.getVersionLabel(), history.getHeadVersion().getVersionLabel());
@@ -787,6 +791,8 @@ public class VersionServiceImplTest extends BaseVersionStoreTest
        // Check that the aspects have been reverted correctly
        Set<QName> aspects2 = this.dbNodeService.getAspects(versionableNode);
        assertEquals(aspects2.size(), origAspects.size());
+       // Verify marker aspect still exists on node after revert (MNT-19773)
+       assertTrue(aspects2.contains(TEST_MARKER_ASPECT_QNAME));
 
        // Check that the version label is still the same
        assertEquals(versionLabel, this.dbNodeService.getProperty(versionableNode, ContentModel.PROP_VERSION_LABEL));

--- a/src/test/resources/org/alfresco/repo/version/VersionStoreBaseTest_model.xml
+++ b/src/test/resources/org/alfresco/repo/version/VersionStoreBaseTest_model.xml
@@ -173,6 +173,11 @@
           </properties>
        </aspect>
 
+       <aspect name="test:markerAspect">
+          <title>Marker Aspect</title>
+          <description>Test aspect with no properties</description>
+       </aspect>
+
     </aspects>
    
 </model>


### PR DESCRIPTION
   - copy marker aspects when creating node's version
   - add test marker aspect
   - add marker aspect checks on testRevert()