### PR TITLE
MNT-18308 force async acl creation

### DIFF
--- a/src/main/java/org/alfresco/repo/domain/permissions/ADMAccessControlListDAO.java
+++ b/src/main/java/org/alfresco/repo/domain/permissions/ADMAccessControlListDAO.java
@@ -503,9 +503,9 @@ public class ADMAccessControlListDAO implements AccessControlListDAO
         if (log.isWarnEnabled() && (AlfrescoTransactionSupport.getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY) == null
                 || (Boolean) AlfrescoTransactionSupport.getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY) == false))
         {
-            log.warn("Time was exceeded in transaction " + AlfrescoTransactionSupport.getTransactionId()
-                    + " and is scheduled to async processing. Time passed: " + transactionTime
-                    + "ms. Current max transaction time defined is " + fixedAclMaxTransactionTime + "ms.");
+            log.warn("The ACL processing time in transaction " + AlfrescoTransactionSupport.getTransactionId()
+                    + " exceeded the configured limit of " + fixedAclMaxTransactionTime
+                    + " ms. The rest of the ACL processing will be done asynchronously.");
         }
         // set ASPECT_PENDING_FIX_ACL aspect on node to be later on processed with FixedAclUpdater amd switch flag
         // FIXED_ACL_ASYNC_REQUIRED_KEY

--- a/src/main/java/org/alfresco/repo/domain/permissions/ADMAccessControlListDAO.java
+++ b/src/main/java/org/alfresco/repo/domain/permissions/ADMAccessControlListDAO.java
@@ -461,35 +461,60 @@ public class ADMAccessControlListDAO implements AccessControlListDAO
     }
     
     /**
-     * If async call required adds ASPECT_PENDING_FIX_ACL aspect to nodes when transactionTime reaches max admitted time
-     * MNT-18308: No longer checks if call is async in order to evaluate time passed to decide if nodes should be processed by job.
-     * This is now the default behavior for both sync and async calls: when fixedAclMaxTransactionTime is exceeded, call turns
-     * async and all remaining nodes should be processed by job FixedACLUpdater
+     * Adds ASPECT_PENDING_FIX_ACL aspect to nodes when transactionTime reaches max admitted time
+     * MNT-18308: No longer checks if call is async in order to evaluate time passed to decide if nodes should be
+     * processed by job. This is now the default behavior for both sync and async calls: when fixedAclMaxTransactionTime
+     * is exceeded, call turns async and all remaining nodes should be processed by job FixedACLUpdater
+     * 
+     * @param nodeId
+     *            the nodeId of the current node being processed
+     * @param inheritFrom
+     *            the parent node's ACL
+     * @param mergeFrom
+     *            the new shared ACL, if already known.
+     * @param sharedAclToReplace
+     *            the old shared ACL, to be replaced
+     * @param changes
+     *            the list in which to record changes
+     * @param set
+     *            if to set the shared ACL on the parent
+     * @param asyncCall
+     *            if the call was initially set as async
+     * @param propagateOnChildren
+     *            current setting of child propagation of ACL creation
+     * @return new setting on child propagation of ACL creation
+     * 
      */
-    private boolean setFixAclPending(Long nodeId, Long inheritFrom, Long mergeFrom, Long sharedAclToReplace, List<AclChange> changes,
-            boolean set, boolean asyncCall, boolean propagateOnChildren)
+    private boolean setFixAclPending(Long nodeId, Long inheritFrom, Long mergeFrom, Long sharedAclToReplace,
+            List<AclChange> changes, boolean set, boolean asyncCall, boolean propagateOnChildren)
     {
-        
         // check transaction time
         long transactionStartTime = AlfrescoTransactionSupport.getTransactionStartTime();
         long transactionTime = System.currentTimeMillis() - transactionStartTime;
-
         if (transactionTime < fixedAclMaxTransactionTime)
         {
             // make regular method call if time is under max transaction configured time
             setFixedAcls(nodeId, inheritFrom, mergeFrom, sharedAclToReplace, changes, set, asyncCall, propagateOnChildren);
             return true;
         }
-        
-        // set ASPECT_PENDING_FIX_ACL aspect on node to be later on processed with FixedAclUpdater
+
+        // If flag is still unset or false, the call until now has been sync and will turn async, we should throw a
+        // warning
+        if (log.isWarnEnabled() && (AlfrescoTransactionSupport.getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY) == null
+                || (Boolean) AlfrescoTransactionSupport.getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY) == false))
+        {
+            log.warn("Time was exceeded in transaction " + AlfrescoTransactionSupport.getTransactionId()
+                    + " and is scheduled to async processing. Time passed: " + transactionTime
+                    + "ms. Current max transaction time defined is " + fixedAclMaxTransactionTime + "ms.");
+        }
+        // set ASPECT_PENDING_FIX_ACL aspect on node to be later on processed with FixedAclUpdater amd switch flag
+        // FIXED_ACL_ASYNC_REQUIRED_KEY
         addFixedAclPendingAspect(nodeId, sharedAclToReplace, inheritFrom);
         AlfrescoTransactionSupport.bindResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY, true);
         // stop propagating on children nodes
         return false;
