### PR TITLE
MNT-19887: Non-responsive SOLR address solr breaks admin console pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ jobs:
     - stage: test
       name: "AllUnitTestsSuite"
       script: mvn test -B -Dtest=AllUnitTestsSuite
+
     - name: "WhiteSource scan"
       # only on support branches or master and if it is not a PR
       if: fork = false AND (branch = master OR branch =~ /support\/SP\/.*/) AND type != pull_request
@@ -40,16 +41,19 @@ jobs:
         - curl -LJO https://github.com/whitesource/unified-agent-distribution/raw/v20.1.2/standAlone/wss-unified-agent-20.1.2.jar
         # Run WhiteSource Unified Agent
         - java -jar wss-unified-agent-20.1.2.jar -apiKey ${WHITESOURCE_API_KEY} -c .wss-unified-agent.config
+
     - name: "AppContext01TestSuite"
       before_install:
         - docker run -d -p 5433:5432 -e POSTGRES_PASSWORD=alfresco -e POSTGRES_USER=alfresco -e POSTGRES_DB=alfresco postgres:11.4 postgres -c 'max_connections=300'
         - docker run -d -p 61616:61616 -p 5672:5672 alfresco/alfresco-activemq:5.15.8
       script: travis_wait 20 mvn test -B -Dtest=AppContext01TestSuite -Ddb.driver=org.postgresql.Driver -Ddb.name=alfresco -Ddb.url=jdbc:postgresql://localhost:5433/alfresco -Ddb.username=alfresco -Ddb.password=alfresco
+
     - name: "AppContext02TestSuite"
       before_install:
         - docker run -d -p 5433:5432 -e POSTGRES_PASSWORD=alfresco -e POSTGRES_USER=alfresco -e POSTGRES_DB=alfresco postgres:11.4 postgres -c 'max_connections=300'
         - docker run -d -p 61616:61616 -p 5672:5672 alfresco/alfresco-activemq:5.15.8
       script: travis_wait 20 mvn test -B -Dtest=AppContext02TestSuite -Ddb.driver=org.postgresql.Driver -Ddb.name=alfresco -Ddb.url=jdbc:postgresql://localhost:5433/alfresco -Ddb.username=alfresco -Ddb.password=alfresco
+
     - name: "AppContext03TestSuite"
       before_install:
         - docker run -d -p 5433:5432 -e POSTGRES_PASSWORD=alfresco -e POSTGRES_USER=alfresco -e POSTGRES_DB=alfresco postgres:11.4 postgres -c 'max_connections=300'
@@ -60,6 +64,7 @@ jobs:
         - docker run -d -p 8093:8090 -e JAVA_OPTS=" -Xms256m -Xmx256m" alfresco/alfresco-tika:2.1.0-RC3
         - docker run -d -p 8094:8090 -e JAVA_OPTS=" -Xms256m -Xmx256m" alfresco/alfresco-transform-misc:2.1.0-RC3
       script: travis_wait 20 mvn test -B -Dtest=AppContext03TestSuite -Ddb.driver=org.postgresql.Driver -Ddb.name=alfresco -Ddb.url=jdbc:postgresql://localhost:5433/alfresco -Ddb.username=alfresco -Ddb.password=alfresco -Dalfresco-pdf-renderer.url=http://localhost:8090/ -Djodconverter.url=http://localhost:8092/ -Dimg.url=http://localhost:8091/ -Dtika.url=http://localhost:8093/ -Dtransform.misc.url=http://localhost:8094/
+
     - name: "AppContext04TestSuite"
       before_install:
         - docker run -d -p 5433:5432 -e POSTGRES_PASSWORD=alfresco -e POSTGRES_USER=alfresco -e POSTGRES_DB=alfresco postgres:11.4 postgres -c 'max_connections=300'
@@ -70,11 +75,13 @@ jobs:
         - docker run -d -p 8093:8090 -e JAVA_OPTS=" -Xms256m -Xmx256m" alfresco/alfresco-tika:2.1.0-RC3
         - docker run -d -p 8094:8090 -e JAVA_OPTS=" -Xms256m -Xmx256m" alfresco/alfresco-transform-misc:2.1.0-RC3
       script: travis_wait 20 mvn test -B -Dtest=AppContext04TestSuite -Ddb.driver=org.postgresql.Driver -Ddb.name=alfresco -Ddb.url=jdbc:postgresql://localhost:5433/alfresco -Ddb.username=alfresco -Ddb.password=alfresco
+
     - name: "AppContext05TestSuite"
       before_install:
         - docker run -d -p 5433:5432 -e POSTGRES_PASSWORD=alfresco -e POSTGRES_USER=alfresco -e POSTGRES_DB=alfresco postgres:11.4 postgres -c 'max_connections=300'
         - docker run -d -p 61616:61616 -p 5672:5672 alfresco/alfresco-activemq:5.15.8
       script: travis_wait 20 mvn test -B -Dtest=AppContext05TestSuite -Ddb.driver=org.postgresql.Driver -Ddb.name=alfresco -Ddb.url=jdbc:postgresql://localhost:5433/alfresco -Ddb.username=alfresco -Ddb.password=alfresco
+
     - name: "AppContext06TestSuite"
       before_install:
         - docker run -d -p 5433:5432 -e POSTGRES_PASSWORD=alfresco -e POSTGRES_USER=alfresco -e POSTGRES_DB=alfresco postgres:11.4 postgres -c 'max_connections=300'
@@ -85,11 +92,13 @@ jobs:
         - docker run -d -p 8093:8090 -e JAVA_OPTS=" -Xms256m -Xmx256m" alfresco/alfresco-tika:2.1.0-RC3
         - docker run -d -p 8094:8090 -e JAVA_OPTS=" -Xms256m -Xmx256m" alfresco/alfresco-transform-misc:2.1.0-RC3
       script: travis_wait 20 mvn test -B -Dtest=AppContext06TestSuite -Ddb.driver=org.postgresql.Driver -Ddb.name=alfresco -Ddb.url=jdbc:postgresql://localhost:5433/alfresco -Ddb.username=alfresco -Ddb.password=alfresco -Dalfresco-pdf-renderer.url=http://localhost:8090/ -Djodconverter.url=http://localhost:8092/ -Dimg.url=http://localhost:8091/ -Dtika.url=http://localhost:8093/ -Dtransform.misc.url=http://localhost:8094/
+
     - name: "AppContextExtraTestSuite"
       before_install:
         - docker run -d -p 5433:5432 -e POSTGRES_PASSWORD=alfresco -e POSTGRES_USER=alfresco -e POSTGRES_DB=alfresco postgres:11.4 postgres -c 'max_connections=300'
         - docker run -d -p 61616:61616 -p 5672:5672 alfresco/alfresco-activemq:5.15.8
       script: travis_wait 20 mvn test -B -Dtest=AppContextExtraTestSuite -Ddb.driver=org.postgresql.Driver -Ddb.name=alfresco -Ddb.url=jdbc:postgresql://localhost:5433/alfresco -Ddb.username=alfresco -Ddb.password=alfresco
+
     - name: "MiscContextTestSuite"
       before_install:
         - docker run -d -p 5433:5432 -e POSTGRES_PASSWORD=alfresco -e POSTGRES_USER=alfresco -e POSTGRES_DB=alfresco postgres:11.4 postgres -c 'max_connections=300'
@@ -100,26 +109,31 @@ jobs:
         - docker run -d -p 8093:8090 -e JAVA_OPTS=" -Xms256m -Xmx256m" alfresco/alfresco-tika:2.1.0-RC3
         - docker run -d -p 8094:8090 -e JAVA_OPTS=" -Xms256m -Xmx256m" alfresco/alfresco-transform-misc:2.1.0-RC3
       script: travis_wait 20 mvn test -B -Dtest=MiscContextTestSuite -Ddb.driver=org.postgresql.Driver -Ddb.name=alfresco -Ddb.url=jdbc:postgresql://localhost:5433/alfresco -Ddb.username=alfresco -Ddb.password=alfresco -Dalfresco-pdf-renderer.url=http://localhost:8090/ -Djodconverter.url=http://localhost:8092/ -Dimg.url=http://localhost:8091/ -Dtika.url=http://localhost:8093/ -Dtransform.misc.url=http://localhost:8094/
+
     - name: "MySQL tests"
       before_install:
         - docker run -d -p 3307:3306 -e MYSQL_ROOT_PASSWORD=alfresco -e MYSQL_USER=alfresco -e MYSQL_DATABASE=alfresco -e MYSQL_PASSWORD=alfresco  mysql:5.7.23 --transaction-isolation='READ-COMMITTED'
         - docker run -d -p 61616:61616 -p 5672:5672 alfresco/alfresco-activemq:5.15.8
       script: travis_wait 20 mvn test -B -Dtest=AllDBTestsTestSuite -Ddb.driver=com.mysql.jdbc.Driver -Ddb.name=alfresco -Ddb.url=jdbc:mysql://localhost:3307/alfresco -Ddb.username=alfresco -Ddb.password=alfresco
+
     - name: "PostgreSQL 10 tests"
       before_install:
         - docker run -d -p 5433:5432 -e POSTGRES_PASSWORD=alfresco -e POSTGRES_USER=alfresco -e POSTGRES_DB=alfresco postgres:10.9 postgres -c 'max_connections=300'
         - docker run -d -p 61616:61616 -p 5672:5672 alfresco/alfresco-activemq:5.15.8
       script: travis_wait 20 mvn test -B -Dtest=AllDBTestsTestSuite -Ddb.driver=org.postgresql.Driver -Ddb.name=alfresco -Ddb.url=jdbc:postgresql://localhost:5433/alfresco -Ddb.username=alfresco -Ddb.password=alfresco
