### PR TITLE
REPO-5235: Use unforked tika

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
         <maven.build.sourceVersion>11</maven.build.sourceVersion>
 
-        <dependency.alfresco-data-model.version>repo-5235-0</dependency.alfresco-data-model.version>
+        <dependency.alfresco-data-model.version>8.134</dependency.alfresco-data-model.version>
         <dependency.alfresco-core.version>8.36</dependency.alfresco-core.version>
 
         <dependency.alfresco-legacy-lucene.version>6.2</dependency.alfresco-legacy-lucene.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
         <maven.build.sourceVersion>11</maven.build.sourceVersion>
 
-        <dependency.alfresco-data-model.version>8.131</dependency.alfresco-data-model.version>
+        <dependency.alfresco-data-model.version>repo-5235-0</dependency.alfresco-data-model.version>
         <dependency.alfresco-core.version>8.36</dependency.alfresco-core.version>
 
         <dependency.alfresco-legacy-lucene.version>6.2</dependency.alfresco-legacy-lucene.version>
@@ -50,7 +50,6 @@
         <dependency.spring-security.version>5.2.1.RELEASE</dependency.spring-security.version>
         <dependency.httpcomponents.version>4.5.10</dependency.httpcomponents.version>
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
-        <dependency.tika.version>1.24.1</dependency.tika.version>
         <dependency.poi.version>4.1.2</dependency.poi.version>
         <dependency.ooxml-schemas.version>1.4</dependency.ooxml-schemas.version>
         <dependency.webscripts.version>8.4</dependency.webscripts.version>
@@ -1128,29 +1127,8 @@
                     <groupId>org.apache.geronimo.specs</groupId>
                     <artifactId>geronimo-jta_1.1_spec</artifactId>
                 </exclusion>