-        
-        
     }
-    
+
     private void addFixedAclPendingAspect(Long nodeId, Long sharedAclToReplace, Long inheritFrom)
     {
         Set<QName> aspect = new HashSet<>();

--- a/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
+++ b/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
@@ -321,7 +321,8 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
             if (nodes.size() < maxItemBatchSize)
             {
                 nodes.add(nodePair.getSecond());
-                if(nodePair.getFirst() > maxNodeId) {
+                if (nodePair.getFirst() > maxNodeId)
+                {
                     maxNodeId = nodePair.getFirst();
                 }
                 return true;

--- a/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
+++ b/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
@@ -321,7 +321,9 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
             if (nodes.size() < maxItemBatchSize)
             {
                 nodes.add(nodePair.getSecond());
-                maxNodeId = nodePair.getFirst();
+                if(nodePair.getFirst() > maxNodeId) {
+                    maxNodeId = nodePair.getFirst();
+                }
                 return true;
             }
             return false;

--- a/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterTest.java
+++ b/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterTest.java
@@ -92,13 +92,16 @@ public class FixedAclUpdaterTest extends TestCase
         NodeRef home = repository.getCompanyHome();
         // create a folder hierarchy for which will change permission inheritance
         int[] filesPerLevel = { 5, 5, 10 };
-        RetryingTransactionCallback<NodeRef> cb1 = createFolderHierchyCallback(home, fileFolderService, "rootFolderAsyncCall", filesPerLevel);
+        RetryingTransactionCallback<NodeRef> cb1 = createFolderHierchyCallback(home, fileFolderService, "rootFolderAsyncCall",
+                filesPerLevel);
         folderAsyncCallNodeRef = txnHelper.doInTransaction(cb1);
-        
-        RetryingTransactionCallback<NodeRef> cb2 = createFolderHierchyCallback(home, fileFolderService, "rootFolderSyncCall", filesPerLevel);
+
+        RetryingTransactionCallback<NodeRef> cb2 = createFolderHierchyCallback(home, fileFolderService, "rootFolderSyncCall",
+                filesPerLevel);
         folderSyncCallNodeRef = txnHelper.doInTransaction(cb2);
 
-        // change setFixedAclMaxTransactionTime to lower value so setInheritParentPermissions on created folder hierarchy require async call
+        // change setFixedAclMaxTransactionTime to lower value so setInheritParentPermissions on created folder
+        // hierarchy require async call
         setFixedAclMaxTransactionTime(permissionsDaoComponent, home, 50);
 
     }
@@ -139,20 +142,15 @@ public class FixedAclUpdaterTest extends TestCase
         // delete created folder hierarchy
         try
         {
-            txnHelper.doInTransaction(new RetryingTransactionCallback<Void>()
-            {
-                @Override
-                public Void execute() throws Throwable
-                {
-                    Set<QName> aspect = new HashSet<>();
-                    aspect.add(ContentModel.ASPECT_TEMPORARY);
-                    nodeDAO.addNodeAspects(nodeDAO.getNodePair(folderAsyncCallNodeRef).getFirst(), aspect);
-                    nodeDAO.addNodeAspects(nodeDAO.getNodePair(folderSyncCallNodeRef).getFirst(), aspect);
-                    fileFolderService.delete(folderAsyncCallNodeRef);
-                    fileFolderService.delete(folderSyncCallNodeRef);
-                    return null;
-                }
-            });
+            txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+                Set<QName> aspect = new HashSet<>();
+                aspect.add(ContentModel.ASPECT_TEMPORARY);
+                nodeDAO.addNodeAspects(nodeDAO.getNodePair(folderAsyncCallNodeRef).getFirst(), aspect);
+                nodeDAO.addNodeAspects(nodeDAO.getNodePair(folderSyncCallNodeRef).getFirst(), aspect);
+                fileFolderService.delete(folderAsyncCallNodeRef);
+                fileFolderService.delete(folderSyncCallNodeRef);
+                return null;
+            }, false, true);
         }
         catch (Exception e)
         {
@@ -170,126 +168,67 @@ public class FixedAclUpdaterTest extends TestCase
      */
     private int getNodesCountWithPendingFixedAclAspect()
     {
-        return txnHelper.doInTransaction(new RetryingTransactionCallback<Integer>()
-        {
-            @Override
-            public Integer execute() throws Throwable
-            {
-                final Set<QName> aspects = new HashSet<>(1);
-                aspects.add(ContentModel.ASPECT_PENDING_FIX_ACL);
-                GetNodesCountWithAspectCallback callback = new GetNodesCountWithAspectCallback();
-                nodeDAO.getNodesWithAspects(aspects, 1L, null, callback);
-                return callback.getNodesNumber();
-            }
-        });
+        return txnHelper.doInTransaction((RetryingTransactionCallback<Integer>) () -> {
+            final Set<QName> aspects = new HashSet<>(1);
+            aspects.add(ContentModel.ASPECT_PENDING_FIX_ACL);
+            GetNodesCountWithAspectCallback callback = new GetNodesCountWithAspectCallback();
+            nodeDAO.getNodesWithAspects(aspects, 1L, null, callback);
+            return callback.getNodesNumber();
+        }, true, true);
     }
 
     @Test
-    public void testMNT15368()
+    public void testSyncTimeOut()
+    {
+        testWork(folderSyncCallNodeRef, false);
+    }
+
+    @Test
+    public void testAsync()
+    {
+        testWork(folderAsyncCallNodeRef, true);
+    }
+
+    private void testWork(NodeRef folderRef, boolean asyncCall)
     {
         // kick it off by setting inherit parent permissions == false
-        txnHelper.doInTransaction(new RetryingTransactionCallback<Void>()
-        {
-            @Override
-            public Void execute() throws Throwable
-            {
-                permissionService.setInheritParentPermissions(folderAsyncCallNodeRef, false, true);
+        txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+            permissionService.setInheritParentPermissions(folderRef, false, asyncCall);
+            assertTrue("asyncCallRequired should be true", isFixedAclAsyncRequired());
+            return null;
+        }, false, true);
 
-                Boolean asyncCallRequired = (Boolean) AlfrescoTransactionSupport.getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY);
-                assertTrue("asyncCallRequired should be true", asyncCallRequired);
-
-                return null;
-            }
+        // Assert that there are nodes with aspect ASPECT_PENDING_FIX_ACL to be processed
+        txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+            assertTrue("There are no nodes to process", getNodesCountWithPendingFixedAclAspect() > 0);
+            return null;
         }, false, true);
 
         // run the fixedAclUpdater until there is nothing more to fix (running the updater
         // may create more to fix up)
