### PR TITLE
[MNT-21847] - Aync permissions fail when new nodes are created (#1188)

### DIFF
--- a/src/main/java/org/alfresco/repo/domain/permissions/ADMAccessControlListDAO.java
+++ b/src/main/java/org/alfresco/repo/domain/permissions/ADMAccessControlListDAO.java
@@ -430,8 +430,8 @@ public class ADMAccessControlListDAO implements AccessControlListDAO
 //                    {
 //                        setFixedAcls(child.getId(), inheritFrom, mergeFrom, sharedAclToReplace, changes, false);
 //                    }
-                    // Already replaced
-                    if(acl.equals(sharedAclToReplace))
+                    // Still has old shared ACL or already replaced
+                    if(acl.equals(sharedAclToReplace) || acl.equals(mergeFrom))
                     {
                         propagateOnChildren = setFixAclPending(child.getId(), inheritFrom, mergeFrom, sharedAclToReplace, changes, false, asyncCall, propagateOnChildren);
                     }


### PR DESCRIPTION
Fix:
*Changed method setFixedAcls on class ADMAccessControlListDAO to continue to propagate through children to apply the correct acl not only when the current child acl matches the shared acl to replace but also when the current child acl matches the new shared acl
Unit Test:
*Refactored the unit test FixedAclUpdaterTest to be able to add in a new test without repeating code: separating the operations that set the permissions from the one that triggers the job into separate methods
*As it was if one test failed, leaving aspects to be processed, the test would run indefinitely (it was programmed to keep running the job while there where nodes with the aspect). Added a verification to stop triggering the job if the number of nodes with the pendingFixAcl did not change between executions.
*Also, if one test failed, it would leave nodes with pendingFixAcl aspect in the database, and the other tests that ran after would also fail, not completing the goal of processing all nodes with the aspect. If a test fails, the folder structure it ran is now deleted so no nodes with the aspect from that structure are processed by the other tests.
*Added a test to find the first folder in a tree where permissions where set async that has the pendingFixAcl aspect and that creates a new node in it to verify the issue

(cherry picked from commit 443e5e226430a2760492fb82214ad520e7e1cb75)