+
     - name: "PostgreSQL 11 tests"
       before_install:
         - docker run -d -p 5433:5432 -e POSTGRES_PASSWORD=alfresco -e POSTGRES_USER=alfresco -e POSTGRES_DB=alfresco postgres:11.4 postgres -c 'max_connections=300'
         - docker run -d -p 61616:61616 -p 5672:5672 alfresco/alfresco-activemq:5.15.8
       script: travis_wait 20 mvn test -B -Dtest=AllDBTestsTestSuite -Ddb.driver=org.postgresql.Driver -Ddb.name=alfresco -Ddb.url=jdbc:postgresql://localhost:5433/alfresco -Ddb.username=alfresco -Ddb.password=alfresco
+
     - name: "MariaDB tests"
       before_install:
         - docker run -d -p 3307:3306 --name mariadb -e MYSQL_ROOT_PASSWORD=alfresco -e MYSQL_USER=alfresco -e MYSQL_DATABASE=alfresco -e MYSQL_PASSWORD=alfresco mariadb:10.2.18 --transaction-isolation=READ-COMMITTED --max-connections=300 --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
         - docker run -d -p 61616:61616 -p 5672:5672 alfresco/alfresco-activemq:5.15.8
       script: travis_wait 20 mvn test -B -Dtest=AllDBTestsTestSuite -Ddb.name=alfresco -Ddb.url=jdbc:mariadb://localhost:3307/alfresco?useUnicode=yes\&characterEncoding=UTF-8 -Ddb.username=alfresco -Ddb.password=alfresco -Ddb.driver=org.mariadb.jdbc.Driver
+
     - stage: release
       name: "Push to Nexus"
       if: fork = false AND (branch = master OR branch =~ /support\/.*/) AND type != pull_request AND commit_message !~ /\[no-release\]/

--- a/src/main/java/org/alfresco/repo/search/impl/solr/AbstractSolrAdminHTTPClient.java
+++ b/src/main/java/org/alfresco/repo/search/impl/solr/AbstractSolrAdminHTTPClient.java
@@ -4,40 +4,47 @@
  * %%
  * Copyright (C) 2005 - 2016 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
 package org.alfresco.repo.search.impl.solr;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.commons.httpclient.HttpStatus.SC_MOVED_PERMANENTLY;
+import static org.apache.commons.httpclient.HttpStatus.SC_MOVED_TEMPORARILY;
+import static org.apache.commons.httpclient.HttpStatus.SC_OK;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
-
-import javax.servlet.http.HttpServletResponse;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeoutException;
 
 import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.repo.search.impl.lucene.LuceneQueryParserException;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.HttpMethod;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.json.JSONException;
@@ -47,58 +54,89 @@ import org.json.JSONTokener;
 /**
  * HTTP Client providing GET invocations to SOLR.
  * These invocations are used for the SOLR CoreAdmin API and for the SOLR Backup API.
- * 
+ *
  * @author aborroy
  * @since 6.2
- *
  */
 public abstract class AbstractSolrAdminHTTPClient
 {
-    
-    /**
-     * Executes an action or a command in SOLR using REST API 
-     * 
-     * @param httpClient HTTP Client to be used for the invocation
-     * @param url Complete URL of SOLR REST API Endpoint
-     * @return A JSON Object including SOLR response
-     * @throws UnsupportedEncodingException
-     */
-    protected JSONObject getOperation(HttpClient httpClient, String url) throws UnsupportedEncodingException 
-    {
+    protected ExecutorService threadPoolExecutor;
+    protected int solrConnectTimeout;
 
-        GetMethod get = new GetMethod(url);
-        
-        try {
-            
-            httpClient.executeMethod(get);
-            if(get.getStatusCode() == HttpStatus.SC_MOVED_PERMANENTLY || get.getStatusCode() == HttpStatus.SC_MOVED_TEMPORARILY)
+    /**
+     * Executes an action or a command in SOLR using REST API
+     *
+     * @param httpClient HTTP Client to be used for the invocation
+     * @param url        Complete URL of SOLR REST API Endpoint
+     * @return A JSON Object including SOLR response
+     */
+    protected JSONObject getOperation(HttpClient httpClient, String url)
+    {
+        final GetMethod get = getMethod(url);
+        try
+        {
+            int status = executeWithTimeout(httpClient, get);
+            if (status == SC_MOVED_PERMANENTLY || status == SC_MOVED_TEMPORARILY)
             {
-                Header locationHeader = get.getResponseHeader("location");
+                final Header locationHeader = get.getResponseHeader("location");
                 if (locationHeader != null)
                 {
-                    String redirectLocation = locationHeader.getValue();
+                    final String redirectLocation = locationHeader.getValue();
                     get.setURI(new URI(redirectLocation, true));
-                    httpClient.executeMethod(get);
+                    status = executeWithTimeout(httpClient, get);
                 }
             }
-            if (get.getStatusCode() != HttpServletResponse.SC_OK)
+            if (status != SC_OK)
             {
-                throw new LuceneQueryParserException("Request failed " + get.getStatusCode() + " " + url.toString());
+                throw new LuceneQueryParserException("Request failed " + status + " " + url);
             }
 
-            Reader reader = new BufferedReader(new InputStreamReader(get.getResponseBodyAsStream(), get.getResponseCharSet()));
-            JSONObject json = new JSONObject(new JSONTokener(reader));
-            return json;
-            
+            final Reader reader = new BufferedReader(new InputStreamReader(
+                get.getResponseBodyAsStream(), get.getResponseCharSet()));
+            // TODO - replace with streaming-based solution e.g. SimpleJSON ContentHandler
+            return new JSONObject(new JSONTokener(reader));
         }
-        catch (IOException | JSONException e) 
+        catch (TimeoutException e)
+        {
+            get.abort();
+            throw new AlfrescoRuntimeException("SOLR REST API timeout (remote port may be invalid or " +
+                                               "filtered by a firewall): " + e.getMessage(), e);
+        }
+        catch (IOException | JSONException e)
         {
             throw new AlfrescoRuntimeException(e.getMessage(), e);
-        } 
-        finally 
+        }
+        finally
         {
             get.releaseConnection();
         }
     }
 
+    private int executeWithTimeout(final HttpClient httpClient, final HttpMethod httpMethod) throws TimeoutException
+    {
+        final Future<Integer> future = threadPoolExecutor.submit(() -> httpClient.executeMethod(httpMethod));
+        try
+        {
+            return future.get(solrConnectTimeout, MILLISECONDS);
+        }
+        catch (InterruptedException | ExecutionException e)
+        {
+            throw new AlfrescoRuntimeException(e.getMessage(), e);
+        }
+    }
+
+    public void setThreadPoolExecutor(ThreadPoolExecutor threadPoolExecutor)
+    {
+        this.threadPoolExecutor = threadPoolExecutor;
+    }
+
+    public void setSolrConnectTimeout(int solrConnectTimeout)
+    {
+        this.solrConnectTimeout = solrConnectTimeout;
+    }
+
+    protected GetMethod getMethod(final String url)
+    {
+        return new GetMethod(url);
+    }
 }

--- a/src/main/java/org/alfresco/repo/search/impl/solr/SolrAdminHTTPClient.java
+++ b/src/main/java/org/alfresco/repo/search/impl/solr/SolrAdminHTTPClient.java
@@ -4,91 +4,57 @@
  * %%
  * Copyright (C) 2005 - 2016 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
 package org.alfresco.repo.search.impl.solr;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletResponse;
-
-import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.httpclient.HttpClientFactory;
-import org.alfresco.repo.domain.node.NodeDAO;
 import org.alfresco.repo.search.impl.lucene.LuceneQueryParserException;
-import org.alfresco.repo.search.impl.lucene.SolrJSONResultSet;
-import org.alfresco.service.cmr.repository.datatype.DefaultTypeConverter;
-import org.alfresco.service.cmr.search.ResultSet;
-import org.alfresco.service.cmr.search.SearchParameters;
-import org.alfresco.service.cmr.search.SearchParameters.FieldFacet;
-import org.alfresco.service.cmr.search.SearchParameters.FieldFacetMethod;
-import org.alfresco.service.cmr.search.SearchParameters.FieldFacetSort;
-import org.alfresco.service.cmr.search.SearchParameters.SortDefinition;
-import org.alfresco.service.cmr.security.PermissionService;
 import org.alfresco.util.ParameterCheck;
 import org.apache.commons.codec.net.URLCodec;
-import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
 import org.apache.commons.httpclient.auth.AuthScope;
-import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
-import org.apache.commons.httpclient.methods.GetMethod;
-import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.params.HttpClientParams;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
-import org.json.JSONTokener;
-import org.springframework.extensions.surf.util.I18NUtil;
 
 /**
  * @author Andy
  */
-public class SolrAdminHTTPClient
+public class SolrAdminHTTPClient extends AbstractSolrAdminHTTPClient
 {
-    static Log s_logger = LogFactory.getLog(SolrAdminHTTPClient.class);
-
     private String adminUrl;
-    
+
     private String baseUrl;
 
     private HttpClient httpClient;
-	private HttpClientFactory httpClientFactory;
-	
+    private HttpClientFactory httpClientFactory;
+
     public SolrAdminHTTPClient()
     {
     }
 
-    
     public void setBaseUrl(String baseUrl)
     {
         this.baseUrl = baseUrl;
@@ -97,105 +63,37 @@ public class SolrAdminHTTPClient
     public void init()
     {
         ParameterCheck.mandatory("baseUrl", baseUrl);
-        
-    	StringBuilder sb = new StringBuilder();
-    	sb.append(baseUrl + "/admin/cores");
-    	this.adminUrl = sb.toString();
 
-    	httpClient = httpClientFactory.getHttpClient();
-    	HttpClientParams params = httpClient.getParams();
-    	params.setBooleanParameter(HttpClientParams.PREEMPTIVE_AUTHENTICATION, true);
-    	httpClient.getState().setCredentials(new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT), new UsernamePasswordCredentials("admin", "admin"));
+        adminUrl = baseUrl + "/admin/cores";
+
+        httpClient = httpClientFactory.getHttpClient();
+        HttpClientParams params = httpClient.getParams();
+        params.setBooleanParameter(HttpClientParams.PREEMPTIVE_AUTHENTICATION, true);
+        httpClient.getState().setCredentials(new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT),
+            new UsernamePasswordCredentials("admin", "admin"));
     }
 
     public void setHttpClientFactory(HttpClientFactory httpClientFactory)
-	{
-		this.httpClientFactory = httpClientFactory;
-	}
+    {
+        this.httpClientFactory = httpClientFactory;
+    }
 
-    public JSONObject execute(HashMap<String, String> args)
+    public JSONObject execute(Map<String, String> args)
     {
         return execute(adminUrl, args);
     }
 
-    public JSONObject execute(String relativeHandlerPath, HashMap<String, String> args)
+    public JSONObject execute(String relativeHandlerPath, Map<String, String> args)
     {
         ParameterCheck.mandatory("relativeHandlerPath", relativeHandlerPath);
         ParameterCheck.mandatory("args", args);
 
-        String path = getPath(relativeHandlerPath);
+        final String path = getPath(relativeHandlerPath);
         try
         {
-            URLCodec encoder = new URLCodec();
-            StringBuilder url = new StringBuilder();
-
-            for (String key : args.keySet())
-            {
-                String value = args.get(key);
-                if (url.length() == 0)
-                {
-                    url.append(path);
-                    url.append("?");
-                    url.append(encoder.encode(key, "UTF-8"));
-                    url.append("=");
-                    url.append(encoder.encode(value, "UTF-8"));
-                }
-                else
-                {
-                    url.append("&");
-                    url.append(encoder.encode(key, "UTF-8"));
-                    url.append("=");
-                    url.append(encoder.encode(value, "UTF-8"));
-                }
-
-            }
-
-            // PostMethod post = new PostMethod(url.toString());
-            GetMethod get = new GetMethod(url.toString());
-
-            try
-            {
-                httpClient.executeMethod(get);
-
-                if (get.getStatusCode() == HttpStatus.SC_MOVED_PERMANENTLY || get.getStatusCode() == HttpStatus.SC_MOVED_TEMPORARILY)
-                {
-                    Header locationHeader = get.getResponseHeader("location");
-                    if (locationHeader != null)
-                    {
-                        String redirectLocation = locationHeader.getValue();
-                        get.setURI(new URI(redirectLocation, true));
-                        httpClient.executeMethod(get);
-                    }
-                }
-
-                if (get.getStatusCode() != HttpServletResponse.SC_OK)
-                {
-                    throw new LuceneQueryParserException("Request failed " + get.getStatusCode() + " " + url.toString());
-                }
-
-                Reader reader = new BufferedReader(new InputStreamReader(get.getResponseBodyAsStream()));
-                // TODO - replace with streaming-based solution e.g. SimpleJSON ContentHandler
-                JSONObject json = new JSONObject(new JSONTokener(reader));
-                return json;
-            }
-            finally
-            {
-                get.releaseConnection();
-            }
-        }
-        catch (UnsupportedEncodingException e)
-        {
-            throw new LuceneQueryParserException("", e);
-        }
-        catch (HttpException e)
-        {
-            throw new LuceneQueryParserException("", e);
+            return getOperation(httpClient, buildUrl(path, args));
         }
         catch (IOException e)
-        {
-            throw new LuceneQueryParserException("", e);
-        }
-        catch (JSONException e)
         {
             throw new LuceneQueryParserException("", e);
         }
@@ -207,14 +105,38 @@ public class SolrAdminHTTPClient
         {
             return path;
         }
-        else if (path.startsWith("/"))
+        if (path.startsWith("/"))
         {
             return baseUrl + path;
         }
-        else
-        {
-            return baseUrl + '/' + path;
-        }
+        return baseUrl + '/' + path;
     }
 
+    private static String buildUrl(final String path, final Map<String, String> args)
+        throws UnsupportedEncodingException
+    {
+        final URLCodec encoder = new URLCodec();
+        final StringBuilder url = new StringBuilder();
+
+        for (String key : args.keySet())
+        {
+            String value = args.get(key);
+            if (url.length() == 0)
+            {
+                url.append(path)
+                   .append("?")
+                   .append(encoder.encode(key, "UTF-8"))
+                   .append("=")
+                   .append(encoder.encode(value, "UTF-8"));
+            }
+            else
+            {
+                url.append("&")
+                   .append(encoder.encode(key, "UTF-8"))
+                   .append("=")
+                   .append(encoder.encode(value, "UTF-8"));
+            }
+        }
+        return url.toString();
+    }
 }