-        txnHelper.doInTransaction(new RetryingTransactionCallback<Void>()
-        {
-            @Override
-            public Void execute() throws Throwable
+        txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+            int count = 0;
+            do
             {
-                int count = 0;
-                do
-                {
-                    count = fixedAclUpdater.execute();
-                }
-                while(count > 0);
-
-                return null;
-            }
+                count = fixedAclUpdater.execute();
+            } while (count > 0);
+            return null;
         }, false, true);
 
         // check if nodes with ASPECT_PENDING_FIX_ACL are processed
-        txnHelper.doInTransaction(new RetryingTransactionCallback<Void>()
-        {
-            @Override
-            public Void execute() throws Throwable
-            {
-                assertEquals("Not all nodes were processed", 0, getNodesCountWithPendingFixedAclAspect());
-                return null;
-            }
+        txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+            assertEquals("Not all nodes were processed", 0, getNodesCountWithPendingFixedAclAspect());
+            return null;
         }, false, true);
     }
     
-    @Test
-    public void testMNT18308()
-    {
-        // Set Permissions Synchronously
-        txnHelper.doInTransaction(new RetryingTransactionCallback<Void>()
-        {
-            @Override
-            public Void execute() throws Throwable
-            {
-             
-                permissionService.setInheritParentPermissions(folderSyncCallNodeRef, false, false);
-                
-                //As time has exceeded, the transaction should turn async
-                Boolean asyncCallRequiredAfter = (Boolean) AlfrescoTransactionSupport.getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY);
-                assertTrue("asyncCallRequired should be true", asyncCallRequiredAfter);
-
-                return null;
-            }
-        }, false, true);
-        
-        // Assert that there are nodes with aspect ASPECT_PENDING_FIX_ACL to be processed
-        txnHelper.doInTransaction(new RetryingTransactionCallback<Void>()
-        {
-            @Override
-            public Void execute() throws Throwable
-            {
-                assertTrue("There are no nodes to process", getNodesCountWithPendingFixedAclAspect() > 0);
-                return null;
-            }
-        }, false, true);
-
-        // Run the fixedAclUpdater until there is nothing more to fix
-        txnHelper.doInTransaction(new RetryingTransactionCallback<Void>()
-        {
-            @Override
-            public Void execute() throws Throwable
-            {
-                int count = 0;
-                do
-                {
-                    count = fixedAclUpdater.execute();
-                }
-                while(count > 0);
-
-                return null;
-            }
-        }, false, true);
-
-        // Check if nodes with ASPECT_PENDING_FIX_ACL are processed
-        txnHelper.doInTransaction(new RetryingTransactionCallback<Void>()
-        {
-            @Override
-            public Void execute() throws Throwable
-            {
-                assertEquals("Not all nodes were processed", 0, getNodesCountWithPendingFixedAclAspect());
-                return null;
-            }
-        }, false, true);
+    private static boolean isFixedAclAsyncRequired() {
+        if(AlfrescoTransactionSupport
+                .getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY) == null) {
+            return false;
+        }
+        return (Boolean) AlfrescoTransactionSupport
+                .getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY);
     }
 
     private static class GetNodesCountWithAspectCallback implements NodeRefQueryCallback
