### PR TITLE
REPO-4859 : HTTP_UNAUTHORIZED instead of HTTP_FORBIDDEN for some CMIS apis

### DIFF
--- a/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceImpl.java
+++ b/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceImpl.java
@@ -44,8 +44,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.http.HttpServletRequest;
 
-import net.sf.acegisecurity.Authentication;
-
 import org.alfresco.model.ContentModel;
 import org.alfresco.opencmis.dictionary.CMISNodeInfo;
 import org.alfresco.opencmis.dictionary.CMISObjectVariant;
@@ -136,12 +134,15 @@ import org.apache.chemistry.opencmis.commons.impl.server.AbstractCmisService;
 import org.apache.chemistry.opencmis.commons.impl.server.ObjectInfoImpl;
 import org.apache.chemistry.opencmis.commons.impl.server.RenditionInfoImpl;
 import org.apache.chemistry.opencmis.commons.server.CallContext;
+import org.apache.chemistry.opencmis.commons.server.MutableCallContext;
 import org.apache.chemistry.opencmis.commons.server.ObjectInfo;
 import org.apache.chemistry.opencmis.commons.server.RenditionInfo;
 import org.apache.chemistry.opencmis.commons.spi.Holder;
 import org.apache.chemistry.opencmis.server.shared.QueryStringHttpServletRequestWrapper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
+import net.sf.acegisecurity.Authentication;
 
 /**
  * OpenCMIS service implementation
@@ -176,7 +177,19 @@ public class AlfrescoCmisServiceImpl extends AbstractCmisService implements Alfr
     @Override
     public void open(CallContext context)
     {
-        AlfrescoCmisServiceCall.set(context);
+        if (context instanceof MutableCallContext)
+        {
+            MutableCallContext mutableCallContext = (MutableCallContext) context;
+            if (mutableCallContext.getUsername() == null && AuthenticationUtil.getFullyAuthenticatedUser() != null)
+            {
+                mutableCallContext.put(CallContext.USERNAME, AuthenticationUtil.getFullyAuthenticatedUser());
+            }
+            AlfrescoCmisServiceCall.set(mutableCallContext);
+        }
+        else
+        {
+            AlfrescoCmisServiceCall.set(context);
+        }
     }
     
     protected CallContext getContext()


### PR DESCRIPTION
    - updated code so the Context set includes the USERNAME field.
    - the missing of that field on the context was causing the CMIS lib to trigger a 401

## Long story short
The 401 is triggered at this line, because the username is empty.

<img width="814" alt="Screenshot 2020-04-09 at 13 45 38" src="https://user-images.githubusercontent.com/10231850/78887370-67824700-7a68-11ea-87b4-0e3d40121135.png">

The username is empty because it is never set. The created context is an instance of `BrowserCallContextImpl`. No piece of code/logic that is being executed is putting the `USERNAME` in the context.

The context is created as you can see below in `CmisBrowserBindingServlet`.

<img width="816" alt="Screenshot 2020-04-09 at 13 47 15" src="https://user-images.githubusercontent.com/10231850/78887495-a1534d80-7a68-11ea-9cac-85ca282ec881.png">

Immediately after the context is created the request is being dispatched.
After the dispatch, we have access through the Alfresco code to the context.

First in `AlfrescoCmisServiceFactory` which opens the service as per below.
<img width="778" alt="Screenshot 2020-04-09 at 13 50 07" src="https://user-images.githubusercontent.com/10231850/78887709-07d86b80-7a69-11ea-9fac-22efefa66428.png">

As the `AlfrescoCmisServiceFactory` is no place for modifying the context, I've added the fix logic in the `AlfrescoCmisServiceImpl` class.

It is in my opinion, the first moment when we can add this.
Before the context is created there is no way of 'forcing' the construction logic for the`BrowserCallContextImpl` to include the `USERNAME` field.

Therefor, this is why I think this is where the addition of the username should happen.