-
-                <!-- Exclude forked tika-->
-                <exclusion>
-                    <groupId>org.apache.tika</groupId>
-                    <artifactId>tika-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.tika</groupId>
-                    <artifactId>tika-parsers</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.apache.tika</groupId>
-            <artifactId>tika-core</artifactId>
-            <version>${dependency.tika.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tika</groupId>
-            <artifactId>tika-parsers</artifactId>
-            <version>${dependency.tika.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-legacy-lucene</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,8 @@
         <dependency.spring-security.version>5.2.1.RELEASE</dependency.spring-security.version>
         <dependency.httpcomponents.version>4.5.10</dependency.httpcomponents.version>
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
-        <dependency.poi.version>4.1.1</dependency.poi.version>
+        <dependency.tika.version>1.24.1</dependency.tika.version>
+        <dependency.poi.version>4.1.2</dependency.poi.version>
         <dependency.ooxml-schemas.version>1.4</dependency.ooxml-schemas.version>
         <dependency.webscripts.version>8.4</dependency.webscripts.version>
         <dependency.opencmis.version>1.0.0</dependency.opencmis.version>
@@ -1127,8 +1128,29 @@
                     <groupId>org.apache.geronimo.specs</groupId>
                     <artifactId>geronimo-jta_1.1_spec</artifactId>
                 </exclusion>
+
+                <!-- Exclude forked tika-->
+                <exclusion>
+                    <groupId>org.apache.tika</groupId>
+                    <artifactId>tika-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tika</groupId>
+                    <artifactId>tika-parsers</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>${dependency.tika.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-parsers</artifactId>
+            <version>${dependency.tika.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-legacy-lucene</artifactId>

--- a/src/main/java/org/alfresco/repo/content/metadata/TikaAutoMetadataExtracter.java
+++ b/src/main/java/org/alfresco/repo/content/metadata/TikaAutoMetadataExtracter.java
@@ -70,6 +70,8 @@ public class TikaAutoMetadataExtracter extends TikaPoweredMetadataExtracter
     private static TikaConfig config;
     private static String EXIF_IMAGE_HEIGHT_TAG = "Exif Image Height";
     private static String EXIF_IMAGE_WIDTH_TAG = "Exif Image Width";
+    private static String NEW_EXIF_IMAGE_HEIGHT_TAG = "Exif SubIFD:Exif Image Height";
+    private static String NEW_EXIF_IMAGE_WIDTH_TAG = "Exif SubIFD:Exif Image Width";
     private static String JPEG_IMAGE_HEIGHT_TAG = "Image Height";
     private static String JPEG_IMAGE_WIDTH_TAG = "Image Width";
     private static String COMPRESSION_TAG = "Compression";
@@ -122,24 +124,19 @@ public class TikaAutoMetadataExtracter extends TikaPoweredMetadataExtracter
      */
     @Override
     protected Map<String, Serializable> extractSpecific(Metadata metadata,
-         Map<String, Serializable> properties, Map<String,String> headers) 
+                                                        Map<String, Serializable> properties, Map<String, String> headers)
     {
-        if(MimetypeMap.MIMETYPE_IMAGE_JPEG.equals(metadata.get(Metadata.CONTENT_TYPE)))
+        if (MimetypeMap.MIMETYPE_IMAGE_JPEG.equals(metadata.get(Metadata.CONTENT_TYPE)))
         {
             //check if the image has exif information
-            if(metadata.get(EXIF_IMAGE_WIDTH_TAG) != null
-                    && metadata.get(EXIF_IMAGE_HEIGHT_TAG) != null
-                    && metadata.get(COMPRESSION_TAG) != null)
+            if (metadata.get(NEW_EXIF_IMAGE_WIDTH_TAG) != null && metadata.get(NEW_EXIF_IMAGE_HEIGHT_TAG) != null)
             {
                 //replace the exif size properties that will be embedded in the node with
                 //the guessed dimensions from Tika
-                putRawValue(TIFF.IMAGE_LENGTH.getName(), extractSize(metadata.get(EXIF_IMAGE_HEIGHT_TAG)), properties);
-                putRawValue(TIFF.IMAGE_WIDTH.getName(), extractSize(metadata.get(EXIF_IMAGE_WIDTH_TAG)), properties);
-                putRawValue(JPEG_IMAGE_HEIGHT_TAG, metadata.get(EXIF_IMAGE_HEIGHT_TAG), properties);
-                putRawValue(JPEG_IMAGE_WIDTH_TAG, metadata.get(EXIF_IMAGE_WIDTH_TAG), properties);
+                putRawValue(TIFF.IMAGE_LENGTH.getName(), extractSize(metadata.get(JPEG_IMAGE_HEIGHT_TAG)), properties);
+                putRawValue(TIFF.IMAGE_WIDTH.getName(), extractSize(metadata.get(JPEG_IMAGE_WIDTH_TAG)), properties);
             }
         }
         return properties;
     }
-    
 }

--- a/src/main/java/org/alfresco/repo/content/metadata/TikaAutoMetadataExtracter.java
+++ b/src/main/java/org/alfresco/repo/content/metadata/TikaAutoMetadataExtracter.java
@@ -72,7 +72,6 @@ public class TikaAutoMetadataExtracter extends TikaPoweredMetadataExtracter
     private static String EXIF_IMAGE_WIDTH_TAG = "Exif SubIFD:Exif Image Width";
     private static String JPEG_IMAGE_HEIGHT_TAG = "Image Height";
     private static String JPEG_IMAGE_WIDTH_TAG = "Image Width";
-    private static String COMPRESSION_TAG = "Compression";
 
     public static ArrayList<String> SUPPORTED_MIMETYPES;
     private static ArrayList<String> buildMimeTypes(TikaConfig tikaConfig)

--- a/src/main/java/org/alfresco/repo/content/metadata/TikaAutoMetadataExtracter.java
+++ b/src/main/java/org/alfresco/repo/content/metadata/TikaAutoMetadataExtracter.java
@@ -68,10 +68,8 @@ public class TikaAutoMetadataExtracter extends TikaPoweredMetadataExtracter
     protected static Log logger = LogFactory.getLog(TikaAutoMetadataExtracter.class);
     private static AutoDetectParser parser;
     private static TikaConfig config;
-    private static String EXIF_IMAGE_HEIGHT_TAG = "Exif Image Height";
-    private static String EXIF_IMAGE_WIDTH_TAG = "Exif Image Width";
-    private static String NEW_EXIF_IMAGE_HEIGHT_TAG = "Exif SubIFD:Exif Image Height";
-    private static String NEW_EXIF_IMAGE_WIDTH_TAG = "Exif SubIFD:Exif Image Width";
+    private static String EXIF_IMAGE_HEIGHT_TAG = "Exif SubIFD:Exif Image Height";
+    private static String EXIF_IMAGE_WIDTH_TAG = "Exif SubIFD:Exif Image Width";
     private static String JPEG_IMAGE_HEIGHT_TAG = "Image Height";
     private static String JPEG_IMAGE_WIDTH_TAG = "Image Width";
     private static String COMPRESSION_TAG = "Compression";
@@ -124,12 +122,12 @@ public class TikaAutoMetadataExtracter extends TikaPoweredMetadataExtracter
      */
     @Override
     protected Map<String, Serializable> extractSpecific(Metadata metadata,
-                                                        Map<String, Serializable> properties, Map<String, String> headers)
+         Map<String, Serializable> properties, Map<String, String> headers)
     {
         if (MimetypeMap.MIMETYPE_IMAGE_JPEG.equals(metadata.get(Metadata.CONTENT_TYPE)))
         {
             //check if the image has exif information
-            if (metadata.get(NEW_EXIF_IMAGE_WIDTH_TAG) != null && metadata.get(NEW_EXIF_IMAGE_HEIGHT_TAG) != null)
+            if (metadata.get(EXIF_IMAGE_WIDTH_TAG) != null && metadata.get(EXIF_IMAGE_HEIGHT_TAG) != null)
             {
                 //replace the exif size properties that will be embedded in the node with
                 //the guessed dimensions from Tika


### PR DESCRIPTION
* Use latest unforked Tika version and exclude the forked version from alfresco-model.
* Bring back the old fix done in https://fisheye.alfresco.com/changelog/alfresco-enterprise?cs=103763