@@ -310,8 +249,7 @@ public class FixedAclUpdaterTest extends TestCase
     }
 
     /**
-     * Creates a level in folder/file hierarchy. Intermediate levels will
-     * contain folders and last ones files
+     * Creates a level in folder/file hierarchy. Intermediate levels will contain folders and last ones files
      * 
      * @param fileFolderService
      * @param parent
@@ -343,142 +281,5 @@ public class FixedAclUpdaterTest extends TestCase
                 createFile(fileFolderService, parent, "File" + i, ContentModel.TYPE_CONTENT);
             }
         }
-    }
-
-    /**
-     * Create a folder hierarchy and start FixedAclUpdater. See {@link #getUsage()} for usage parameters 
-     */
-    public static void main(String... args)
-    {
-        ConfigurableApplicationContext ctx = (ConfigurableApplicationContext) ApplicationContextHelper.getApplicationContext();
-        try
-        {
-            run(ctx, args);
-        }
-        catch (Exception e)
-        {
-            System.out.println("Failed to run FixedAclUpdaterTest  test");
-            e.printStackTrace();
-        }
-        finally
-        {
-            ctx.close();
-        }
-    }
-
-    public static void run(final ApplicationContext ctx, String... args) throws InterruptedException
-    {
-        ArgumentHelper argHelper = new ArgumentHelper(getUsage(), args);
-        int threadCount = argHelper.getIntegerValue("threads", true, 1, 100);
-        String levels[] = argHelper.getStringValue("filesPerLevel", true, true).split(",");
-        int fixedAclMaxTransactionTime = argHelper.getIntegerValue("fixedAclMaxTransactionTime", true, 1, 10000);
-        final int[] filesPerLevel = new int[levels.length];
-        for (int i = 0; i < levels.length; i++)
-        {
-            filesPerLevel[i] = Integer.parseInt(levels[i]);
-        }
-
-        ServiceRegistry serviceRegistry = (ServiceRegistry) ctx.getBean(ServiceRegistry.SERVICE_REGISTRY);
-        final RetryingTransactionHelper txnHelper = serviceRegistry.getTransactionService().getRetryingTransactionHelper();
-        final FileFolderService fileFolderService = serviceRegistry.getFileFolderService();
-        Repository repository = (Repository) ctx.getBean("repositoryHelper");
-        final FixedAclUpdater fixedAclUpdater = (FixedAclUpdater) ctx.getBean("fixedAclUpdater");
-        final PermissionsDaoComponent permissionsDaoComponent = (PermissionsDaoComponent) ctx.getBean("admPermissionsDaoComponent");
-
-        AuthenticationUtil.setFullyAuthenticatedUser(AuthenticationUtil.getSystemUserName());
-
-        NodeRef home = repository.getCompanyHome();
-        final NodeRef root = createFile(fileFolderService, home, "ROOT", ContentModel.TYPE_FOLDER);
-
-        // create a folder hierarchy for which will change permission inheritance
-        Thread[] threads = new Thread[threadCount];
-        for (int i = 0; i < threadCount; i++)
-        {
-            final int index = i;
-            Thread t = new Thread(new Runnable()
-            {
-                @Override
-                public void run()
-                {
-                    AuthenticationUtil.runAs(new RunAsWork<Void>()
-                    {
-                        @Override
-                        public Void doWork() throws Exception
-                        {
-                            
-                            RetryingTransactionCallback<NodeRef> cb = createFolderHierchyCallback(root, fileFolderService, "FOLDER" + index, filesPerLevel);
-                            txnHelper.doInTransaction(cb);
-                            return null;
-                        }
-                    }, AuthenticationUtil.getSystemUserName());
-                }
-            });
-            t.start();
-            threads[i] = t;
-        }
-        for (int i = 0; i < threads.length; i++)
-        {
-            threads[i].join();
-        }
-
-        setFixedAclMaxTransactionTime(permissionsDaoComponent, home, fixedAclMaxTransactionTime);
-
-        txnHelper.doInTransaction(new RetryingTransactionCallback<Void>()
-        {
-            @Override
-            public Void execute() throws Throwable
-            {
-                // call setInheritParentPermissions on a node that will required async
-                AlfrescoTransactionSupport.bindResource(FixedAclUpdater.FIXED_ACL_ASYNC_CALL_KEY, true);
-                final long startTime = System.currentTimeMillis();
-                permissionsDaoComponent.setInheritParentPermissions(root, false);
-
-                Boolean asyncCallRequired = (Boolean) AlfrescoTransactionSupport.getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY);
-                if (asyncCallRequired != null && asyncCallRequired)
-                {
-                    // check if there are nodes with ASPECT_PENDING_FIX_ACL
-                    AlfrescoTransactionSupport.bindListener(new TransactionListenerAdapter()
-                    {
-                        @Override
-                        public void afterCommit()
-                        {
-                            long userEndTime = System.currentTimeMillis();
-                            // start fixedAclUpdater
-                            Thread t = new Thread(new Runnable()
-                            {
-                                @Override
-                                public void run()
-                                {
-                                    fixedAclUpdater.execute();
-                                }
-                            });
-                            t.start();
-                            try
-                            {
-                                // wait to finish work
-                                t.join();
-                                System.out.println("Backend time " + (System.currentTimeMillis() - startTime));
-                                System.out.println("User time " + (userEndTime - startTime));
-                            }
-                            catch (InterruptedException e)
-                            {
-                            }
-                        }
-                    });
-                }
-                return null;
-            }
-        }, false, true);
-    }
-    
-    private static String getUsage()
-    {
-        StringBuilder sb = new StringBuilder();
-        sb.append("FixedAclUpdaterTest usage: ").append("\n");
-        sb.append("   FixedAclUpdaterTest --threads=<threadcount> --fixedAclMaxTransactionTime=<maxtime> --filesPerLevel=<levelfiles>").append("\n");
-        sb.append("      maxtime: max transaction time for fixed acl ").append("\n");
-        sb.append("      threadcount: number of threads to create the folder hierarchy ").append("\n");
-        sb.append("      levelfiles: number of folders/files per level separated by comma").append("\n");
-        return sb.toString();
     }
 }

