### PR TITLE
REPO-5094: Allow switching between existing content store subsystems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ branches:
   only:
     - master
     - /support\/.*/
+    - feature/REPO-5094_SwitchingContentStores
 
 stages:
   - test
@@ -110,7 +111,7 @@ jobs:
       script: travis_wait 20 mvn test -B -Dtest=AllDBTestsTestSuite -Ddb.name=alfresco -Ddb.url=jdbc:mariadb://localhost:3307/alfresco?useUnicode=yes\&characterEncoding=UTF-8 -Ddb.username=alfresco -Ddb.password=alfresco -Ddb.driver=org.mariadb.jdbc.Driver
     - stage: release
       name: "Push to Nexus"
-      if: fork = false AND (branch = master OR branch =~ /support\/.*/) AND type != pull_request AND commit_message !~ /\[no-release\]/
+      if: fork = false AND (branch = feature/REPO-5094_SwitchingContentStores) AND type != pull_request AND commit_message !~ /\[no-release\]/
       before_install:
         - "cp .travis.settings.xml $HOME/.m2/settings.xml"
       script:
@@ -119,4 +120,4 @@ jobs:
         # Add email to link commits to user
         - git config user.email "${GIT_EMAIL}"
         # Skip building of release commits
-        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform
+        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests -DreleaseVersion=repo-5094 -DdevelopmentVersion=8.241-SNAPSHOT release:clean release:prepare release:perform

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ branches:
   only:
     - master
     - /support\/.*/
-    - feature/REPO-5094_SwitchingContentStores
 
 stages:
   - test
@@ -111,7 +110,7 @@ jobs:
       script: travis_wait 20 mvn test -B -Dtest=AllDBTestsTestSuite -Ddb.name=alfresco -Ddb.url=jdbc:mariadb://localhost:3307/alfresco?useUnicode=yes\&characterEncoding=UTF-8 -Ddb.username=alfresco -Ddb.password=alfresco -Ddb.driver=org.mariadb.jdbc.Driver
     - stage: release
       name: "Push to Nexus"
-      if: fork = false AND (branch = feature/REPO-5094_SwitchingContentStores) AND type != pull_request AND commit_message !~ /\[no-release\]/
+      if: fork = false AND (branch = master OR branch =~ /support\/.*/) AND type != pull_request AND commit_message !~ /\[no-release\]/
       before_install:
         - "cp .travis.settings.xml $HOME/.m2/settings.xml"
       script:
@@ -120,4 +119,4 @@ jobs:
         # Add email to link commits to user
         - git config user.email "${GIT_EMAIL}"
         # Skip building of release commits
-        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests -DreleaseVersion=repo-5094 -DdevelopmentVersion=8.241-SNAPSHOT release:clean release:prepare release:perform
+        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform

--- a/src/main/java/org/alfresco/repo/management/subsystems/CryptodocSwitchableApplicationContextFactory.java
+++ b/src/main/java/org/alfresco/repo/management/subsystems/CryptodocSwitchableApplicationContextFactory.java
@@ -136,7 +136,7 @@ public class CryptodocSwitchableApplicationContextFactory extends SwitchableAppl
 
     private boolean isEncryptionSupported()
     {
-        boolean isSupported = false;
+        boolean isSupported = true;
         if (descriptorService != null)
         {
             LicenseDescriptor license = descriptorService.getLicenseDescriptor();

--- a/src/main/java/org/alfresco/repo/management/subsystems/CryptodocSwitchableApplicationContextFactory.java
+++ b/src/main/java/org/alfresco/repo/management/subsystems/CryptodocSwitchableApplicationContextFactory.java
@@ -65,7 +65,7 @@ public class CryptodocSwitchableApplicationContextFactory extends SwitchableAppl
         {
             if (!isUpdateable(name))
             {
-                throw new IllegalStateException("Switching to an unknown content store is not possible.");
+                throw new IllegalStateException("Switching to the unknown content store \"" + value + "\" is not possible.");
             }
 
             if (name.equals(SOURCE_BEAN_PROPERTY))
@@ -77,7 +77,7 @@ public class CryptodocSwitchableApplicationContextFactory extends SwitchableAppl
                 }
                 catch (BeansException e)
                 {
-                    throw new IllegalStateException("Switching to an unknown content store is not possible.");
+                    throw new IllegalStateException("Switching to the unknown content store \"" + value + "\" is not possible.");
                 }
 
                 if (canSwitchSubsystemTo(newSourceBean, value))
@@ -85,12 +85,12 @@ public class CryptodocSwitchableApplicationContextFactory extends SwitchableAppl
                     boolean isNewEncrypted = isEncryptedContentStoreSubsystem(newSourceBean, value);
                     if (isNewEncrypted && !isEncryptionSupported())
                     {
-                        throw new IllegalStateException("Switching to an encrypted content store is not licensed.");
+                        throw new IllegalStateException("Switching to the encrypted content store \"" + value + "\" is not licensed.");
                     }
                 } 
                 else
                 {
-                    throw new IllegalStateException("Switching to an unencrypted content store is not possible.");
+                    throw new IllegalStateException("Switching to the unencrypted content store \"" + value + "\" is not possible.");
                 }
             }
             super.setProperty(name, value);
