### PR TITLE
[MNT-21766]: Significant degradation of performance as file and site count increase

### DIFF
--- a/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/AlfrescoCreate-RepoTables.sql
+++ b/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/AlfrescoCreate-RepoTables.sql
@@ -169,7 +169,9 @@ CREATE TABLE alf_transaction
     change_txn_id VARCHAR(56) NOT NULL,
     commit_time_ms BIGINT,
     PRIMARY KEY (id),
-    KEY idx_alf_txn_ctms (commit_time_ms)
+    KEY idx_alf_txn_ctms (commit_time_ms, id),
+    KEY idx_alf_txn_ctms_sc (commit_time_ms),
+    key idx_alf_txn_id_ctms (id, commit_time_ms)
 ) ENGINE=InnoDB;
 
 CREATE TABLE alf_store
@@ -210,6 +212,8 @@ CREATE TABLE alf_node
     KEY idx_alf_node_crd (audit_created, store_id, type_qname_id),
     KEY idx_alf_node_mor (audit_modifier, store_id, type_qname_id),
     KEY idx_alf_node_mod (audit_modified, store_id, type_qname_id),
+    KEY idx_alf_node_ver (version),
+    KEY idx_alf_node_txn (transaction_id),
     CONSTRAINT fk_alf_node_acl FOREIGN KEY (acl_id) REFERENCES alf_access_control_list (id),
     CONSTRAINT fk_alf_node_store FOREIGN KEY (store_id) REFERENCES alf_store (id),
     CONSTRAINT fk_alf_node_tqn FOREIGN KEY (type_qname_id) REFERENCES alf_qname (id),

--- a/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/Schema-Reference-ALF.xml
+++ b/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/Schema-Reference-ALF.xml
@@ -1681,6 +1681,16 @@
             <columnname>type_qname_id</columnname>
           </columnnames>
         </index>
+        <index name="idx_alf_node_ver" unique="false">
+          <columnnames>
+            <columnname>version</columnname>
+          </columnnames>
+        </index>
+        <index name="idx_alf_node_txn" unique="false">
+          <columnnames>
+            <columnname>transaction_id</columnname>
+          </columnnames>
+        </index>
       </indexes>
     </table>
     <table name="alf_node_aspects">
@@ -2629,6 +2639,18 @@
       <indexes>
         <index name="idx_alf_txn_ctms" unique="false">
           <columnnames>
+            <columnname>commit_time_ms</columnname>
+            <columnname>id</columnname>
+          </columnnames>
+        </index>
+        <index name="idx_alf_txn_ctms_sc" unique="false">
+          <columnnames>
+            <columnname>commit_time_ms</columnname>
+          </columnnames>
+        </index>
+        <index name="idx_alf_txn_id_ctms" unique="false">
+          <columnnames>
+            <columnname>id</columnname>
             <columnname>commit_time_ms</columnname>
           </columnnames>
         </index>

--- a/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.PostgreSQLDialect/AlfrescoCreate-RepoTables.sql
+++ b/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.PostgreSQLDialect/AlfrescoCreate-RepoTables.sql
@@ -184,6 +184,8 @@ CREATE TABLE alf_transaction
     PRIMARY KEY (id)
 );
 CREATE INDEX idx_alf_txn_ctms ON alf_transaction (commit_time_ms, id);
+CREATE INDEX idx_alf_txn_ctms_sc ON alf_transaction (commit_time_ms);
+CREATE INDEX idx_alf_txn_id_ctms ON alf_transaction (id, commit_time_ms);
 
 CREATE SEQUENCE alf_store_seq START WITH 1 INCREMENT BY 1;
 CREATE TABLE alf_store
@@ -231,6 +233,8 @@ CREATE INDEX fk_alf_node_acl ON alf_node (acl_id);
 CREATE INDEX fk_alf_node_store ON alf_node (store_id);
 CREATE INDEX idx_alf_node_tqn ON alf_node (type_qname_id, store_id, id);
 CREATE INDEX fk_alf_node_loc ON alf_node (locale_id);
+CREATE INDEX idx_alf_node_ver ON alf_node (version);
+CREATE INDEX idx_alf_node_txn ON alf_node (transaction_id);
 
 CREATE INDEX fk_alf_store_root ON alf_store (root_node_id);
 ALTER TABLE alf_store ADD CONSTRAINT fk_alf_store_root FOREIGN KEY (root_node_id) REFERENCES alf_node (id);

--- a/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.PostgreSQLDialect/Schema-Reference-ALF.xml
+++ b/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.PostgreSQLDialect/Schema-Reference-ALF.xml
@@ -1739,6 +1739,16 @@
             <columnname>id</columnname>
           </columnnames>
         </index>
