### PR TITLE
MNT-20764: Searches fail for users who are members of groups where the authorityName contains double quotes

### DIFF
--- a/src/main/java/org/alfresco/repo/security/authority/AuthorityServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/security/authority/AuthorityServiceImpl.java
@@ -89,6 +89,7 @@ public class AuthorityServiceImpl implements AuthorityService, InitializingBean
     private ClassPolicyDelegate<OnAuthorityRemovedFromGroup> onAuthorityRemovedFromGroup;
     private ClassPolicyDelegate<OnGroupDeleted> onGroupDeletedDelegate;
     private PolicyComponent policyComponent;
+    private static final char[] ILLEGAL_CHARACTERS = {'/', '\\', '\r', '\n', '\"', '\''};
 
     public AuthorityServiceImpl()
     {
@@ -644,7 +645,16 @@ public class AuthorityServiceImpl implements AuthorityService, InitializingBean
     {
         checkTypeIsMutable(type);
         String name = getName(type, shortName);
-
+        if (type == AuthorityType.GROUP)
+        {
+            for (char illegalCharacter : ILLEGAL_CHARACTERS)
+            {
+                if (name.indexOf(illegalCharacter) != -1)
+                {
+                    throw new AuthorityException("group name contains characters that are not permitted: "+name.charAt(name.indexOf(illegalCharacter)));
+                }
+            }
+        }
         authorityDAO.createAuthority(name, authorityDisplayName, authorityZones);
        
         return name;

--- a/src/main/java/org/alfresco/repo/security/authority/AuthorityServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/security/authority/AuthorityServiceImpl.java
@@ -89,7 +89,7 @@ public class AuthorityServiceImpl implements AuthorityService, InitializingBean
     private ClassPolicyDelegate<OnAuthorityRemovedFromGroup> onAuthorityRemovedFromGroup;
     private ClassPolicyDelegate<OnGroupDeleted> onGroupDeletedDelegate;
     private PolicyComponent policyComponent;
-    private static final char[] ILLEGAL_CHARACTERS = {'/', '\\', '\r', '\n', '\"', '\''};
+    private static final char[] ILLEGAL_CHARACTERS = {'/', '\\', '\r', '\n', '"'};
 
     public AuthorityServiceImpl()
     {

--- a/src/test/java/org/alfresco/repo/security/authority/AuthorityServiceTest.java
+++ b/src/test/java/org/alfresco/repo/security/authority/AuthorityServiceTest.java
@@ -365,9 +365,14 @@ public class AuthorityServiceTest extends TestCase
     @Category(RedundantTests.class)
     public void test_ETWOTWO_400()
     {
-        pubAuthorityService.createAuthority(AuthorityType.GROUP, "wo\"of");
-        Set<String> authorities = pubAuthorityService.findAuthorities(AuthorityType.GROUP, null, true, "wo\"of*", AuthorityService.ZONE_APP_DEFAULT);
-        assertEquals(1, authorities.size());
+        try {
+            pubAuthorityService.createAuthority(AuthorityType.GROUP, "wo\"of");
+        } catch (AuthorityException e) {
+            e.getMsgId();
+        } finally {
+            Set<String> authorities = pubAuthorityService.findAuthorities(AuthorityType.GROUP, null, true, "wo\"of*", AuthorityService.ZONE_APP_DEFAULT);
+            assertEquals(0, authorities.size());
+        }
     }
 
     @Category(RedundantTests.class)
@@ -1328,7 +1333,7 @@ public class AuthorityServiceTest extends TestCase
         assertEquals(2, pubAuthorityService.getContainedAuthorities(AuthorityType.GROUP, auth1234, false).size());
         assertEquals(1, pubAuthorityService.getContainedAuthorities(AuthorityType.GROUP, authC1, false).size());
         assertEquals(0, pubAuthorityService.getContainedAuthorities(AuthorityType.GROUP, authC2, false).size());
-        String authStuff = pubAuthorityService.createAuthority(AuthorityType.GROUP, "|<>?~@:}{+_)(*&^%$£!¬`,./#';][=-0987654321 1234556678 '");
+        String authStuff = pubAuthorityService.createAuthority(AuthorityType.GROUP, "|<>?~@:}{+_)(*&^%$£!¬`,.#';][=-0987654321 1234556678 '");
         pubAuthorityService.addAuthority(authC2, authStuff);
         assertEquals(3, pubAuthorityService.getContainedAuthorities(AuthorityType.GROUP, auth1234, false).size());
         assertEquals(2, pubAuthorityService.getContainedAuthorities(AuthorityType.GROUP, authC1, false).size());

--- a/src/test/java/org/alfresco/repo/security/authority/AuthorityServiceTest.java
+++ b/src/test/java/org/alfresco/repo/security/authority/AuthorityServiceTest.java
@@ -252,6 +252,20 @@ public class AuthorityServiceTest extends TestCase
         }
     }
 
+    public void testCreateAuthorityWithIllegalCharacters() throws Exception
+    {
+        char[] illegalCharacters = {'/', '\\', '\n', '\r', '"'};
+        for (char illegalCharacter : illegalCharacters)
+        {
+            String GROUP_NAME = "testGroupNameWith" + illegalCharacter;
+            try {
+                authorityService.createAuthority(AuthorityType.GROUP, GROUP_NAME);
+            } catch (AuthorityException e) {
+                assertEquals(e.getMsgId(), "group name contains characters that are not permitted: "+GROUP_NAME.charAt(GROUP_NAME.indexOf(illegalCharacter)));
+            }
+        }
+    }
+
     public class GroupBehaviour implements NodeServicePolicies.BeforeDeleteNodePolicy
     {
 


### PR DESCRIPTION
- Guard AuthorityServiceImpl against an array of illegal characters while creating group and added a test for it