--- a/src/main/java/org/alfresco/repo/search/impl/solr/SolrChildApplicationContextFactory.java
+++ b/src/main/java/org/alfresco/repo/search/impl/solr/SolrChildApplicationContextFactory.java
@@ -4,345 +4,292 @@
  * %%
  * Copyright (C) 2005 - 2016 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
 package org.alfresco.repo.search.impl.solr;
 
-import java.util.HashMap;
-import java.util.HashSet;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Stream.concat;
+
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.TimeoutException;
 
+import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.repo.management.subsystems.ChildApplicationContextFactory;
-import org.alfresco.repo.search.impl.lucene.LuceneQueryParserException;
-import org.alfresco.service.cmr.repository.datatype.Duration;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.context.ApplicationContext;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * @author Andy
  */
 public class SolrChildApplicationContextFactory extends ChildApplicationContextFactory
 {
+    //region Static Fields
+    private static final String ALFRESCO_ACTIVE = "tracker.alfresco.active";
+    private static final String ALFRESCO_LAG = "tracker.alfresco.lag";
+    private static final String ALFRESCO_LAG_DURATION = "tracker.alfresco.lag.duration";
+    private static final String ALFRESCO_LAST_INDEXED_TXN = "tracker.alfresco.last.indexed.txn";
+    private static final String ALFRESCO_APPROX_TXNS_REMAINING = "tracker.alfresco.approx.txns.remaining";
+    private static final String ALFRESCO_APPROX_INDEXING_TIME_REMAINING = "tracker.alfresco.approx.indexing.time.remaining";
+    private static final String ALFRESCO_DISK = "tracker.alfresco.disk";
+    private static final String ALFRESCO_MEMORY = "tracker.alfresco.memory";
 
-    private static String ALFRESCO_ACTIVE = "tracker.alfresco.active";
+    private static final String ARCHIVE_ACTIVE = "tracker.archive.active";
+    private static final String ARCHIVE_LAG = "tracker.archive.lag";
+    private static final String ARCHIVE_LAG_DURATION = "tracker.archive.lag.duration";
+    private static final String ARCHIVE_LAST_INDEXED_TXN = "tracker.archive.last.indexed.txn";
+    private static final String ARCHIVE_APPROX_TXNS_REMAINING = "tracker.archive.approx.txns.remaining";
+    private static final String ARCHIVE_APPROX_INDEXING_TIME_REMAINING = "tracker.archive.approx.indexing.time.remaining";
+    private static final String ARCHIVE_DISK = "tracker.archive.disk";
+    private static final String ARCHIVE_MEMORY = "tracker.archive.memory";
 
-    private static String ALFRESCO_LAG = "tracker.alfresco.lag";
+    private static final Set<String> SOLR_TRACKER_PROPERTIES = ImmutableSet.of(
+        ALFRESCO_ACTIVE,
+        ALFRESCO_LAG,
+        ALFRESCO_LAG_DURATION,
+        ALFRESCO_LAST_INDEXED_TXN,
+        ALFRESCO_APPROX_TXNS_REMAINING,
+        ALFRESCO_APPROX_INDEXING_TIME_REMAINING,
+        ALFRESCO_DISK,
+        ALFRESCO_MEMORY,
 
-    private static String ALFRESCO_LAG_DURATION = "tracker.alfresco.lag.duration";
-    
-    private static String ALFRESCO_LAST_INDEXED_TXN = "tracker.alfresco.last.indexed.txn";
-    
-    private static String ALFRESCO_APPROX_TXNS_REMAINING = "tracker.alfresco.approx.txns.remaining";
-    
-    private static String ALFRESCO_APPROX_INDEXING_TIME_REMAINING = "tracker.alfresco.approx.indexing.time.remaining";
-    
-    private static String ALFRESCO_DISK = "tracker.alfresco.disk";
-    
-    private static String ALFRESCO_MEMORY = "tracker.alfresco.memory";
+        ARCHIVE_ACTIVE,
+        ARCHIVE_LAG,
+        ARCHIVE_LAG_DURATION,
+        ARCHIVE_LAST_INDEXED_TXN,
+        ARCHIVE_APPROX_TXNS_REMAINING,
+        ARCHIVE_APPROX_INDEXING_TIME_REMAINING,
+        ARCHIVE_DISK,
+        ARCHIVE_MEMORY);
 
-    private static String ARCHIVE_ACTIVE = "tracker.archive.active";
-
-    private static String ARCHIVE_LAG = "tracker.archive.lag";
-
-    private static String ARCHIVE_LAG_DURATION = "tracker.archive.lag.duration";
-    
-    private static String ARCHIVE_LAST_INDEXED_TXN = "tracker.archive.last.indexed.txn";
-    
-    private static String ARCHIVE_APPROX_TXNS_REMAINING = "tracker.archive.approx.txns.remaining";
-    
-    private static String ARCHIVE_APPROX_INDEXING_TIME_REMAINING = "tracker.archive.approx.indexing.time.remaining";
-    
-    private static String ARCHIVE_DISK = "tracker.archive.disk";
-    
-    private static String ARCHIVE_MEMORY = "tracker.archive.memory";
-    
+    /**
+     * If SOLR is unreachable, this cache holds the Timeout error for a short while (1-2) seconds for subsequent
+     * requests.
+     * This will speed up the refresh of the "Search Services" page in the Alfresco Admin Console. Without it, the UI
+     * refresh takes: nr_of_properties (~15) x timeout (~5 sec)
+     */
+    private static final Cache<Integer, AlfrescoRuntimeException> SOLR_CONNECTION_ERROR = CacheBuilder
+        .newBuilder()
+        .maximumSize(1)
+        .expireAfterWrite(2, SECONDS)
+        .build();
+    //endregion
 
     @Override
-    public boolean isUpdateable(String name)
+    public boolean isUpdateable(final String name)
     {
         // TODO Auto-generated method stub
-        return super.isUpdateable(name)
-                && !name.equals(SolrChildApplicationContextFactory.ALFRESCO_ACTIVE) 
-                && !name.equals(SolrChildApplicationContextFactory.ALFRESCO_LAG)
-                && !name.equals(SolrChildApplicationContextFactory.ALFRESCO_LAG_DURATION) 
-                && !name.equals(SolrChildApplicationContextFactory.ALFRESCO_LAST_INDEXED_TXN) 
-                && !name.equals(SolrChildApplicationContextFactory.ALFRESCO_APPROX_TXNS_REMAINING) 
-                && !name.equals(SolrChildApplicationContextFactory.ALFRESCO_APPROX_INDEXING_TIME_REMAINING)
-                && !name.equals(SolrChildApplicationContextFactory.ALFRESCO_DISK)
-                && !name.equals(SolrChildApplicationContextFactory.ALFRESCO_MEMORY)
-                
-                && !name.equals(SolrChildApplicationContextFactory.ARCHIVE_ACTIVE)
-                && !name.equals(SolrChildApplicationContextFactory.ARCHIVE_LAG) 
-                && !name.equals(SolrChildApplicationContextFactory.ARCHIVE_LAG_DURATION)
-                && !name.equals(SolrChildApplicationContextFactory.ARCHIVE_APPROX_TXNS_REMAINING)
-                && !name.equals(SolrChildApplicationContextFactory.ARCHIVE_APPROX_INDEXING_TIME_REMAINING)
-                && !name.equals(SolrChildApplicationContextFactory.ARCHIVE_LAST_INDEXED_TXN)
-                && !name.equals(SolrChildApplicationContextFactory.ARCHIVE_DISK)
-                && !name.equals(SolrChildApplicationContextFactory.ARCHIVE_MEMORY)
-                ;
+        return super.isUpdateable(name) && !SOLR_TRACKER_PROPERTIES.contains(name);
     }
 
     @Override
-    public String getProperty(String name)
+    public String getProperty(final String name)
     {
-        // MNT-9254 fix, use search.solrAdminHTTPCLient bean to retrive property value only if sorl subsystem is active and started (application context in state should be not null)
-        if (false == isUpdateable(name) && ((ApplicationContextState) getState(false)).getApplicationContext(false) != null)
+        // MNT-9254 fix, use search.solrAdminHTTPCLient bean to retrieve property value only if sorl subsystem is
+        // active and started (application context in state should be not null)
+        if (isUpdateable(name) || isSolrInactive())
         {
-            try
-            {
-                ApplicationContext ctx = getApplicationContext();
-                SolrAdminHTTPClient adminClient = (SolrAdminHTTPClient) ctx.getBean("search.solrAdminHTTPCLient");
-                HashMap<String, String> args = new HashMap<String, String>();
-                args.put("action", "SUMMARY");
-                args.put("wt", "json");
-                JSONObject json = adminClient.execute(args);
-                JSONObject summary = json.getJSONObject("Summary");
-
-	            JSONObject alfresco = null;
-                try
-                {
-                    alfresco = summary.getJSONObject("alfresco");
-                }
-                catch (JSONException e)
-                {
-                    // The core might be absent.
-                }
-
-                if (alfresco != null)
-                {
-                    if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_ACTIVE))
-                    {
-                        String alfrescoActive = alfresco.getString("Active");
-                        if (alfrescoActive == null || alfrescoActive.isEmpty())
-                        {
-                            // Admin Console is expecting a true/false value, not blank
-                            return "false";
-                        }
-                        return alfrescoActive;
-                    }
-                    else if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_LAG))
-                    {
-                        return alfresco.getString("TX Lag");
-                    }
-                    else if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_LAG_DURATION))
-                    {
-                        return alfresco.getString("TX Duration");
-                    }
-                    else if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_LAST_INDEXED_TXN))
-                    {
-                        return alfresco.getString("Id for last TX in index");
-                    }
-                    else if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_APPROX_TXNS_REMAINING))
-                    {
-                        return alfresco.getString("Approx transactions remaining");
-                    }
-                    else if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_APPROX_INDEXING_TIME_REMAINING))
-                    {
-                        return alfresco.getString("Approx transaction indexing time remaining");
-                    }
-                    else if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_DISK))
-                    {
-                        return alfresco.getString("On disk (GB)");
-                    }
-                    else if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_MEMORY))
-                    {
-                        return alfresco.getString("Total Searcher Cache (GB)");
-                    }
-                }
-
-                JSONObject archive = null;
-                try
-                {
-                    archive = summary.getJSONObject("archive");
-                }
-                catch (JSONException e)
-                {
-                    // The core might be absent.
-                }
-
-                if (archive != null)
-                {
-                    if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_ACTIVE))
-                    {
-                        return archive.getString("Active");
-                    }
-                    else if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_LAG))
-                    {
-                        return archive.getString("TX Lag");
-                    }
-                    else if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_LAG_DURATION))
-                    {
-                        return archive.getString("TX Duration");
-                    }
-                    else if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_LAST_INDEXED_TXN))
-                    {
-                        return archive.getString("Id for last TX in index");
-                    }
-                    else if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_APPROX_TXNS_REMAINING))
-                    {
-                        return archive.getString("Approx transactions remaining");
-                    }
-                    else if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_APPROX_INDEXING_TIME_REMAINING))
-                    {
-                        return archive.getString("Approx transaction indexing time remaining");
-                    }
-                    else if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_DISK))
-                    {
-                        return archive.getString("On disk (GB)");
-                    }
-                    else if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_MEMORY))
-                    {
-                        return archive.getString("Total Searcher Cache (GB)");
-                    }
-                }
-
-                // Did not find the property in JSON or the core is turned off
-                return "Unavailable";
-            }
-            catch (LuceneQueryParserException lqe)
-            {
-                return "Unavailable: " + lqe.getMessage();
-            }
-            catch (JSONException e)
-            {
-                return "Unavailable: " + e.getMessage();
-            }
-            catch (IllegalArgumentException iae)
-            {
-                return "Unavailable: " + iae.getMessage();
-            }
+            // solr subsystem is not started or not active
+            return getPropertyWithInactiveSolr(name);
         }
