### PR TITLE
ACS-406: S3 Connector: support for content direct access urls throws …

### DIFF
--- a/src/main/java/org/alfresco/repo/content/caching/CachingContentStore.java
+++ b/src/main/java/org/alfresco/repo/content/caching/CachingContentStore.java
@@ -25,6 +25,7 @@
  */
 package org.alfresco.repo.content.caching;
 
+import java.util.Date;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
@@ -39,6 +40,7 @@ import org.alfresco.service.cmr.repository.ContentIOException;
 import org.alfresco.service.cmr.repository.ContentReader;
 import org.alfresco.service.cmr.repository.ContentStreamListener;
 import org.alfresco.service.cmr.repository.ContentWriter;
+import org.alfresco.service.cmr.repository.DirectAccessUrl;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.BeanNameAware;
@@ -474,5 +476,15 @@ public class CachingContentStore implements ContentStore, ApplicationEventPublis
     public String getBeanName()
     {
         return this.beanName;
-    }    
+    }
+
+    public boolean isDirectAccessSupported()
+    {
+        return backingStore.isDirectAccessSupported();
+    }
+
+    public DirectAccessUrl getDirectAccessUrl(String contentUrl, Date expiresAt)
+    {
+        return backingStore.getDirectAccessUrl(contentUrl, expiresAt);
+    }
 }

--- a/src/test/java/org/alfresco/repo/content/caching/CachingContentStoreTest.java
+++ b/src/test/java/org/alfresco/repo/content/caching/CachingContentStoreTest.java
@@ -504,7 +504,7 @@ public class CachingContentStoreTest
     {
         try
         {
-            backingStore.getDirectAccessUrl("url", null);
+            cachingStore.getDirectAccessUrl("url", null);
             fail();
         }
         catch (UnsupportedOperationException e)
@@ -513,6 +513,6 @@ public class CachingContentStoreTest
         }
 
         when(backingStore.getDirectAccessUrl(anyString(), any())).thenReturn(new DirectAccessUrl());
-        backingStore.getDirectAccessUrl("url", null);
+        cachingStore.getDirectAccessUrl("url", null);
     }
 }

--- a/src/test/java/org/alfresco/repo/content/caching/CachingContentStoreTest.java
+++ b/src/test/java/org/alfresco/repo/content/caching/CachingContentStoreTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -54,6 +55,7 @@ import org.alfresco.service.cmr.repository.ContentIOException;
 import org.alfresco.service.cmr.repository.ContentReader;
 import org.alfresco.service.cmr.repository.ContentStreamListener;
 import org.alfresco.service.cmr.repository.ContentWriter;
+import org.alfresco.service.cmr.repository.DirectAccessUrl;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -486,5 +488,31 @@ public class CachingContentStoreTest
         
         when(backingStore.delete("url")).thenReturn(false);
         assertFalse(cachingStore.delete("url"));
+    }
+
+    @Test
+    public void isDirectAccessSupported()
+    {
+        assertFalse(cachingStore.isDirectAccessSupported());
+
+        when(backingStore.isDirectAccessSupported()).thenReturn(true);
+        assertTrue(cachingStore.isDirectAccessSupported());
+    }
+
+    @Test
+    public void getDirectAccessUrl()
+    {
+        try
+        {
+            backingStore.getDirectAccessUrl("url", null);
+            fail();
+        }
+        catch (UnsupportedOperationException e)
+        {
+            // expected
+        }
+
+        when(backingStore.getDirectAccessUrl(anyString(), any())).thenReturn(new DirectAccessUrl());
+        backingStore.getDirectAccessUrl("url", null);
     }
 }

--- a/src/test/java/org/alfresco/repo/content/caching/CachingContentStoreTest.java
+++ b/src/test/java/org/alfresco/repo/content/caching/CachingContentStoreTest.java
@@ -500,10 +500,11 @@ public class CachingContentStoreTest
     }
 
     @Test
-    public void getDirectAccessUrl()
+    public void getDirectAccessUrlUnsupported()
     {
         try
         {
+            when(backingStore.getDirectAccessUrl(anyString(), any())).thenThrow(new UnsupportedOperationException());
             cachingStore.getDirectAccessUrl("url", null);
             fail();
         }
@@ -511,7 +512,11 @@ public class CachingContentStoreTest
         {
             // expected
         }
+    }
 
+    @Test
+    public void getDirectAccessUrl()
+    {
         when(backingStore.getDirectAccessUrl(anyString(), any())).thenReturn(new DirectAccessUrl());
         cachingStore.getDirectAccessUrl("url", null);
     }

