### PR TITLE
ACS-306: ACS Repository: V1 Rest API for content direct access urls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
         <maven.build.sourceVersion>11</maven.build.sourceVersion>
 
-        <dependency.alfresco-data-model.version>8.125</dependency.alfresco-data-model.version>
+        <dependency.alfresco-data-model.version>8.126</dependency.alfresco-data-model.version>
         <dependency.alfresco-core.version>8.35</dependency.alfresco-core.version>
 
         <dependency.alfresco-legacy-lucene.version>6.2</dependency.alfresco-legacy-lucene.version>

--- a/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
@@ -46,6 +46,7 @@ import org.alfresco.service.cmr.repository.ContentIOException;
 import org.alfresco.service.cmr.repository.ContentReader;
 import org.alfresco.service.cmr.repository.ContentService;
 import org.alfresco.service.cmr.repository.ContentWriter;
+import org.alfresco.service.cmr.repository.DirectAccessUrl;
 import org.alfresco.service.cmr.repository.MimetypeService;
 import org.alfresco.service.cmr.repository.MimetypeServiceAware;
 import org.alfresco.service.cmr.repository.NodeRef;
@@ -510,22 +511,22 @@ public class ContentServiceImpl extends ContentTransformServiceAdaptor implement
     }
 
     @Override
-    public String getDirectAccessUrl(NodeRef nodeRef, Date expiresAt)
+    public DirectAccessUrl getDirectAccessUrl(NodeRef nodeRef, Date expiresAt)
     {
         ContentData contentData = getContentData(nodeRef, ContentModel.PROP_CONTENT);
 
         // check that the URL is available
         if (contentData == null || contentData.getContentUrl() == null)
         {
-            // there is no URL - the interface specifies that this is not an error condition
-            return null;
+            throw new IllegalArgumentException("The supplied nodeRef " + nodeRef + " has no content.");
         }
 
         if (store.isDirectAccessSupported())
         {
             return store.getDirectAccessUrl(contentData.getContentUrl(), expiresAt);
         }
-        return "";
+
+        return null;
     }
 
     /**

--- a/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
+++ b/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
@@ -165,9 +165,9 @@ public interface ContentService extends ContentTransformService
      * @param expiresAt
      *            an optional expiry date, so the direct access url would become
      *            invalid when the expiry date is reached
-     * @return A direct access URL for a binary content or returns null if there is
-     *         no binary content for the node or empty string if not supported
+     * @return A direct access URL object for a binary content or returns null if not supported
+     * @throws IllegalArgumentException if there is no binary content for the node
      */
     @Auditable(parameters = {"nodeRef", "expiresAt"})
-    public String getDirectAccessUrl(NodeRef nodeRef, Date expiresAt);
+    public DirectAccessUrl getDirectAccessUrl(NodeRef nodeRef, Date expiresAt);
 }

--- a/src/main/resources/alfresco/repository.properties
+++ b/src/main/resources/alfresco/repository.properties
@@ -1332,4 +1332,4 @@ system.prop_table_cleaner.algorithm=V2
 
 # Configure the expiration time of the direct access url. This is the length of time in seconds that the link is valid for.
 # Note: It is up to the actual ContentStore implementation if it can fulfil this request or not.
-alfresco.content.directAccessUrl.lifetimeInSec=28800
+alfresco.content.directAccessUrl.lifetimeInSec=300

--- a/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
+++ b/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
@@ -38,6 +38,7 @@ import org.alfresco.service.cmr.repository.NoTransformerException;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.TransformationOptions;
 import org.alfresco.service.cmr.version.Version;
+import org.alfresco.service.namespace.QName;
 import org.alfresco.test_category.OwnJVMTestsCategory;
 import org.junit.Before;
 import org.junit.Test;
@@ -191,7 +192,7 @@ public class ContentServiceImplTest extends BaseVersionStoreTest
     @Test
     public void testWhenGetDirectAccessUrlIsNotSupported()
     {
-        NodeRef versionableNode = createNewVersionableNode();
+        assertFalse(contentStore.isDirectAccessSupported());
 
         // Set the presigned URL to expire after one minute.
         Date expiresAt = new Date();
@@ -199,10 +200,37 @@ public class ContentServiceImplTest extends BaseVersionStoreTest
         expTimeMillis += 1000 * 60;
         expiresAt.setTime(expTimeMillis);
 
-        assertEquals("", contentService.getDirectAccessUrl(versionableNode, expiresAt));
-        assertFalse(contentStore.isDirectAccessSupported());
+        try
+        {
+            // Create a node without content
+            NodeRef nodeRef = this.dbNodeService
+                    .createNode(rootNodeRef, ContentModel.ASSOC_CHILDREN, QName.createQName("{test}MyNoContentNode"), TEST_TYPE_QNAME, this.nodeProperties).getChildRef();
+
+            assertEquals(null, contentService.getDirectAccessUrl(nodeRef, expiresAt));
+            fail("nodeRef has no content");
+        }
+        catch (IllegalArgumentException e)
+        {
+            // Expected exception
+        }
+
+        try
+        {
+            assertEquals(null, contentService.getDirectAccessUrl(null, null));
+            fail("nodeRef is null");
+        }
+        catch (IllegalArgumentException e)
+        {
+            // Expected exception
+        }
+
+        // Create a node with content
+        NodeRef nodeRef = createNewVersionableNode();
+
+        assertEquals(null, contentService.getDirectAccessUrl(nodeRef, null));
+        assertEquals(null, contentService.getDirectAccessUrl(nodeRef, expiresAt));
     }
-    
+
 //  Commented out as OpenOffice is not on the build machines.
 //    public void testGetTransformer0()
 //    {


### PR DESCRIPTION
   - getDirectAccessUrl now also returns DirectAccessUrl, this will allow us to send null expiresAt and get the ContentStore implementation default value
   - changed default value for alfresco.content.directAccessUrl.lifetimeInSec to 300