### PR TITLE
MNT-21417: LDAP Sync not working after making changes via admin UI

### DIFF
--- a/src/main/resources/alfresco/subsystems/Synchronization/default/default-synchronization-context.xml
+++ b/src/main/resources/alfresco/subsystems/Synchronization/default/default-synchronization-context.xml
@@ -9,7 +9,7 @@
         (e.g. LDAP directory)
     -->
 
-    <bean id="ldapSyncSchedulerAccessor" class="org.springframework.scheduling.quartz.SchedulerAccessorBean">
+    <bean id="ldapSyncSchedulerAccessor" class="org.alfresco.schedule.AlfrescoSchedulerAccessorBean">
         <property name="scheduler" ref="schedulerFactory"/>
         <property name="triggers">
             <list>
@@ -17,7 +17,7 @@
                     <property name="cronExpression" value="${synchronization.import.cron}"/>
                     <property name="startDelay" value="${system.cronJob.startDelayMilliseconds}"/>
                     <property name="jobDetail">
-                        <bean class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
+                        <bean id="ldapPeopleJobDetail" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
                             <property name="jobClass" value="org.alfresco.repo.security.sync.UserRegistrySynchronizerJob"/>
                             <property name="jobDataAsMap">
                                 <map>


### PR DESCRIPTION
Use `AlfrescoSchedulerAccessorBean` instead of `SchedulerAccessorBean`, to ensure the ldap sync job is unscheduled when the 'Synchronization' subsystem is restarted.
Add a bean name for the sync trigger job details - `ldapPeopleJobDetail`, this will appear as job name in Admin console > Scheduled Jobs.
