### PR TITLE
MNT-21671 : Download as zip REST api does not include custom folders

### DIFF
--- a/src/main/java/org/alfresco/repo/download/CreateDownloadArchiveAction.java
+++ b/src/main/java/org/alfresco/repo/download/CreateDownloadArchiveAction.java
@@ -43,6 +43,7 @@ import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransacti
 import org.alfresco.service.cmr.action.Action;
 import org.alfresco.service.cmr.action.ParameterDefinition;
 import org.alfresco.service.cmr.coci.CheckOutCheckInService;
+import org.alfresco.service.cmr.dictionary.DictionaryService;
 import org.alfresco.service.cmr.download.DownloadRequest;
 import org.alfresco.service.cmr.download.DownloadStatus;
 import org.alfresco.service.cmr.download.DownloadStatus.Status;
@@ -84,6 +85,7 @@ public class CreateDownloadArchiveAction extends ActionExecuterAbstractBase
     private NodeService nodeService;
     private RetryingTransactionHelper transactionHelper;
     private DownloadStatusUpdateService updateService;
+    private DictionaryService dictionaryService;
 
     private long maximumContentSize = -1l;
     
@@ -167,6 +169,11 @@ public class CreateDownloadArchiveAction extends ActionExecuterAbstractBase
         this.updateService = updateService;
     }
 
+    public void setDictionaryService(DictionaryService dictionaryService)
+    {
+        this.dictionaryService = dictionaryService;
+    }
+
     /**
      * Create an archive file containing content from the repository.
      * 
@@ -246,7 +253,7 @@ public class CreateDownloadArchiveAction extends ActionExecuterAbstractBase
     {
         // perform the actual export
         final File tempFile = TempFileProvider.createTempFile(TEMP_FILE_PREFIX, TEMP_FILE_SUFFIX);
-        final ZipDownloadExporter handler = new ZipDownloadExporter(tempFile, checkOutCheckInService, nodeService, transactionHelper, updateService, downloadStorage, actionedUponNodeRef, estimator.getSize(), estimator.getFileCount());
+        final ZipDownloadExporter handler = new ZipDownloadExporter(tempFile, checkOutCheckInService, nodeService, transactionHelper, updateService, downloadStorage, dictionaryService, actionedUponNodeRef, estimator.getSize(), estimator.getFileCount());
         
         try {
             exporterService.exportView(handler, crawlerParameters, null);

--- a/src/main/java/org/alfresco/repo/download/ZipDownloadExporter.java
+++ b/src/main/java/org/alfresco/repo/download/ZipDownloadExporter.java
@@ -39,6 +39,7 @@ import org.alfresco.model.ContentModel;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.service.cmr.coci.CheckOutCheckInService;
+import org.alfresco.service.cmr.dictionary.DictionaryService;
 import org.alfresco.service.cmr.download.DownloadStatus;
 import org.alfresco.service.cmr.download.DownloadStatus.Status;
 import org.alfresco.service.cmr.repository.ContentData;
@@ -77,6 +78,7 @@ public class ZipDownloadExporter extends BaseExporter
     
     private RetryingTransactionHelper transactionHelper;
     private DownloadStorage downloadStorage;
+    private DictionaryService dictionaryService;
     private DownloadStatusUpdateService updateService;
 
     private Deque<Pair<String, NodeRef>> path = new LinkedList<Pair<String, NodeRef>>();
@@ -93,11 +95,12 @@ public class ZipDownloadExporter extends BaseExporter
      * @param transactionHelper RetryingTransactionHelper
      * @param updateService DownloadStatusUpdateService
      * @param downloadStorage DownloadStorage
+     * @param dictionaryService DictionaryService
      * @param downloadNodeRef NodeRef
      * @param total long
      * @param totalFileCount long
      */