+        <index name="idx_alf_node_ver" unique="false">
+          <columnnames>
+            <columnname>version</columnname>
+          </columnnames>
+        </index>
+        <index name="idx_alf_node_txn" unique="false">
+          <columnnames>
+            <columnname>transaction_id</columnname>
+          </columnnames>
+        </index>
       </indexes>
     </table>
     <table name="alf_node_aspects">
@@ -2701,6 +2711,17 @@
           <columnnames>
             <columnname>commit_time_ms</columnname>
             <columnname>id</columnname>
+          </columnnames>
+        </index>
+        <index name="idx_alf_txn_ctms_sc" unique="false">
+          <columnnames>
+            <columnname>commit_time_ms</columnname>
+          </columnnames>
+        </index>
+        <index name="idx_alf_txn_id_ctms" unique="false">
+          <columnnames>
+            <columnname>id</columnname>
+            <columnname>commit_time_ms</columnname>
           </columnnames>
         </index>
       </indexes>

--- a/src/main/resources/alfresco/dbscripts/db-schema-context.xml
+++ b/src/main/resources/alfresco/dbscripts/db-schema-context.xml
@@ -55,6 +55,7 @@
                 <ref bean="patch.db-V5.2-remove-jbpm-tables-from-db" />
                 <ref bean="patch.db-V6.0-change-set-indexes" />
                 <ref bean="patch.db-V6.3-remove-alf_server-table" />
+                <ref bean="patch.db-V6.3-add-indexes-node-transaction" />
             </list>
         </property>
     </bean>

--- a/src/main/resources/alfresco/dbscripts/upgrade/6.3/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/add-indexes-node-transaction.sql
+++ b/src/main/resources/alfresco/dbscripts/upgrade/6.3/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/add-indexes-node-transaction.sql
@@ -1,0 +1,35 @@
+--
+-- Title:      Update alf_node and alf_transaction indexes for more performance
+-- Database:   MySQL
+-- Since:      V6.3
+-- Author:     Eva Vasques
+--
+-- Please contact support@alfresco.com if you need assistance with the upgrade.
+--
+
+DROP INDEX idx_alf_node_ver;  --(optional)
+CREATE INDEX idx_alf_node_ver ON alf_node (version);
+
+DROP INDEX idx_alf_node_txn;  --(optional)
+CREATE INDEX idx_alf_node_txn ON alf_node (transaction_id);
+
+DROP INDEX idx_alf_txn_ctms;  --(optional)
+CREATE INDEX idx_alf_txn_ctms ON alf_transaction (commit_time_ms, id);
+
+DROP INDEX idx_alf_txn_ctms_sc;  --(optional)
+CREATE INDEX idx_alf_txn_ctms_sc ON alf_transaction (commit_time_ms);
+
+DROP INDEX idx_alf_txn_id_ctms;  --(optional)
+CREATE INDEX idx_alf_txn_id_ctms ON alf_transaction (id, commit_time_ms);
+
+--
+-- Record script finish
+--
+DELETE FROM alf_applied_patch WHERE id = 'patch.db-V6.3-add-indexes-node-transaction';
+INSERT INTO alf_applied_patch
+  (id, description, fixes_from_schema, fixes_to_schema, applied_to_schema, target_schema, applied_on_date, applied_to_server, was_executed, succeeded, report)
+  VALUES
+  (
+    'patch.db-V6.3-add-indexes-node-transaction', 'Create aditional indexes on alf_node and alf_transaction',
+    0, 14001, -1, 14002, null, 'UNKNOWN', ${TRUE}, ${TRUE}, 'Script completed'
+  );

