### PR TITLE
MNT-18308 - Add flag forceAsyncAclCreation

### DIFF
--- a/src/main/resources/alfresco/dao/dao-context.xml
+++ b/src/main/resources/alfresco/dao/dao-context.xml
@@ -265,6 +265,7 @@
       <property name="behaviourFilter" ref="policyBehaviourFilter" />
       <property name="preserveAuditableData" value="${system.auditableData.ACLs}"></property>
       <property name="fixedAclMaxTransactionTime" value="${system.fixedACLs.maxTransactionTime}"/>
+      <property name="forceAsyncAclCreation" value="${system.fixedACLsUpdater.forceAsyncAclCreation}"></property>
    </bean>
     
    <bean id="aclCrudDAO" class="org.alfresco.repo.domain.permissions.ibatis.AclCrudDAOImpl">

--- a/src/main/resources/alfresco/repository.properties
+++ b/src/main/resources/alfresco/repository.properties
@@ -1194,6 +1194,8 @@ system.fixedACLsUpdater.maxItemBatchSize=100
 system.fixedACLsUpdater.numThreads=4
 # fixedACLsUpdater cron expression - fire at midnight every day
 system.fixedACLsUpdater.cronExpression=0 0 0 * * ? 
+# forceAsyncAclCreation - If transaction exceeds maxTransactionTime, force all remaining nodes to be updated asynchronously
+system.fixedACLsUpdater.forceAsyncAclCreation=false
 
 cmis.disable.hidden.leading.period.files=false
 


### PR DESCRIPTION
If time fixedAclMaxTransactionTime exceeds, force ACL creation to be async if flag is set to true.

I did create a new method isSubjectToAsyncAclCreation to try to improve code legibility and avoid an if-else hell and changed method setFixAclPending to use that method where I kept the previous logic and added the new feature also:

Old logic for reference:
- if async call is NOT required, make regular call
- else check transaction time and,
     - if transaction time is NOT exceeded, make regular method call 
     - else check if node has children and,
          - if node does not have children, make regular call
          - else, do not make regular call to create ACL and add aspect to be processed by job later. 

The new feature's intention is, if the flag is set to true, to force the node to be processed by the job later if of the following conditions are met:
- No matter if call is sync or async;
- No matter if node has children or not;
- Defined max transaction time was exceeded ( system.fixedACLs.maxTransactionTime )

Also found that the current job (FixedAclUpdater) had a bug in it: it is multi-thread and did not control which nodes it has already picked up to process. This causes the batch class to pick up nodes twice in different threads and if the node had meanwhile already been processed in the other thread it would throw a null pointer when trying to access properties that were already unset. It did not affect the overall job behavior but it was not efficient. 

In order to fix this I added a control list currentlyProcessingNodes that only adds new nodes for the next batch if they are nor currently being processed. When a new node is picked up it goes into that list and as soon as it is processed it is removed from that list - keeping the overall list size manageable with max objects being batchsize*numThreads. We do not have to keep processed nodes in that list as when they are processed, the aspect is removed and properties are unset, so they have no way of being picked up again by the job.