-    public ZipDownloadExporter(File zipFile, CheckOutCheckInService checkOutCheckInService, NodeService nodeService, RetryingTransactionHelper transactionHelper, DownloadStatusUpdateService updateService, DownloadStorage downloadStorage, NodeRef downloadNodeRef, long total, long totalFileCount)
+    public ZipDownloadExporter(File zipFile, CheckOutCheckInService checkOutCheckInService, NodeService nodeService, RetryingTransactionHelper transactionHelper, DownloadStatusUpdateService updateService, DownloadStorage downloadStorage, DictionaryService dictionaryService, NodeRef downloadNodeRef, long total, long totalFileCount)
     {
         super(checkOutCheckInService, nodeService);
         try
@@ -106,6 +109,7 @@ public class ZipDownloadExporter extends BaseExporter
             this.updateService = updateService;
             this.transactionHelper = transactionHelper;
             this.downloadStorage = downloadStorage;
+            this.dictionaryService = dictionaryService;
             
             this.downloadNodeRef = downloadNodeRef;
             this.total = total;
@@ -134,7 +138,7 @@ public class ZipDownloadExporter extends BaseExporter
     {
         this.currentName = (String)nodeService.getProperty(nodeRef, ContentModel.PROP_NAME);
         path.push(new Pair<String, NodeRef>(currentName, nodeRef));
-        if (ContentModel.TYPE_FOLDER.equals(nodeService.getType(nodeRef)))
+        if (dictionaryService.isSubClass(nodeService.getType(nodeRef), ContentModel.TYPE_FOLDER))
         {
             String path = getPath() + PATH_SEPARATOR;
             ZipArchiveEntry archiveEntry = new ZipArchiveEntry(path);

--- a/src/main/resources/alfresco/download-services-context.xml
+++ b/src/main/resources/alfresco/download-services-context.xml
@@ -89,18 +89,19 @@
    <bean id="downloadContentServiceHelper" class="org.alfresco.repo.download.LocalContentServiceHelper">
       <property name="contentService" ref="contentService"/>
    </bean>
-   
-   <bean id="createDownloadArchiveAction" class="org.alfresco.repo.download.CreateDownloadArchiveAction" parent="action-executer">
-      <property name="checkOutCheckInSerivce" ref="checkOutCheckInService"/>
-      <property name="contentServiceHelper" ref="downloadContentServiceHelper" />
-     <property name="downloadStorage" ref="downloadStorage" />
-     <property name="exporterService" ref="downloadExporterComponent" />
-     <property name="maximumContentSize" value="${download.maxContentSize}" />
-     <property name="nodeService" ref="nodeService" />
-     <property name="publicAction" value="false"/>
-     <property name="transactionHelper" ref="retryingTransactionHelper"/>
-     <property name="updateService" ref="downloadStatusUpdateService"/>
-   </bean>
+
+    <bean id="createDownloadArchiveAction" class="org.alfresco.repo.download.CreateDownloadArchiveAction" parent="action-executer">
+        <property name="checkOutCheckInSerivce" ref="checkOutCheckInService"/>
+        <property name="contentServiceHelper" ref="downloadContentServiceHelper"/>
+        <property name="downloadStorage" ref="downloadStorage"/>
+        <property name="exporterService" ref="downloadExporterComponent"/>
+        <property name="maximumContentSize" value="${download.maxContentSize}"/>
+        <property name="nodeService" ref="nodeService"/>
+        <property name="publicAction" value="false"/>
+        <property name="transactionHelper" ref="retryingTransactionHelper"/>
+        <property name="updateService" ref="downloadStatusUpdateService"/>
+        <property name="dictionaryService" ref="dictionaryService"/>
+    </bean>
 
     <bean id="downloadExporterComponent" parent="exporterComponent">
         <property name="exportSecondaryNodes" value="true"/>


### PR DESCRIPTION
   Add dictionaryService to CreateDwonloadArchiveAction
   ZipDownloadExporter constructor now required dictionaryService
   ZipDownloadExporter#startNode will include into archive all subclasses of node type cm:folder.
   Add a custom model and create a custom node in DownloadServiceIntegrationTest, this use case will be tested in DownloadServiceIntegrationTest#createDownload()

(cherry picked from commit 3a31ac363435d021e9e0021e4d2cb194cc8ded2c)