--- a/src/main/resources/alfresco/dbscripts/upgrade/6.3/org.alfresco.repo.domain.dialect.PostgreSQLDialect/add-indexes-node-transaction.sql
+++ b/src/main/resources/alfresco/dbscripts/upgrade/6.3/org.alfresco.repo.domain.dialect.PostgreSQLDialect/add-indexes-node-transaction.sql
@@ -1,0 +1,32 @@
+--
+-- Title:      Update alf_node and alf_transaction indexes for more performance
+-- Database:   PostgreSQL
+-- Since:      V6.3
+-- Author:     Eva Vasques
+--
+-- Please contact support@alfresco.com if you need assistance with the upgrade.
+--
+
+DROP INDEX idx_alf_node_ver;  --(optional)
+CREATE INDEX idx_alf_node_ver ON alf_node (version);
+
+DROP INDEX idx_alf_node_txn;  --(optional)
+CREATE INDEX idx_alf_node_txn ON alf_node (transaction_id);
+
+DROP INDEX idx_alf_txn_ctms_sc;  --(optional)
+CREATE INDEX idx_alf_txn_ctms_sc ON alf_transaction (commit_time_ms);
+
+DROP INDEX idx_alf_txn_id_ctms;  --(optional)
+CREATE INDEX idx_alf_txn_id_ctms ON alf_transaction (id, commit_time_ms);
+
+--
+-- Record script finish
+--
+DELETE FROM alf_applied_patch WHERE id = 'patch.db-V6.3-add-indexes-node-transaction';
+INSERT INTO alf_applied_patch
+  (id, description, fixes_from_schema, fixes_to_schema, applied_to_schema, target_schema, applied_on_date, applied_to_server, was_executed, succeeded, report)
+  VALUES
+  (
+    'patch.db-V6.3-add-indexes-node-transaction', 'Create aditional indexes on alf_node and alf_transaction',
+    0, 14001, -1, 14002, null, 'UNKNOWN', ${TRUE}, ${TRUE}, 'Script completed'
+  );

--- a/src/main/resources/alfresco/messages/patch-service.properties
+++ b/src/main/resources/alfresco/messages/patch-service.properties
@@ -403,3 +403,5 @@ patch.db-V5.2-remove-jbpm-tables-from-db.description=Removes all JBPM related ta
 patch.db-V6.0-change-set-indexes.description=Add additional indexes to support acl tracking.
 
 patch.db-V6.3-remove-alf_server-table.description=Remove alf_server table.
+
+patch.db-V6.3-add-indexes-node-transaction.description=Create additional indexes on alf_node and alf_transaction

--- a/src/main/resources/alfresco/patch/patch-services-context.xml
+++ b/src/main/resources/alfresco/patch/patch-services-context.xml
@@ -1408,4 +1408,16 @@
             <value>classpath:alfresco/dbscripts/upgrade/6.3/${db.script.dialect}/remove-alf_server-table.sql</value>
         </property>
     </bean>
+    
+    <bean id="patch.db-V6.3-add-indexes-node-transaction" class="org.alfresco.repo.admin.patch.impl.SchemaUpgradeScriptPatch" parent="basePatch">
+        <property name="id"><value>patch.db-V6.3-add-indexes-node-transaction</value></property>
+        <property name="description"><value>patch.db-V6.3-add-indexes-node-transaction.description</value></property>
+        <property name="fixesFromSchema"><value>0</value></property>
+        <property name="fixesToSchema"><value>14001</value></property>
+        <property name="targetSchema"><value>14002</value></property>
+        <property name="ignored"><value>${system.new-node-transaction-indexes.ignored}</value></property>
+        <property name="scriptUrl">
+            <value>classpath:alfresco/dbscripts/upgrade/6.3/${db.script.dialect}/add-indexes-node-transaction.sql</value>
+        </property>
+    </bean>
 </beans>

--- a/src/main/resources/alfresco/repository.properties
+++ b/src/main/resources/alfresco/repository.properties
@@ -3,7 +3,7 @@
 repository.name=Main Repository
 
 # Schema number
-version.schema=14001
+version.schema=14002
 
 # Directory configuration
 
@@ -1333,3 +1333,6 @@ system.prop_table_cleaner.algorithm=V2
 # Configure the expiration time of the direct access url. This is the length of time in seconds that the link is valid for.
 # Note: It is up to the actual ContentStore implementation if it can fulfil this request or not.
 alfresco.content.directAccessUrl.lifetimeInSec=300
+
+# Creates additional indexes on alf_node and alf_transaction. Recommended for large repositories.
+system.new-node-transaction-indexes.ignored=true


### PR DESCRIPTION
- Added the following indexes on alf_transaction:
idx_alf_txn_ctms_sc, cols (commit_time_ms)
idx_alf_txn_id_ctms, cols (id, commit_time_ms)
- Added the following indexes on alf_node:
idx_alf_node_ver, cols (version)
idx_alf_node_txn, cols (transaction_id)
- Created patch patch.db-V6.3-add-indexes-node-transaction
- Updated version.schema to 14002
- Added system property system.new-node-transaction-indexes.ignored, set
as true by default to not apply the patch automatically
- Created the MySQL update dbscripts to add the new indexes - and also
drop and recreate the pre-existing index idx_alf_txn_ctms on alf_transaction that was
inconsistent with the other DBMS: was indexing only commit_time_ms when
on all other DBMS index idx_alf_txn_ctms was on (commit_time_ms, id)
- Created the Postgres update dbscripts to add the new indexes