### PR TITLE
REPO-5339 Improve concurrency of SimplePermissionReference

### DIFF
--- a/src/main/java/org/alfresco/repo/security/permissions/impl/SimplePermissionReference.java
+++ b/src/main/java/org/alfresco/repo/security/permissions/impl/SimplePermissionReference.java
@@ -25,7 +25,7 @@
  */
 package org.alfresco.repo.security.permissions.impl;
 
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.HashMap;
 
 import org.alfresco.service.namespace.QName;
 import org.alfresco.util.Pair;
@@ -39,7 +39,7 @@ public final class SimplePermissionReference extends AbstractPermissionReference
 {   
     private static final long serialVersionUID = 637302438293417818L;
 
-    private static ConcurrentHashMap<Pair<QName, String>, SimplePermissionReference> instances = new ConcurrentHashMap<>();
+    private static HashMap<Pair<QName, String>, SimplePermissionReference> instances = new HashMap<>();
 
     /**
      * Factory method to create simple permission references
@@ -52,9 +52,15 @@ public final class SimplePermissionReference extends AbstractPermissionReference
         SimplePermissionReference instance = instances.get(key);
         if (instance == null)
         {
-            // TODO This may result in duplicate objects, but it is most likely does not matter
-            instance = new SimplePermissionReference(qName, name);
-            instances.put(key, instance);
+            synchronized (SimplePermissionReference.class)
+            {
+                instance = instances.get(key);
+                if (instance == null)
+                {
+                    instance = new SimplePermissionReference(qName, name);
+                    instances.put(key, instance);
+                }
+            }
         }
         return instance;
     }

--- a/src/main/java/org/alfresco/repo/security/permissions/impl/SimplePermissionReference.java
+++ b/src/main/java/org/alfresco/repo/security/permissions/impl/SimplePermissionReference.java
@@ -25,8 +25,15 @@
  */
 package org.alfresco.repo.security.permissions.impl;
 
-import java.util.HashMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 
+import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.service.namespace.QName;
 import org.alfresco.util.Pair;
 
@@ -35,34 +42,56 @@ import org.alfresco.util.Pair;
  * 
  * @author andyh
  */
-public final class SimplePermissionReference extends AbstractPermissionReference
-{   
+public final class SimplePermissionReference extends AbstractPermissionReference {
     private static final long serialVersionUID = 637302438293417818L;
 
-    private static HashMap<Pair<QName, String>, SimplePermissionReference> instances = new HashMap<>();
+    //Use thread-safe map initiallized with a slightly larger capacity to reduce the posibility of two or more threads attempting to resize at the same time
+    private static ConcurrentMap<Pair<QName, String>, Future<SimplePermissionReference>> instances = new ConcurrentHashMap<>(100);
 
     /**
      * Factory method to create simple permission references
      * 
      * @return a simple permission reference
      */
-    public static SimplePermissionReference getPermissionReference(QName qName, String name)
-    {
-        Pair<QName, String> key = new Pair<>(qName, name);
-        SimplePermissionReference instance = instances.get(key);
-        if (instance == null)
+    public static SimplePermissionReference getPermissionReference(QName qName, String name) {
+        //loop if thread is interrupted and should be run again
+        while (true)
         {
-            synchronized (SimplePermissionReference.class)
-            {
-                instance = instances.get(key);
-                if (instance == null)
+            Pair<QName, String> key = new Pair<>(qName, name);
+            Future<SimplePermissionReference> instance = instances.get(key);
+            if (instance == null) {
+                //Set up task to be completed if the thread is waiting
+                Callable<SimplePermissionReference> callableReference = new Callable<SimplePermissionReference>() {
+                    public SimplePermissionReference call() throws InterruptedException {
+                        return new SimplePermissionReference(qName, name);
+                    }
+                };
+
+                FutureTask<SimplePermissionReference> instanceTask = new FutureTask<>(callableReference);
+                instance = instances.putIfAbsent(key, instanceTask);
+                if (instance == null) {
+                    instance = instanceTask;
+                    instanceTask.run();
+                }
+
+                try
                 {
-                    instance = new SimplePermissionReference(qName, name);
-                    instances.put(key, instance);
+                    return instance.get();
+                } 
+                catch (CancellationException e)
+                {
+                    instances.remove(key, instance);
+                }
+                catch (InterruptedException e)
+                {
+                    Thread.currentThread().interrupt();
+                } 
+                catch (ExecutionException e)
+                {
+                    throw new AlfrescoRuntimeException(e.getMessage());
                 }
             }
         }
-        return instance;
     }
     
     /*

--- a/src/main/java/org/alfresco/repo/security/permissions/impl/SimplePermissionReference.java
+++ b/src/main/java/org/alfresco/repo/security/permissions/impl/SimplePermissionReference.java
@@ -41,7 +41,7 @@ public final class SimplePermissionReference extends AbstractPermissionReference
     private static final long serialVersionUID = 637302438293417818L;
 
     //Use thread-safe map initiallized with a slightly larger capacity to reduce the posibility of two or more threads attempting to resize at the same time
-    private static ConcurrentMap<Pair<QName, String>, SimplePermissionReference> instances = new ConcurrentHashMap<>(100);
+    private static ConcurrentMap<Pair<QName, String>, SimplePermissionReference> instances = new ConcurrentHashMap<>(100, 0.9f, 2);
 
     /**
      * Factory method to create simple permission references


### PR DESCRIPTION
The piece of code before changes seemed to be designed to provide a thread safe factory for singletons. I didn't find any particular reason for this choice by looking at the usages of SimplePermissionReference in the code. It actually may be sufficient to just create new SimplePermissionReference objects each time.