-        else
+
+        try
         {
-        	// solr subsystem is not started or not active
-            if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_ACTIVE))
+            final JSONObject json = retrieveSolrAdminJson();
+            return readPropertyFromJSON(json, name);
+        }
+        catch (AlfrescoRuntimeException | IllegalArgumentException e)
+        {
+            return "Unavailable: " + e.getMessage();
+        }
+    }
+
+    boolean isSolrInactive()
+    {
+        return ((ApplicationContextState) getState(false)).getApplicationContext(false) == null;
+    }
+
+    private JSONObject retrieveSolrAdminJson() throws AlfrescoRuntimeException, IllegalArgumentException
+    {
+        try
+        {
+            final AlfrescoRuntimeException e = SOLR_CONNECTION_ERROR.getIfPresent(0);
+            if (e != null)
             {
-             	return "";
+                throw e;
             }
-            else if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_ACTIVE))
+            return executeSolrAdminQuery();
+        }
+        catch (AlfrescoRuntimeException e)
+        {
+            if (e.getCause() instanceof TimeoutException)
             {
-                return "";
+                SOLR_CONNECTION_ERROR.put(0, e);
             }
-            else if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_LAG))
+            throw e;
+        }
+    }
+
+    private JSONObject executeSolrAdminQuery()
+    {
+        final ApplicationContext ctx = getApplicationContext();
+        final SolrAdminHTTPClient adminClient = ctx.getBean("search.solrAdminHTTPCLient", SolrAdminHTTPClient.class);
+        return adminClient.execute(Map.of(
+            "action", "SUMMARY",
+            "wt", "json"));
+    }
+
+    private String getPropertyWithInactiveSolr(final String name)
+    {
+        switch (name)
+        {
+        case ALFRESCO_ACTIVE:
+        case ARCHIVE_ACTIVE:
+            return "";
+        case ALFRESCO_LAG:
+        case ALFRESCO_LAG_DURATION:
+        case ALFRESCO_LAST_INDEXED_TXN:
+        case ALFRESCO_APPROX_TXNS_REMAINING:
+        case ALFRESCO_APPROX_INDEXING_TIME_REMAINING:
+        case ALFRESCO_DISK:
+        case ALFRESCO_MEMORY:
+        case ARCHIVE_APPROX_TXNS_REMAINING:
+        case ARCHIVE_LAST_INDEXED_TXN:
+        case ARCHIVE_LAG_DURATION:
+        case ARCHIVE_LAG:
+        case ARCHIVE_MEMORY:
+        case ARCHIVE_DISK:
+        case ARCHIVE_APPROX_INDEXING_TIME_REMAINING:
+            return "Unavailable: solr subsystem not started";
+        }
+        return super.getProperty(name);
+    }
+
+    private static String readPropertyFromJSON(final JSONObject json, final String name)
+    {
+        try
+        {
+            final JSONObject summaryJson = json.getJSONObject("Summary");
+            final JSONObject alfresco = getFieldOrNull(summaryJson, "alfresco");
+            if (alfresco != null)
             {
-                return "Unavailable: solr subsystem not started";
+                switch (name)
+                {
+                case ALFRESCO_ACTIVE:
+                    String alfrescoActive = alfresco.getString("Active");
+                    if (alfrescoActive == null || alfrescoActive.isEmpty())
+                    {
+                        // Admin Console is expecting a true/false value, not blank
+                        return "false";
+                    }
+                    return alfrescoActive;
+                case ALFRESCO_LAG:
+                    return alfresco.getString("TX Lag");
+                case ALFRESCO_LAG_DURATION:
+                    return alfresco.getString("TX Duration");
+                case ALFRESCO_LAST_INDEXED_TXN:
+                    return alfresco.getString("Id for last TX in index");
+                case ALFRESCO_APPROX_TXNS_REMAINING:
+                    return alfresco.getString("Approx transactions remaining");
+                case ALFRESCO_APPROX_INDEXING_TIME_REMAINING:
+                    return alfresco.getString("Approx transaction indexing time remaining");
+                case ALFRESCO_DISK:
+                    return alfresco.getString("On disk (GB)");
+                case ALFRESCO_MEMORY:
+                    return alfresco.getString("Total Searcher Cache (GB)");
+                }
             }
-            else if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_LAG_DURATION))
+
+            final JSONObject archive = getFieldOrNull(summaryJson, "archive");
+            if (archive != null)
             {
-            	return "Unavailable: solr subsystem not started";
+                switch (name)
+                {
+                case ARCHIVE_ACTIVE:
+                    return archive.getString("Active");
+                case ARCHIVE_LAG:
+                    return archive.getString("TX Lag");
+                case ARCHIVE_LAG_DURATION:
+                    return archive.getString("TX Duration");
+                case ARCHIVE_LAST_INDEXED_TXN:
+                    return archive.getString("Id for last TX in index");
+                case ARCHIVE_APPROX_TXNS_REMAINING:
+                    return archive.getString("Approx transactions remaining");
+                case ARCHIVE_APPROX_INDEXING_TIME_REMAINING:
+                    return archive.getString("Approx transaction indexing time remaining");
+                case ARCHIVE_DISK:
+                    return archive.getString("On disk (GB)");
+                case ARCHIVE_MEMORY:
+                    return archive.getString("Total Searcher Cache (GB)");
+                }
             }