@@ -100,8 +100,7 @@ public class CryptodocSwitchableApplicationContextFactory extends SwitchableAppl
     private boolean canSwitchSubsystemTo(Object newSourceBean, String beanName)
     {
         Object currentSourceBean = getParent().getBean(getCurrentSourceBeanName());
-        boolean isCurrentEncrypted = isCryptoDocEnabled() || 
-                                     isEncryptedContentStoreSubsystem(currentSourceBean, getCurrentSourceBeanName());
+        boolean isCurrentEncrypted = isEncryptedContentStoreSubsystem(currentSourceBean, getCurrentSourceBeanName());
         // Can switch from an unencrypted content store to any kind of content store
         if (!isCurrentEncrypted)
         {
@@ -125,13 +124,6 @@ public class CryptodocSwitchableApplicationContextFactory extends SwitchableAppl
             isEncrypted = beanName.equals("encryptedContentStore");
         }
         return isEncrypted;
-    }
-
-    private boolean isCryptoDocEnabled()
-    {
-        Object bean = getParent().getBean("fileContentStore");
-        return bean != null &&
-                bean.getClass().getSimpleName().equals("CryptoContentStore");
     }
 
     private boolean isEncryptionSupported()

--- a/src/main/java/org/alfresco/repo/management/subsystems/CryptodocSwitchableApplicationContextFactory.java
+++ b/src/main/java/org/alfresco/repo/management/subsystems/CryptodocSwitchableApplicationContextFactory.java
@@ -63,11 +63,6 @@ public class CryptodocSwitchableApplicationContextFactory extends SwitchableAppl
         @Override
         public void setProperty(String name, String value)
         {
-            if (!isUpdateable(name))
-            {
-                throw new IllegalStateException("Switching to the unknown content store \"" + value + "\" is not possible.");
-            }
-
             if (name.equals(SOURCE_BEAN_PROPERTY))
             {
                 ChildApplicationContextFactory newSourceBean;

--- a/src/main/java/org/alfresco/repo/management/subsystems/CryptodocSwitchableApplicationContextFactory.java
+++ b/src/main/java/org/alfresco/repo/management/subsystems/CryptodocSwitchableApplicationContextFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -25,97 +25,34 @@
  */
 package org.alfresco.repo.management.subsystems;
 
-import java.io.IOException;
-
 import org.alfresco.repo.descriptor.DescriptorServiceAvailableEvent;
 import org.alfresco.service.descriptor.DescriptorService;
 import org.alfresco.service.license.LicenseDescriptor;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationEvent;
 
+import java.io.IOException;
+
 /**
- * {@link SwitchableApplicationContextFactory} that only allows the subsystem to be switched
- * if the current subsystem is the unencrypted content store. When an attempt is made to switch away
- * from any other store (e.g. the encrypted store) then nothing happens. This is achieved by returning
- * <code>false</code> for {@link #isUpdateable(String)} calls when the current sourceBeanName is
- * that of the unencrypted content store's subsystem.
- *  
+ * {@link SwitchableApplicationContextFactory} that only allows the subsystem to be switched from unencrypted to encrypted, 
+ * or if the two subsystems have the same ecrypted state.
+ * Switching back to unencrypted from encrypted content store is not allowed. 
+ * 
  * @author Matt Ward
  */
 public class CryptodocSwitchableApplicationContextFactory extends SwitchableApplicationContextFactory
-	
 {
-    private static final String SOURCE_BEAN_PROPERTY = "sourceBeanName";
-    private String unencryptedContentStoreBeanName;
-    private String encryptedContentStoreBeanName;
     private DescriptorService descriptorService;
     private static final Log logger = LogFactory.getLog(CryptodocSwitchableApplicationContextFactory.class);
     
-    @Override
-    public boolean isUpdateable(String name)
-    {
-        if (name == null)
-        {
-            throw new IllegalStateException("Property name cannot be null");
-        }
-        
-        boolean updateable = true;
-        if (name.equals(SOURCE_BEAN_PROPERTY))
-        {
-        	if(getCurrentSourceBeanName().equals(unencryptedContentStoreBeanName))
-        	{
-        		if(descriptorService != null)
-        		{
-        			LicenseDescriptor license = descriptorService.getLicenseDescriptor();
-        			if(license != null && license.isCryptodocEnabled())
-        			{
-        				return true;
-        			}
-        			return false;
-        		}
-        	}
-
-        	// can the source bean name be changed?
-        	if(!getCurrentSourceBeanName().equals(unencryptedContentStoreBeanName))
-        	{
-        		// the subsystem has been switched once.
-        		return false;
-        	}
-        }
-        return updateable;
-    }
-
     @Override
     protected PropertyBackedBeanState createInitialState() throws IOException
     {
         return new CryptoSwitchableState(sourceBeanName);
     }
-
-
-    /**
-     * The bean name of the unencrypted ContentStore subsystem.
-     * 
-     * @param unencryptedContentStoreBeanName String
-     */
-    public void setUnencryptedContentStoreBeanName(String unencryptedContentStoreBeanName)
-    {
-        this.unencryptedContentStoreBeanName = unencryptedContentStoreBeanName;
-    }
     
-	public String getEncryptedContentStoreBeanName() 
-	{
-		return encryptedContentStoreBeanName;
-	}
-
-	public void setEncryptedContentStoreBeanName(
-			String encryptedContentStoreBeanName) 
-	{
-	    this.encryptedContentStoreBeanName = encryptedContentStoreBeanName;
-	}
-
-
-
 	protected class CryptoSwitchableState extends SwitchableState
     {
         protected CryptoSwitchableState(String sourceBeanName)
@@ -128,23 +65,88 @@ public class CryptodocSwitchableApplicationContextFactory extends SwitchableAppl
         {
             if (!isUpdateable(name))
             {
-            	if(value.equalsIgnoreCase(unencryptedContentStoreBeanName))
-            	{
-            		throw new IllegalStateException("Switching to an unencrypted content store is not possible.");
-            	}
-            	if(value.equalsIgnoreCase(encryptedContentStoreBeanName))
-            	{
-            		throw new IllegalStateException("Switching to an encrypted content store is not licensed.");
-            	}
-                throw new IllegalStateException("Switching to an unknown content store is not possible." + value);
+                throw new IllegalStateException("Switching to an unknown content store is not possible.");
+            }
+
+            if (name.equals(SOURCE_BEAN_PROPERTY))
+            {
+                ChildApplicationContextFactory newSourceBean;
+                try
+                {
+                    newSourceBean = getParent().getBean(value, ChildApplicationContextFactory.class);
+                }
+                catch (BeansException e)
+                {
+                    throw new IllegalStateException("Switching to an unknown content store is not possible.");
+                }
+
+                if (canSwitchSubsystemTo(newSourceBean, value))
+                {
+                    boolean isNewEncrypted = isEncryptedContentStoreSubsystem(newSourceBean, value);
+                    if (isNewEncrypted && !isEncryptionSupported())
+                    {
+                        throw new IllegalStateException("Switching to an encrypted content store is not licensed.");
+                    }
+                } 
+                else
+                {
+                    throw new IllegalStateException("Switching to an unencrypted content store is not possible.");
+                }
             }
             super.setProperty(name, value);
         }
     }
-	
+
+    private boolean canSwitchSubsystemTo(Object newSourceBean, String beanName)
+    {
+        Object currentSourceBean = getParent().getBean(getCurrentSourceBeanName());
+        boolean isCurrentEncrypted = isCryptoDocEnabled() || 
+                                     isEncryptedContentStoreSubsystem(currentSourceBean, getCurrentSourceBeanName());
+        // Can switch from an unencrypted content store to any kind of content store
+        if (!isCurrentEncrypted)
+        {
+            return true;
+        }
+        boolean isNewEncrypted = isEncryptedContentStoreSubsystem(newSourceBean, beanName);
+        // Can switch from an encrypted content store only to another encrypted one
+        return isCurrentEncrypted && isNewEncrypted;
+    }
+
+    private boolean isEncryptedContentStoreSubsystem(Object sourceBean, String beanName)
+    {
+        boolean isEncrypted = false;
+        if (sourceBean instanceof EncryptedContentStoreChildApplicationContextFactory)
+        {
+            isEncrypted = ((EncryptedContentStoreChildApplicationContextFactory) sourceBean).isEncryptedContent();
+        }
+        //If not explicitly set as encrypted, check if the source bean is the cryptodoc subsystem bean
+        if (!isEncrypted)
+        {
+            isEncrypted = beanName.equals("encryptedContentStore");
+        }
+        return isEncrypted;
+    }
+
+    private boolean isCryptoDocEnabled()
+    {
+        Object bean = getParent().getBean("fileContentStore");
+        return bean != null &&
+                bean.getClass().getSimpleName().equals("CryptoContentStore");
+    }
+
+    private boolean isEncryptionSupported()
+    {
+        boolean isSupported = false;
+        if (descriptorService != null)
+        {
+            LicenseDescriptor license = descriptorService.getLicenseDescriptor();
+            isSupported = license != null && license.isCryptodocEnabled();
+        }
+        return isSupported;
+    }
+    
 	public void onApplicationEvent(ApplicationEvent event)
 	{
-		
 		if(logger.isDebugEnabled())
 		{
 			logger.debug("event : " + event);

--- a/src/main/java/org/alfresco/repo/management/subsystems/EncryptedContentStoreChildApplicationContextFactory.java
+++ b/src/main/java/org/alfresco/repo/management/subsystems/EncryptedContentStoreChildApplicationContextFactory.java
@@ -1,0 +1,45 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.management.subsystems;
+
+/**
+ * ChildApplicationContextFactory extension used to identify the type of the content store subsystem, encrypted or unecrypted.
+ * See {@link CryptodocSwitchableApplicationContextFactory} for how is used.
+ */
+public class EncryptedContentStoreChildApplicationContextFactory extends ChildApplicationContextFactory
+{
+    private boolean encryptedContent;
+    
+    public boolean isEncryptedContent()
+    {
+        return encryptedContent;
+    }
+
+    public void setEncryptedContent(boolean encryptedContent)
+    {
+        this.encryptedContent = encryptedContent;
+    }
+}

--- a/src/main/java/org/alfresco/repo/management/subsystems/SwitchableApplicationContextFactory.java
+++ b/src/main/java/org/alfresco/repo/management/subsystems/SwitchableApplicationContextFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 

--- a/src/main/java/org/alfresco/repo/management/subsystems/SwitchableApplicationContextFactory.java
+++ b/src/main/java/org/alfresco/repo/management/subsystems/SwitchableApplicationContextFactory.java
@@ -41,7 +41,7 @@ public class SwitchableApplicationContextFactory extends AbstractPropertyBackedB
 {
 
     /** The name of the property holding the bean name of the source {@link ApplicationContextFactory}. */
-    private static final String SOURCE_BEAN_PROPERTY = "sourceBeanName";
+    protected static final String SOURCE_BEAN_PROPERTY = "sourceBeanName";
 
     /** The default bean name of the source {@link ApplicationContextFactory}. */
     protected String sourceBeanName;

--- a/src/main/resources/alfresco/content-services-context.xml
+++ b/src/main/resources/alfresco/content-services-context.xml
@@ -22,8 +22,6 @@
                 <value>manager</value>
             </list>
         </property>
-        <property name="unencryptedContentStoreBeanName" value="unencryptedContentStore"/>
-        <property name="encryptedContentStoreBeanName" value="encryptedContentStore"/>
     </bean>
 
     <!-- Default ContentStore subsystem, that does not use encryption -->
@@ -229,9 +227,9 @@
       </property>
       <property name="jsonObjectMapper" ref="mimetypeServiceJsonObjectMapper" />
       <property name="mimetypeJsonConfigDir" value="${mimetype.config.dir}" />
-      <property name="cronExpression" value="${mimetype.config.cronExpression}"></property>
-      <property name="initialAndOnErrorCronExpression" value="${mimetype.config.initialAndOnError.cronExpression}"></property>
-      <property name="shutdownIndicator" ref="shutdownIndicator"></property>
+      <property name="cronExpression" value="${mimetype.config.cronExpression}" />
+      <property name="initialAndOnErrorCronExpression" value="${mimetype.config.initialAndOnError.cronExpression}" />
+      <property name="shutdownIndicator" ref="shutdownIndicator" />
    </bean>
 
     <bean id="mimetypeServiceJsonObjectMapper" class="com.fasterxml.jackson.databind.ObjectMapper" />


### PR DESCRIPTION
* Update `CryptodocSwitchableApplicationContextFactory` to accept switching (via JMX) between existing content store subsystems, not just based on plain bean names.
* Added `EncryptedContentStoreChildApplicationContextFactory` as an extension of `ChildApplicationContextFactory` with support to specify if the content store in the subsystem is encrypted or not.