--- a/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterTest.java
+++ b/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterTest.java
@@ -221,14 +221,14 @@ public class FixedAclUpdaterTest extends TestCase
             return null;
         }, false, true);
     }
-    
-    private static boolean isFixedAclAsyncRequired() {
-        if(AlfrescoTransactionSupport
-                .getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY) == null) {
+
+    private static boolean isFixedAclAsyncRequired()
+    {
+        if (AlfrescoTransactionSupport.getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY) == null)
+        {
             return false;
         }
-        return (Boolean) AlfrescoTransactionSupport
-                .getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY);
+        return (Boolean) AlfrescoTransactionSupport.getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY);
     }
 
     private static class GetNodesCountWithAspectCallback implements NodeRefQueryCallback


### PR DESCRIPTION
Replaces PR https://github.com/Alfresco/alfresco-repository/pull/984 

Implements solution provided by @killerboot : 
- When time is exceeded (set on fixedAclMaxTransactionTime), it shall always turn the call async and delegate ACL creation to the job
- Fix the current async behavior to also delegate the current's branch children to the job instead of processing them because they have no children

Aditionally also contains:
- Fix to the FixedACLUpdater job: it was picking up nodes in batches and kept resetting a maxNodeId with the last node of the list so on next iteration it would not pick those up again. Problem is the list is sorted desc, so smallest ID comes last - so the next iteration was picking up everything again except the lowest nodeID from the previous. This caused no error on the job, but threw null pointers as it tried to re-process nodes.
- Unit test to assert that when time is exceeded in a sync call, the call with turn async, there will be nodes with aspect ASPECT_PENDING_FIX_ACL to be processed by job and job will then process them correctly.