--- a/src/test/java/org/alfresco/repo/content/replication/AggregatingContentStoreTest.java
+++ b/src/test/java/org/alfresco/repo/content/replication/AggregatingContentStoreTest.java
@@ -246,7 +246,7 @@ public class AggregatingContentStoreTest extends AbstractWritableContentStoreTes
 
         try
         {
-            when(primaryStoreMock.getDirectAccessUrl(eq("urlNotSupported"), any())).thenThrow(unsupportedContentUrlExc);
+            when(primaryStoreMock.getDirectAccessUrl(eq("urlDANotSupported"), any())).thenThrow(unsupportedContentUrlExc);
             when(secondaryStoreMock.getDirectAccessUrl(eq("urlDANotSupported"), any())).thenThrow(unsupportedExc);
             aggStore.getDirectAccessUrl("urlDANotSupported", null);
             fail();
@@ -259,7 +259,7 @@ public class AggregatingContentStoreTest extends AbstractWritableContentStoreTes
         try
         {
             when(primaryStoreMock.getDirectAccessUrl(eq("urlDANotSupported"), any())).thenThrow(unsupportedExc);
-            when(secondaryStoreMock.getDirectAccessUrl(eq("urlNotSupported"), any())).thenThrow(unsupportedContentUrlExc);
+            when(secondaryStoreMock.getDirectAccessUrl(eq("urlDANotSupported"), any())).thenThrow(unsupportedContentUrlExc);
             aggStore.getDirectAccessUrl("urlDANotSupported", null);
             fail();
         }
@@ -282,21 +282,21 @@ public class AggregatingContentStoreTest extends AbstractWritableContentStoreTes
         }
 
         when(primaryStoreMock.getDirectAccessUrl(eq("urlPriSupported"), any())).thenReturn(new DirectAccessUrl());
-        when(secondaryStoreMock.getDirectAccessUrl(eq("urlDANotSupported"), any())).thenThrow(unsupportedExc);
+        when(secondaryStoreMock.getDirectAccessUrl(eq("urlPriSupported"), any())).thenThrow(unsupportedExc);
         directAccessUrl = aggStore.getDirectAccessUrl("urlPriSupported", null);
         assertNotNull(directAccessUrl);
 
         when(primaryStoreMock.getDirectAccessUrl(eq("urlPriSupported"), any())).thenReturn(new DirectAccessUrl());
-        when(secondaryStoreMock.getDirectAccessUrl(eq("urlNotSupported"), any())).thenThrow(unsupportedContentUrlExc);
+        when(secondaryStoreMock.getDirectAccessUrl(eq("urlPriSupported"), any())).thenThrow(unsupportedContentUrlExc);
         directAccessUrl = aggStore.getDirectAccessUrl("urlPriSupported", null);
         assertNotNull(directAccessUrl);
 
-        when(primaryStoreMock.getDirectAccessUrl(eq("urlDANotSupported"), any())).thenThrow(unsupportedExc);
+        when(primaryStoreMock.getDirectAccessUrl(eq("urlSecSupported"), any())).thenThrow(unsupportedExc);
         when(secondaryStoreMock.getDirectAccessUrl(eq("urlSecSupported"), any())).thenReturn(new DirectAccessUrl());
         directAccessUrl = aggStore.getDirectAccessUrl("urlSecSupported", null);
         assertNotNull(directAccessUrl);
 
-        when(primaryStoreMock.getDirectAccessUrl(eq("urlNotSupported"), any())).thenThrow(unsupportedContentUrlExc);
+        when(primaryStoreMock.getDirectAccessUrl(eq("urlSecSupported"), any())).thenThrow(unsupportedContentUrlExc);
         when(secondaryStoreMock.getDirectAccessUrl(eq("urlSecSupported"), any())).thenReturn(new DirectAccessUrl());
         directAccessUrl = aggStore.getDirectAccessUrl("urlSecSupported", null);
         assertNotNull(directAccessUrl);

--- a/src/test/java/org/alfresco/repo/content/replication/AggregatingContentStoreTest.java
+++ b/src/test/java/org/alfresco/repo/content/replication/AggregatingContentStoreTest.java
@@ -224,13 +224,13 @@ public class AggregatingContentStoreTest extends AbstractWritableContentStoreTes
         UnsupportedOperationException unsupportedEx = new UnsupportedOperationException("Retrieving direct access URLs is not supported by this content store.");
 
         when(primaryStoreMock.getDirectAccessUrl(anyString(), any())).thenThrow(unsupportedEx);
-        when(primaryStoreMock.getDirectAccessUrl(anyString(), any())).thenReturn(new DirectAccessUrl());
+        when(secondaryStoreMock.getDirectAccessUrl(anyString(), any())).thenReturn(new DirectAccessUrl());
         aggStore.getDirectAccessUrl("url", null);
 
         try
         {
             when(primaryStoreMock.getDirectAccessUrl(anyString(), any())).thenThrow(unsupportedEx);
-            when(primaryStoreMock.getDirectAccessUrl(anyString(), any())).thenThrow(unsupportedEx);
+            when(secondaryStoreMock.getDirectAccessUrl(anyString(), any())).thenThrow(unsupportedEx);
             aggStore.getDirectAccessUrl("url", null);
             fail();
         }


### PR DESCRIPTION
…error even if supported

   -  added implementation for CachingContentStore and AggregatingContentStore