-            else if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_LAST_INDEXED_TXN))
-            {
-            	return "Unavailable: solr subsystem not started";
-            }
-            else if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_APPROX_TXNS_REMAINING))
-            {
-            	return "Unavailable: solr subsystem not started";
-            }
-            else if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_APPROX_INDEXING_TIME_REMAINING))
-            {
-            	return "Unavailable: solr subsystem not started";
-            }
-            else if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_DISK))
-            {
-                return "Unavailable: solr subsystem not started";   
-            }
-            else if (name.equals(SolrChildApplicationContextFactory.ALFRESCO_MEMORY))
-            {
-                return "Unavailable: solr subsystem not started";
-            }
-            else if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_LAG))
-            {
-            	return "Unavailable: solr subsystem not started";
-            }
-            else if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_LAG_DURATION))
-            {
-            	return "Unavailable: solr subsystem not started";
-            }
-            else if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_LAST_INDEXED_TXN))
-            {
-            	return "Unavailable: solr subsystem not started";
-            }
-            else if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_APPROX_TXNS_REMAINING))
-            {
-            	return "Unavailable: solr subsystem not started";
-            }
-            else if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_APPROX_INDEXING_TIME_REMAINING))
-            {
-            	return "Unavailable: solr subsystem not started";
-            }
-            else if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_DISK))
-            {
-                return "Unavailable: solr subsystem not started";   
-            }
-            else if (name.equals(SolrChildApplicationContextFactory.ARCHIVE_MEMORY))
-            {
-                return "Unavailable: solr subsystem not started";
-            }
-            else
-            {
-                return super.getProperty(name);
-            }
+
+            // Did not find the property in JSON or the core is turned off
+            return "Unavailable";
+        }
+        catch (JSONException e)
+        {
+            return "Unavailable: " + e.getMessage();
         }
     }
 
     @Override
     public Set<String> getPropertyNames()
     {
-        Set<String> result = new TreeSet<String>();
-        result.add(SolrChildApplicationContextFactory.ALFRESCO_ACTIVE);
-        result.add(SolrChildApplicationContextFactory.ALFRESCO_LAG);
-        result.add(SolrChildApplicationContextFactory.ALFRESCO_LAG_DURATION);
-        result.add(SolrChildApplicationContextFactory.ALFRESCO_LAST_INDEXED_TXN);
-        result.add(SolrChildApplicationContextFactory.ALFRESCO_APPROX_TXNS_REMAINING);
-        result.add(SolrChildApplicationContextFactory.ALFRESCO_APPROX_INDEXING_TIME_REMAINING);
-        result.add(SolrChildApplicationContextFactory.ALFRESCO_DISK);
-        result.add(SolrChildApplicationContextFactory.ALFRESCO_MEMORY);
-       
-        result.add(SolrChildApplicationContextFactory.ARCHIVE_ACTIVE);
-        result.add(SolrChildApplicationContextFactory.ARCHIVE_LAG);
-        result.add(SolrChildApplicationContextFactory.ARCHIVE_LAG_DURATION);
-        result.add(SolrChildApplicationContextFactory.ARCHIVE_LAST_INDEXED_TXN);
-        result.add(SolrChildApplicationContextFactory.ARCHIVE_APPROX_TXNS_REMAINING);
-        result.add(SolrChildApplicationContextFactory.ARCHIVE_APPROX_INDEXING_TIME_REMAINING);
-        result.add(SolrChildApplicationContextFactory.ARCHIVE_DISK);
-        result.add(SolrChildApplicationContextFactory.ARCHIVE_MEMORY);
-        result.addAll(super.getPropertyNames());
-        return result;
+        return concat(super.getPropertyNames().stream(), SOLR_TRACKER_PROPERTIES.stream())
+            .collect(toCollection(TreeSet::new));
     }
 
     public void setProperty(String name, String value)
     {
-        if(false == isUpdateable(name))
+        if (!isUpdateable(name))
         {
             throw new IllegalStateException("Illegal write to property \"" + name + "\"");
         }
         super.setProperty(name, value);
-    }  
-    
+    }
+
     protected void destroy(boolean isPermanent)
     {
         super.destroy(isPermanent);
         doInit();
+    }
+
+    private static JSONObject getFieldOrNull(final JSONObject json, final String field)
+    {
+        try
+        {
+            return json.getJSONObject(field);
+        }
+        catch (JSONException ignore)
+        {
+            // The core might be absent.
+        }
+        return null;
     }
 }

--- a/src/main/java/org/alfresco/repo/solr/SOLRAdminClient.java
+++ b/src/main/java/org/alfresco/repo/solr/SOLRAdminClient.java
@@ -4,30 +4,30 @@
  * %%
  * Copyright (C) 2005 - 2016 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
 package org.alfresco.repo.solr;
 
-import java.io.IOException;
+import static java.util.Collections.emptyList;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +38,6 @@ import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.repo.index.shard.ShardRegistry;
 import org.alfresco.repo.search.impl.lucene.JSONAPIResult;
 import org.alfresco.repo.search.impl.lucene.JSONAPIResultFactory;
-import org.alfresco.repo.search.impl.lucene.LuceneQueryParserException;
 import org.alfresco.repo.search.impl.lucene.SolrActionStatusResult;
 import org.alfresco.repo.search.impl.lucene.SolrCommandBackupResult;
 import org.alfresco.repo.search.impl.solr.AbstractSolrAdminHTTPClient;
@@ -65,46 +64,45 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
+
 /**
  * Provides an interface to the Solr admin APIs, used by the Alfresco Enterprise JMX layer.
  * Also tracks whether Solr is available, sending Spring events when its availability changes.
- * 
- * @since 4.0
  *
+ * @since 4.0
  */
 public class SOLRAdminClient extends AbstractSolrAdminHTTPClient
