### PR TITLE
ACS-525: Bump surf-webscripts which include fix for CSRF Filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency.poi.version>4.1.2</dependency.poi.version>
         <dependency.ooxml-schemas.version>1.4</dependency.ooxml-schemas.version>
         <dependency.webscripts.version>8.10</dependency.webscripts.version>
-        <dependency.opencmis.version>1.1.0</dependency.opencmis.version>
+        <dependency.opencmis.version>1.0.0</dependency.opencmis.version>
         <dependency.activiti-engine.version>5.23.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.23.0</dependency.activiti.version>
         <dependency.postgresql.version>42.2.16</dependency.postgresql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
         <dependency.poi.version>4.1.2</dependency.poi.version>
         <dependency.ooxml-schemas.version>1.4</dependency.ooxml-schemas.version>
-        <dependency.webscripts.version>8.8</dependency.webscripts.version>
+        <dependency.webscripts.version>8.10</dependency.webscripts.version>
         <dependency.opencmis.version>1.1.0</dependency.opencmis.version>
         <dependency.activiti-engine.version>5.23.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.23.0</dependency.activiti.version>


### PR DESCRIPTION
- Bump `org.alfresco.surf:spring-webscripts` to version `8.10`