-        implements ApplicationEventPublisherAware, DisposableBean, SolrAdminClientInterface 
+    implements ApplicationEventPublisherAware, DisposableBean, SolrAdminClientInterface
 {
+    private String solrPingCronExpression;
+    private String baseUrl;
 
-	private String solrPingCronExpression;
-	private String baseUrl;
+    private ApplicationEventPublisher applicationEventPublisher;
+    private SolrTracker solrTracker;
 
-	private ApplicationEventPublisher applicationEventPublisher;
-	private SolrTracker solrTracker;
-	
     private Scheduler scheduler;
-    
+
     private List<SolrStoreMapping> storeMappings;
-    
+
     private HashMap<StoreRef, SolrStoreMappingWrapper> mappingLookup = new HashMap<>();
 
     private BeanFactory beanFactory;
-    
-    private ShardRegistry shardRegistry;
-    
-    private boolean useDynamicShardRegistration;
-    
-    public SOLRAdminClient()
-	{
-	}
 
-	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher)
-	{
-		this.applicationEventPublisher = applicationEventPublisher;
-	}
-	
-	public void setSolrPingCronExpression(String solrPingCronExpression)
+    private ShardRegistry shardRegistry;
+
+    private boolean useDynamicShardRegistration;
+
+    public SOLRAdminClient()
+    {
+    }
+
+    @Override
+    public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher)
+    {
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    public void setSolrPingCronExpression(String solrPingCronExpression)
     {
         this.solrPingCronExpression = solrPingCronExpression;
     }
@@ -121,15 +119,17 @@ public class SOLRAdminClient extends AbstractSolrAdminHTTPClient
     {
         this.scheduler = scheduler;
     }
-    
+
     /**
      * SOLR properties identified by store like "alfresco" or "archive"
+     *
      * @param storeMappings
      */
-    public void setStoreMappings(List<SolrStoreMapping> storeMappings) {
+    public void setStoreMappings(List<SolrStoreMapping> storeMappings)
+    {
         this.storeMappings = storeMappings;
     }
-    
+
     /* (non-Javadoc)
      * @see org.springframework.beans.factory.BeanFactoryAware#setBeanFactory(org.springframework.beans.factory.BeanFactory)
      */
@@ -138,12 +138,14 @@ public class SOLRAdminClient extends AbstractSolrAdminHTTPClient
     {
         this.beanFactory = beanFactory;
     }
-    
-    public void setShardRegistry(ShardRegistry shardRegistry) {
+
+    public void setShardRegistry(ShardRegistry shardRegistry)
+    {
         this.shardRegistry = shardRegistry;
     }
-    
-    public void setUseDynamicShardRegistration(boolean useDynamicShardRegistration) {
+
+    public void setUseDynamicShardRegistration(boolean useDynamicShardRegistration)
+    {
         this.useDynamicShardRegistration = useDynamicShardRegistration;
     }
 
@@ -154,54 +156,57 @@ public class SOLRAdminClient extends AbstractSolrAdminHTTPClient
     public void afterPropertiesSet() throws Exception
     {
         mappingLookup.clear();
-        for(SolrStoreMapping mapping : storeMappings)
+        for (SolrStoreMapping mapping : storeMappings)
         {
             mappingLookup.put(mapping.getStoreRef(), new ExplicitSolrStoreMappingWrapper(mapping, beanFactory));
         }
     }
 
     public void init()
-	{
-		this.solrTracker = new SolrTracker(scheduler);
-	}
-    
+    {
+        this.solrTracker = new SolrTracker(scheduler);
+    }
+
     /* (non-Javadoc)
      * @see org.alfresco.repo.search.impl.solr.SolrAdminClient#executeAction(org.alfresco.repo.search.impl.solr.SolrAdminClient.ACTION, java.util.Map)
      */
     @Override
-    public JSONAPIResult executeAction(String core, JSONAPIResultFactory.ACTION action, Map<String, String> parameters) {
-        
-        StoreRef store = StoreRef.STORE_REF_WORKSPACE_SPACESSTORE;
-        SolrStoreMappingWrapper mapping = 
-                SolrClientUtil.extractMapping(store, 
-                                              mappingLookup,
-                                              shardRegistry, 
-                                              useDynamicShardRegistration,
-                                              beanFactory);
-        
+    public JSONAPIResult executeAction(String core, JSONAPIResultFactory.ACTION action, Map<String, String> parameters)
+    {
+        final StoreRef store = StoreRef.STORE_REF_WORKSPACE_SPACESSTORE;
+        SolrStoreMappingWrapper mapping = SolrClientUtil.extractMapping(
+            store,
+            mappingLookup,
+            shardRegistry,
+            useDynamicShardRegistration,
+            beanFactory);
+
         HttpClient httpClient = mapping.getHttpClientAndBaseUrl().getFirst();
-        
+
         StringBuilder url = new StringBuilder();
         url.append(baseUrl);
-     
-        if(!url.toString().endsWith("/"))
+
+        if (!url.toString().endsWith("/"))
         {
             url.append("/");
         }
         url.append("admin/cores");
-        
+
         URLCodec encoder = new URLCodec();
-        url.append("?action=" + action);
+        url.append("?action=").append(action);
         parameters.forEach((key, value) -> {
-            try {
-                url.append("&" + key + "=" + encoder.encode(value));
-            } catch (EncoderException e) {
+            try
+            {
+                url.append("&").append(key).append("=").append(encoder.encode(value));
+            }
+            catch (EncoderException e)
+            {
                 throw new RuntimeException(e);
             }
         });
 
         url.append("&alfresco.shards=");
-        if(mapping.isSharded())
+        if (mapping.isSharded())
         {
             url.append(mapping.getShards());
         }
@@ -212,255 +217,235 @@ public class SOLRAdminClient extends AbstractSolrAdminHTTPClient
         }
         if (core != null)
         {
-            url.append("&core=" + core);
+            url.append("&core=").append(core);
         }
-        
-        try 
-        {   
-            
-            return JSONAPIResultFactory.buildActionResult(action, getOperation(httpClient, url.toString()));
-        
-        }
-        catch (IOException e)
-        {
-            throw new LuceneQueryParserException("action", e);
-        }
-        
+
+        return JSONAPIResultFactory.buildActionResult(action, getOperation(httpClient, url.toString()));
     }
 
     /* (non-Javadoc)
      * @see org.alfresco.repo.search.impl.solr.SolrAdminClient#executeCommand(java.lang.String, org.alfresco.repo.search.impl.solr.SolrAdminClient.HANDLER, org.alfresco.repo.search.impl.solr.SolrAdminClient.COMMAND, java.util.Map)
      */
     @Override
-    public JSONAPIResult executeCommand(String core, JSONAPIResultFactory.HANDLER handler, JSONAPIResultFactory.COMMAND command, Map<String, String> parameters) {
-        
+    public JSONAPIResult executeCommand(String core, JSONAPIResultFactory.HANDLER handler,
+        JSONAPIResultFactory.COMMAND command, Map<String, String> parameters)
+    {
         StoreRef store = StoreRef.STORE_REF_WORKSPACE_SPACESSTORE;
-        SolrStoreMappingWrapper mapping = 
-                SolrClientUtil.extractMapping(store, 
-                                              mappingLookup,
-                                              shardRegistry, 
-                                              useDynamicShardRegistration,
-                                              beanFactory);
-        
+        SolrStoreMappingWrapper mapping = SolrClientUtil.extractMapping(
+            store,
+            mappingLookup,
+            shardRegistry,
+            useDynamicShardRegistration,
+            beanFactory);
+
         HttpClient httpClient = mapping.getHttpClientAndBaseUrl().getFirst();
-        
+
         StringBuilder url = new StringBuilder();
         url.append(baseUrl);
-        
-        if(!url.toString().endsWith("/"))
+
+        if (!url.toString().endsWith("/"))
         {
             url.append("/");
         }
-        
-        url.append(core + "/" + handler.toString().toLowerCase());
-        
+
+        url.append(core).append("/").append(handler.toString().toLowerCase());
+
         URLCodec encoder = new URLCodec();
-        url.append("?command=" + command.toString().toLowerCase());
+        url.append("?command=").append(command.toString().toLowerCase());
         parameters.forEach((key, value) -> {
-            try {
-                url.append("&" + key + "=" + encoder.encode(value));
-            } catch (EncoderException e) {
+            try
+            {
+                url.append("&").append(key).append("=").append(encoder.encode(value));
+            }
+            catch (EncoderException e)
+            {
                 throw new RuntimeException(e);
             }
         });
 
         url.append("&alfresco.shards=");
-        if(mapping.isSharded())
+        if (mapping.isSharded())
         {
             url.append(mapping.getShards());
         }
         else
         {
-           String solrurl = httpClient.getHostConfiguration().getHostURL() + mapping.getHttpClientAndBaseUrl().getSecond();
+            String solrurl = httpClient.getHostConfiguration().getHostURL() + mapping.getHttpClientAndBaseUrl().getSecond();
             url.append(solrurl);
         }
-        
-        try {
-        
-            JSONAPIResult response = new SolrCommandBackupResult(getOperation(httpClient, url.toString()));
-    
-            if(response.getStatus() != 0)
-            {
-                solrTracker.setSolrActive(false);
-            }
-            
-            return response;
-            
-        }
-        catch (IOException e)
+
+        JSONAPIResult response = new SolrCommandBackupResult(getOperation(httpClient, url.toString()));
+        if (response.getStatus() != 0)
         {
-            throw new LuceneQueryParserException("action", e);
+            solrTracker.setSolrActive(false);
         }
-        
-        
+        return response;
     }
 
-	public List<String> getRegisteredCores()
-	{
-		return solrTracker.getRegisteredCores();
-	}
-	
-	/**
-	 * Tracks the availability of Solr.
-	 * 
-	 * @since 4.0
-	 *
-	 */
-	class SolrTracker
-	{
-	    private final WriteLock writeLock;
-		private boolean solrActive = false;
+    public List<String> getRegisteredCores()
+    {
+        return solrTracker.getRegisteredCores();
+    }
 
-	    private Scheduler scheduler = null;
-	    private Trigger trigger;
+    /**
+     * Tracks the availability of Solr.
+     *
+     * @since 4.0
+     */
+    class SolrTracker
+    {
+        private final WriteLock writeLock;
+        private boolean solrActive = false;
 
-	    private List<String> cores;
+        private Scheduler scheduler;
+        private Trigger trigger;
 
-		SolrTracker(Scheduler scheduler)
-		{
-		    this.scheduler = scheduler;
-	        ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-	        writeLock = lock.writeLock();
-	        
-	        cores = new ArrayList<String>(5);
+        private List<String> cores;
 
-	    	setupTimer();
-		}
-		
-		protected void pingSolr()
-		{
-		    
-		    SolrActionStatusResult result = (SolrActionStatusResult) executeAction(null, JSONAPIResultFactory.ACTION.STATUS, JSON_PARAM);
-		    
-		    if(result != null)
-		    {
-			    registerCores(result.getCores());
-		    	setSolrActive(true);
-		    }
-		    else
-		    {
-		    	setSolrActive(false);
-		    }
-		}
-		
-		void setSolrActive(boolean active)
-		{
-			boolean statusChanged = false;
+        SolrTracker(Scheduler scheduler)
+        {
+            this.scheduler = scheduler;
+            ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+            writeLock = lock.writeLock();
 
-			try
-			{
-		        writeLock.lock();
-		        try
-		        {
-		        	if(solrActive != active)
-		        	{
-			        	solrActive = active;
-			        	statusChanged = true;
-		        	}
-		        }
-		        finally
-		        {
-		            writeLock.unlock();
-		        }
-		        
-		        if(statusChanged)
-		        {
-		        	// do this outside the write lock
-		        	if(solrActive)
-		        	{
-		        		stopTimer();
-		        		applicationEventPublisher.publishEvent(new SolrActiveEvent(this));
-		        	}
-		        	else
-		        	{
-		        		startTimer();
-		        		applicationEventPublisher.publishEvent(new SolrInactiveEvent(this));
-		        	}
-		        }
-			}
-			catch(Exception e)
-			{
-				throw new AlfrescoRuntimeException("", e);
-			}
-		}
-		
-		boolean isSolrActive()
-		{
-			return solrActive;
-		}
+            cores = new ArrayList<>(5);
 
-	    protected void setupTimer()
-	    {
-	    	try
-	    	{
+            setupTimer();
+        }
+
+        protected void pingSolr()
+        {
+            final SolrActionStatusResult result = (SolrActionStatusResult) executeAction(
+                null, JSONAPIResultFactory.ACTION.STATUS, JSON_PARAM);
+            if (result != null)
+            {
+                registerCores(result.getCores());
+                setSolrActive(true);
+            }
+            else
+            {
+                setSolrActive(false);
+            }
+        }
+
+        void setSolrActive(boolean active)
+        {
+            boolean statusChanged = false;
+            try
+            {
+                writeLock.lock();
+                try
+                {
+                    if (solrActive != active)
+                    {
+                        solrActive = active;
+                        statusChanged = true;
+                    }
+                }
+                finally
+                {
+                    writeLock.unlock();
+                }
+
+                if (statusChanged)
+                {
+                    // do this outside the write lock
+                    if (solrActive)
+                    {
+                        stopTimer();
+                        applicationEventPublisher.publishEvent(new SolrActiveEvent(this));
+                    }
+                    else
+                    {
+                        startTimer();
+                        applicationEventPublisher.publishEvent(new SolrInactiveEvent(this));
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                throw new AlfrescoRuntimeException("", e);
+            }
+        }
+
+        boolean isSolrActive()
+        {
+            return solrActive;
+        }
+
+        protected void setupTimer()
+        {
+            try
+            {
                 final String jobName = "SolrWatcher";
                 final String jobGroup = "Solr";
-                
+
                 // If a Quartz job already exists with this name and group then we want to replace it.
                 // It is not expected that this will occur during production, but it is possible during automated testing
                 // where application contexts could be rebuilt between test cases, leading to multiple creations of
                 // equivalent Quartz jobs. Quartz disallows the scheduling of multiple jobs with the same name and group.
-                JobDetail existingJob = scheduler.getJobDetail(new JobKey(jobName, jobGroup));
+                final JobDetail existingJob = scheduler.getJobDetail(new JobKey(jobName, jobGroup));
                 if (existingJob != null)
                 {
                     scheduler.deleteJob(existingJob.getKey());
                 }
                 JobDataMap jobDataMap = new JobDataMap();
                 jobDataMap.put("SOLR_TRACKER", this);
-                final JobDetail jobDetail = JobBuilder.newJob()
-                        .withIdentity(jobName, jobGroup)
-                        .usingJobData(jobDataMap)
-                        .ofType(SOLRWatcherJob.class)
-                        .build();
-	            trigger = TriggerBuilder.newTrigger()
-                        .withIdentity("rmt")
-                        .withSchedule(CronScheduleBuilder.cronSchedule(solrPingCronExpression))
-                        .build();
-	            scheduler.scheduleJob(jobDetail, trigger);
-	    	}
-	    	catch(Exception e)
-	    	{
-	    		throw new AlfrescoRuntimeException("Unable to set up SOLRTracker timer", e);
-	    	}
-	    }
-	    
-	    protected void startTimer() throws SchedulerException
-	    {
-	    	scheduler.resumeTrigger(trigger.getKey());
-	    }
-	    
-	    protected void stopTimer() throws SchedulerException
-	    {
-	    	scheduler.pauseTrigger(trigger.getKey());
-	    }
+                final JobDetail jobDetail = JobBuilder
+                    .newJob()
+                    .withIdentity(jobName, jobGroup)
+                    .usingJobData(jobDataMap)
+                    .ofType(SOLRWatcherJob.class)
+                    .build();
+                trigger = TriggerBuilder
+                    .newTrigger()
+                    .withIdentity("rmt")
+                    .withSchedule(CronScheduleBuilder.cronSchedule(solrPingCronExpression))
+                    .build();
+                scheduler.scheduleJob(jobDetail, trigger);
+            }
+            catch (Exception e)
+            {
+                throw new AlfrescoRuntimeException("Unable to set up SOLRTracker timer", e);
+            }
+        }
 
-	    void registerCores(List<String> cores)
-	    {
-	        writeLock.lock();
-	        try
-	        {
-	        	this.cores = cores;
-	        }
-	        finally
-	        {
-	            writeLock.unlock();
-	        }
-	    }
-	    
-	    @SuppressWarnings("unchecked")
-		List<String> getRegisteredCores()
-	    {
-	        writeLock.lock();
-	        try
-	        {
-	        	return (cores != null ? cores : Collections.EMPTY_LIST);
-	        }
-	        finally
-	        {
-	            writeLock.unlock();
-	        }
-	    }
-	}
+        protected void startTimer() throws SchedulerException
+        {
+            scheduler.resumeTrigger(trigger.getKey());
+        }
+
+        protected void stopTimer() throws SchedulerException
+        {
+            scheduler.pauseTrigger(trigger.getKey());
+        }
+
+        void registerCores(List<String> cores)
+        {
+            writeLock.lock();
+            try
+            {
+                this.cores = cores;
+            }
+            finally
+            {
+                writeLock.unlock();
+            }
+        }
+
+        List<String> getRegisteredCores()
+        {
+            writeLock.lock();
+            try
+            {
+                return (cores != null ? cores : emptyList());
+            }
+            finally
+            {
+                writeLock.unlock();
+            }
+        }
+    }
 
     /* (non-Javadoc)
      * @see org.springframework.beans.factory.DisposableBean#destroy()
@@ -470,5 +455,4 @@ public class SOLRAdminClient extends AbstractSolrAdminHTTPClient
     {
         solrTracker.stopTimer();
     }
-
 }

--- a/src/main/resources/alfresco/subsystems/Search/solr/solr-search-context.xml
+++ b/src/main/resources/alfresco/subsystems/Search/solr/solr-search-context.xml
@@ -139,12 +139,15 @@
       <property name="scheduler">
          <ref bean="searchSchedulerFactory" />
       </property>
+      <property name="threadPoolExecutor" ref="defaultAsyncThreadPool"/>
     </bean>
     
     
     <bean id="search.solrAdminHTTPCLient" class="org.alfresco.repo.search.impl.solr.SolrAdminHTTPClient" init-method="init">
         <property name="httpClientFactory" ref="solrHttpClientFactory"/>
         <property name="baseUrl" value="${solr.baseUrl}"/>
+        <property name="solrConnectTimeout" value="${solr.solrConnectTimeout}"/>
+        <property name="threadPoolExecutor" ref="defaultAsyncThreadPool"/>
     </bean>
     
 

--- a/src/main/resources/alfresco/subsystems/Search/solr/solr-search.properties
+++ b/src/main/resources/alfresco/subsystems/Search/solr/solr-search.properties
@@ -4,3 +4,5 @@ solr.port.ssl=8443
 solr.query.includeGroupsForRoleAdmin=false
 solr.query.maximumResultsFromUnlimitedQuery=${system.acl.maxPermissionChecks}
 solr.baseUrl=/solr
+
+solr.solrConnectTimeout=5000

--- a/src/main/resources/alfresco/subsystems/Search/solr4/solr-search-context.xml
+++ b/src/main/resources/alfresco/subsystems/Search/solr4/solr-search-context.xml
@@ -163,12 +163,15 @@
       <property name="scheduler">
         <ref bean="searchSchedulerFactory" />
       </property>
+      <property name="threadPoolExecutor" ref="defaultAsyncThreadPool"/>
     </bean>
     
     
     <bean id="search.solrAdminHTTPCLient" class="org.alfresco.repo.search.impl.solr.SolrAdminHTTPClient" init-method="init">
         <property name="httpClientFactory" ref="solrHttpClientFactory"/>
         <property name="baseUrl" value="${solr.baseUrl}"/>
+        <property name="solrConnectTimeout" value="${solr.solrConnectTimeout}"/>
+        <property name="threadPoolExecutor" ref="defaultAsyncThreadPool"/>
     </bean>
     
 

--- a/src/main/resources/alfresco/subsystems/Search/solr4/solr-search.properties
+++ b/src/main/resources/alfresco/subsystems/Search/solr4/solr-search.properties
@@ -5,6 +5,8 @@ solr.query.includeGroupsForRoleAdmin=false
 solr.query.maximumResultsFromUnlimitedQuery=${system.acl.maxPermissionChecks}
 solr.baseUrl=/solr4
 
+solr.solrConnectTimeout=5000
+
 solr.defaultUnshardedFacetLimit=100
 solr.defaultShardedFacetLimit=20
 

--- a/src/main/resources/alfresco/subsystems/Search/solr6/solr-search-context.xml
+++ b/src/main/resources/alfresco/subsystems/Search/solr6/solr-search-context.xml
@@ -170,6 +170,7 @@
 
     <bean id="solrAdminClient" class="org.alfresco.repo.solr.SOLRAdminClient" init-method="init">
       <property name="solrPingCronExpression" value="${solr.solrPingCronExpression}"/>
+      <property name="solrConnectTimeout" value="${solr.solrConnectTimeout}"/>
       <property name="baseUrl" value="${solr.baseUrl}"/>
       <property name="scheduler">
         <ref bean="searchSchedulerFactory" />
@@ -178,11 +179,14 @@
         <ref bean="solr6.store.mappings" />
       </property>
       <property name="useDynamicShardRegistration" value="${solr.useDynamicShardRegistration}" />
+      <property name="threadPoolExecutor" ref="defaultAsyncThreadPool"/>
     </bean>
 
     <bean id="search.solrAdminHTTPCLient" class="org.alfresco.repo.search.impl.solr.SolrAdminHTTPClient" init-method="init">
         <property name="httpClientFactory" ref="solrHttpClientFactory"/>
         <property name="baseUrl" value="${solr.baseUrl}"/>
+        <property name="solrConnectTimeout" value="${solr.solrConnectTimeout}"/>
+        <property name="threadPoolExecutor" ref="defaultAsyncThreadPool"/>
     </bean>
     
 

--- a/src/main/resources/alfresco/subsystems/Search/solr6/solr-search.properties
+++ b/src/main/resources/alfresco/subsystems/Search/solr6/solr-search.properties
@@ -5,6 +5,8 @@ solr.query.includeGroupsForRoleAdmin=false
 solr.query.maximumResultsFromUnlimitedQuery=${system.acl.maxPermissionChecks}
 solr.baseUrl=/solr
 
+solr.solrConnectTimeout=5000
+
 solr.defaultUnshardedFacetLimit=100
 solr.defaultShardedFacetLimit=20
 

--- a/src/test/java/org/alfresco/AllUnitTestsSuite.java
+++ b/src/test/java/org/alfresco/AllUnitTestsSuite.java
@@ -112,6 +112,8 @@ import org.junit.runners.Suite;
     org.alfresco.repo.search.impl.solr.SolrQueryHTTPClientTest.class,
     org.alfresco.repo.search.impl.solr.SolrSQLHttpClientTest.class,
     org.alfresco.repo.search.impl.solr.SolrStatsResultTest.class,
+    org.alfresco.repo.search.impl.solr.SolrAdminHTTPClientTest.class,
+    org.alfresco.repo.search.impl.solr.SolrChildApplicationContextFactoryTest.class,
     org.alfresco.repo.search.impl.solr.facet.SolrFacetComparatorTest.class,
     org.alfresco.repo.search.impl.solr.facet.FacetQNameUtilsTest.class,
     org.alfresco.util.BeanExtenderUnitTest.class,

--- a/src/test/java/org/alfresco/AppContextExtraTestSuite.java
+++ b/src/test/java/org/alfresco/AppContextExtraTestSuite.java
@@ -63,6 +63,7 @@ import org.junit.runners.Suite;
     org.alfresco.repo.search.impl.solr.facet.SolrFacetQueriesDisplayHandlersTest.class,
     org.alfresco.repo.search.impl.solr.facet.SolrFacetServiceImplTest.class,
     org.alfresco.repo.search.SolrSearchContextTest.class,
+    org.alfresco.repo.search.impl.solr.SolrChildApplicationContextFactoryTest.class,
     org.alfresco.repo.invitation.InvitationCleanupTest.class,
     org.alfresco.repo.quickshare.QuickShareServiceIntegrationTest.class,
     org.alfresco.repo.remotecredentials.RemoteCredentialsServicesTest.class,

--- a/src/test/java/org/alfresco/repo/search/impl/solr/SolrAdminHTTPClientTest.java
+++ b/src/test/java/org/alfresco/repo/search/impl/solr/SolrAdminHTTPClientTest.java
@@ -1,0 +1,106 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.search.impl.solr;
+
+import static java.util.Collections.emptyMap;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+import static org.apache.commons.httpclient.HttpStatus.SC_OK;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.alfresco.error.AlfrescoRuntimeException;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.tika.io.IOUtils;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.mockito.internal.stubbing.answers.AnswersWithDelay;
+import org.mockito.internal.stubbing.answers.Returns;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class SolrAdminHTTPClientTest
+{
+    @Mock
+    private HttpClient httpClient;
+    @Spy @InjectMocks
+    private SolrAdminHTTPClient client;
+
+    @Before
+    public void setup() throws IOException
+    {
+        MockitoAnnotations.initMocks(this);
+        //ReflectionTestUtils.setField(client, "httpClient", httpClient);
+        ReflectionTestUtils.setField(client, "threadPoolExecutor", newSingleThreadExecutor());
+        ReflectionTestUtils.setField(client, "baseUrl", "baseurl");
+        ReflectionTestUtils.setField(client, "adminUrl", "baseurl/admin");
+        ReflectionTestUtils.setField(client, "solrConnectTimeout", 1000); // 1 sec
+
+        final GetMethod get = mock(GetMethod.class);
+        doReturn(get).when(client).getMethod(anyString());
+        doReturn(IOUtils.toInputStream("{}")).when(get).getResponseBodyAsStream();
+        doReturn("UTF-8").when(get).getResponseCharSet();
+    }
+
+    @Test
+    public void testFlowWhenSolrReachable() throws IOException
+    {
+        doReturn(SC_OK).when(httpClient).executeMethod(any());
+
+        final JSONObject result = client.execute(emptyMap());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testFlowWhenSolrUnreachable() throws IOException
+    {
+        doAnswer(new AnswersWithDelay(2 * 1000, new Returns(SC_OK)))
+            .when(httpClient).executeMethod(any());
+
+        try
+        {
+            client.execute(emptyMap());
+            fail("Expected Timeout exception");
+        }
+        catch (AlfrescoRuntimeException e)
+        {
+            assertTrue(e.getCause() instanceof TimeoutException);
+        }
+    }
+}

--- a/src/test/java/org/alfresco/repo/search/impl/solr/SolrChildApplicationContextFactoryTest.java
+++ b/src/test/java/org/alfresco/repo/search/impl/solr/SolrChildApplicationContextFactoryTest.java
@@ -1,0 +1,172 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.search.impl.solr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import org.alfresco.error.AlfrescoRuntimeException;
+import org.alfresco.repo.search.impl.lucene.LuceneQueryParserException;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.springframework.context.ApplicationContext;
+
+public class SolrChildApplicationContextFactoryTest
+{
+    @Spy @InjectMocks
+    private SolrChildApplicationContextFactory solrContextFactory;
+
+    @Mock
+    private ApplicationContext context;
+    @Mock
+    private SolrAdminHTTPClient client;
+
+    @Before
+    public void setup()
+    {
+        MockitoAnnotations.initMocks(this);
+        doReturn(context).when(solrContextFactory).getApplicationContext();
+        doReturn(false).when(solrContextFactory).isSolrInactive();
+        doReturn(client).when(context).getBean(eq("search.solrAdminHTTPCLient"), eq(SolrAdminHTTPClient.class));
+    }
+
+    @After
+    public void tearDown()
+    {
+        // Sleep two seconds between tests to ensure the error cache is reset
+        sleep(2 * 1000);
+    }
+
+    @Test
+    public void testGetProperty_successfulFlow() throws JSONException
+    {
+        doReturn(new JSONObject("{\"Summary\": {\"alfresco\": {\"TX Lag\": \"abc123\"}}}"))
+            .when(client).execute(any());
+
+        final String result = solrContextFactory.getProperty("tracker.alfresco.lag");
+        assertEquals("abc123", result);
+
+        verify(client, times(1)).execute(any());
+    }
+
+    @Test
+    public void testGetProperty_whenSolrClientThrowsIllegalArgumentException()
+    {
+        doThrow(new IllegalArgumentException("foo")).when(client).execute(any());
+
+        final String result = solrContextFactory.getProperty("tracker.alfresco.lag");
+        assertEquals("Unavailable: foo", result);
+
+        verify(client, times(1)).execute(any());
+    }
+
+    @Test
+    public void testGetProperty_whenSolrClientThrowsAlfrescoRuntimeExceptionWithIOException()
+    {
+        doThrow(new LuceneQueryParserException("bar", new IOException()))
+            .when(client).execute(any());
+
+        final String result = solrContextFactory.getProperty("tracker.alfresco.lag");
+        assertTrue(result.startsWith("Unavailable: "));
+        assertTrue(result.endsWith(" bar"));
+
+        verify(client, times(1)).execute(any());
+    }
+
+    @Test
+    public void testGetProperty_whenSolrClientThrowsTimeoutException()
+    {
+        doThrow(new AlfrescoRuntimeException("foobar", new TimeoutException()))
+            .when(client).execute(any());
+
+        final String result = solrContextFactory.getProperty("tracker.alfresco.lag");
+        assertTrue(result.startsWith("Unavailable: "));
+        assertTrue(result.endsWith(" foobar"));
+
+        verify(client, times(1)).execute(any());
+    }
+
+    @Test
+    public void testGetProperty_exceptionCacheGetsUsed()
+    {
+        doThrow(new AlfrescoRuntimeException("foobar", new TimeoutException()))
+            .when(client).execute(any());
+
+        Stream
+            .of("tracker.alfresco.lag",
+                "tracker.archive.lag",
+                "tracker.archive.disk")
+            .map(solrContextFactory::getProperty)
+            .forEach(r -> assertTrue(r.startsWith("Unavailable: ") && r.endsWith(" foobar")));
+
+        verify(client, times(1)).execute(any());
+    }
+
+    @Test
+    public void testGetProperty_exceptionCacheExpires()
+    {
+        doThrow(new AlfrescoRuntimeException("foobar", new TimeoutException()))
+            .when(client).execute(any());
+
+        Stream
+            .of("tracker.alfresco.lag",
+                "tracker.archive.lag",
+                "tracker.archive.disk")
+            .peek(e -> sleep(2001))
+            .map(solrContextFactory::getProperty)
+            .forEach(r -> assertTrue(r.startsWith("Unavailable: ") && r.endsWith(" foobar")));
+
+        verify(client, times(3)).execute(any());
+    }
+
+    private static void sleep(final long millis)
+    {
+        try
+        {
+            Thread.sleep(millis);
+        }
+        catch (InterruptedException ignore)
+        {
+        }
+    }
+}


### PR DESCRIPTION
- add timeout on SOLR Admin HTTP call
- wire *solrConnectTimeout* (5 sec) in the solrAdminHttpClient beans
- add unit tests for the timeout logic (SolrAdminHTTPClientTest)
- refactor SolrChildApplicationContextFactory
- add *recent_timeout_exception_cache* for SOLR Timeouts
- add unit tests for the recent_timeout_exception_cache (SolrChildApplicationContextFactoryTest)