### PR TITLE
MNT-21936 : Audit query Rest API does not return the correct totalItems

### DIFF
--- a/src/main/java/org/alfresco/repo/audit/AuditComponent.java
+++ b/src/main/java/org/alfresco/repo/audit/AuditComponent.java
@@ -261,4 +261,12 @@ public interface AuditComponent
      * @return                              a map containing min/max and the associated value
      */
     HashMap<String, Long> getAuditMinMaxByApp(String applicationName, List<String> extremes);
+
+    /**
+     * Issue an audit query to retrieve count of records for a given application.
+     *
+     * @param applicationName             the name of the application
+     * @return                  a map containing min/max and the associated value
+     */
+    int getAuditEntriesCountByApp(String applicationName);
 }

--- a/src/main/java/org/alfresco/repo/audit/AuditComponent.java
+++ b/src/main/java/org/alfresco/repo/audit/AuditComponent.java
@@ -268,5 +268,8 @@ public interface AuditComponent
      * @param applicationName             the name of the application
      * @return                  a map containing min/max and the associated value
      */
-    int getAuditEntriesCountByApp(String applicationName);
+    default int getAuditEntriesCountByApp(String applicationName)
+    {
+        return -1;
+    }
 }

--- a/src/main/java/org/alfresco/repo/audit/AuditComponentImpl.java
+++ b/src/main/java/org/alfresco/repo/audit/AuditComponentImpl.java
@@ -942,6 +942,7 @@ public class AuditComponentImpl implements AuditComponent
         return auditDAO.getAuditMinMaxByApp(applicationId, extremes);
     }
 
+    @Override
     public int getAuditEntriesCountByApp(String applicationName)
     {
         // Get the id for the application

--- a/src/main/java/org/alfresco/repo/audit/AuditComponentImpl.java
+++ b/src/main/java/org/alfresco/repo/audit/AuditComponentImpl.java
@@ -941,4 +941,17 @@ public class AuditComponentImpl implements AuditComponent
 
         return auditDAO.getAuditMinMaxByApp(applicationId, extremes);
     }
+
+    public int getAuditEntriesCountByApp(String applicationName)
+    {
+        // Get the id for the application
+        AuditApplication app = auditModelRegistry.getAuditApplicationByName(applicationName);
+        Long applicationId = app.getApplicationId();
+        if (applicationId == null)
+        {
+            throw new AuditException("No persisted instance exists for audit application: " + app);
+        }
+
+        return auditDAO.getAuditEntriesCountByApp(applicationId);
+    }
 }

--- a/src/main/java/org/alfresco/repo/audit/AuditServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/audit/AuditServiceImpl.java
@@ -181,6 +181,7 @@ public class AuditServiceImpl implements AuditService
     /**
      * {@inheritDoc}
      */
+    @Override
     public int getAuditEntriesCountByApp(String applicationName)
     {
         return auditComponent.getAuditEntriesCountByApp(applicationName);

--- a/src/main/java/org/alfresco/repo/audit/AuditServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/audit/AuditServiceImpl.java
@@ -177,4 +177,12 @@ public class AuditServiceImpl implements AuditService
     {
         return auditComponent.getAuditMinMaxByApp(applicationName, extremes);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int getAuditEntriesCountByApp(String applicationName)
+    {
+        return auditComponent.getAuditEntriesCountByApp(applicationName);
+    }
 }

--- a/src/main/java/org/alfresco/repo/domain/audit/AuditDAO.java
+++ b/src/main/java/org/alfresco/repo/domain/audit/AuditDAO.java
@@ -240,5 +240,8 @@ public interface AuditDAO
      * @param applicationId             the database id of the application
      * @return                  a map containing min/max and the associated value
      */
-    int getAuditEntriesCountByApp(long applicationId);
+    default int getAuditEntriesCountByApp(long applicationId)
+    {
+        return -1;
+    }
 }

--- a/src/main/java/org/alfresco/repo/domain/audit/AuditDAO.java
+++ b/src/main/java/org/alfresco/repo/domain/audit/AuditDAO.java
@@ -233,4 +233,12 @@ public interface AuditDAO
      * @return                  a map containing min/max and the associated value
      */
     HashMap<String, Long> getAuditMinMaxByApp(long appId, List<String> extremes);
+
+    /**
+     * Issue an audit query to retrieve count of records for a given application.
+     *
+     * @param applicationId             the database id of the application
+     * @return                  a map containing min/max and the associated value
+     */
+    int getAuditEntriesCountByApp(long applicationId);
 }

--- a/src/main/java/org/alfresco/repo/domain/audit/ibatis/AuditDAOImpl.java
+++ b/src/main/java/org/alfresco/repo/domain/audit/ibatis/AuditDAOImpl.java
@@ -65,6 +65,7 @@ public class AuditDAOImpl extends AbstractAuditDAOImpl
     private static final String DELETE_ENTRIES_BY_ID = "alfresco.audit.delete_AuditEntriesById";
     private static final String INSERT_ENTRY = "alfresco.audit.insert.insert_AuditEntry";
     private static final String SELECT_MINMAX_ENTRY_FOR_APP = "alfresco.audit.select_MinMaxAuditEntryId";
+    private static final String SELECT_COUNT_ENTRIES_FOR_APP = "alfresco.audit.select_CountAuditEntryId";
     
     @SuppressWarnings("unused")
     private static final String SELECT_ENTRIES_SIMPLE = "alfresco.audit.select_AuditEntriesSimple";
@@ -219,6 +220,16 @@ public class AuditDAOImpl extends AbstractAuditDAOImpl
         params.put("auditAppId", appId);
 
         HashMap<String, Long> result = template.selectOne(SELECT_MINMAX_ENTRY_FOR_APP, params);
+
+        return result;
+    }
+
+    public int getAuditEntriesCountByApp(long applicationId)
+    {
+        Map<String, Object> params = new HashMap<>();
+        params.put("auditAppId", applicationId);
+
+        int result = template.selectOne(SELECT_COUNT_ENTRIES_FOR_APP, params);
 
         return result;
     }

--- a/src/main/java/org/alfresco/repo/domain/audit/ibatis/AuditDAOImpl.java
+++ b/src/main/java/org/alfresco/repo/domain/audit/ibatis/AuditDAOImpl.java
@@ -224,6 +224,7 @@ public class AuditDAOImpl extends AbstractAuditDAOImpl
         return result;
     }
 
+    @Override
     public int getAuditEntriesCountByApp(long applicationId)
     {
         Map<String, Object> params = new HashMap<>();

--- a/src/main/java/org/alfresco/service/cmr/audit/AuditService.java
+++ b/src/main/java/org/alfresco/service/cmr/audit/AuditService.java
@@ -248,5 +248,8 @@ public interface AuditService
      * @param applicationName               the name of the application
      * @return                              a map containing min/max and the associated value
      */
-    int getAuditEntriesCountByApp(String applicationName);
+    default int getAuditEntriesCountByApp(String applicationName)
+    {
+        return -1;
+    }
 }

--- a/src/main/java/org/alfresco/service/cmr/audit/AuditService.java
+++ b/src/main/java/org/alfresco/service/cmr/audit/AuditService.java
@@ -241,4 +241,12 @@ public interface AuditService
      * @return                              a map containing min/max and the associated value
      */
     HashMap<String, Long> getAuditMinMaxByApp(String applicationName, List<String> extremes);
+
+    /**
+     * Issue an audit query to retrieve min / max audit record id for a given application.
+     *
+     * @param applicationName               the name of the application
+     * @return                              a map containing min/max and the associated value
+     */
+    int getAuditEntriesCountByApp(String applicationName);
 }

--- a/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/audit-common-SqlMap.xml
+++ b/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/audit-common-SqlMap.xml
@@ -59,6 +59,10 @@
         <parameter property="min" jdbcType="VARCHAR" javaType="String"/>
         <parameter property="max" jdbcType="VARCHAR" javaType="String"/>
     </parameterMap>
+
+    <parameterMap id="parameter_AuditAppId" type="map">
+        <parameter property="auditAppId" jdbcType="BIGINT" javaType="Long"/>
+    </parameterMap>
   
     <!--                -->
     <!-- SQL Snippets   -->
@@ -276,6 +280,16 @@
         <include refid="select_AuditEntriesWhereSnippet"/>
         <include refid="select_AuditEntriesOrderBySnippet"/>
     </sql>
+
+    <!-- Get the count of audit entries for application -->
+    <select id="select_CountAuditEntryId" parameterMap="parameter_AuditAppId" resultType="int">
+        select
+            COUNT(id)
+        from
+        alf_audit_entry
+        where
+        alf_audit_entry.audit_app_id = #{auditAppId}
+    </select>
 
     <!-- Get the maximum/minimum audit entry id for application -->
     <select id="select_MinMaxAuditEntryId" parameterMap="parameter_IdMinMaxMap" resultMap="result_minMaxMap">


### PR DESCRIPTION
   Add CountAuditEntryId select, that provides the total number of items for a specific auditApp
   Add getAuditEntriesCountByApp(long appId) in AuditDAO interface and its implementation in AuditDAOImpl
   Add getAuditEntriesCountByApp(String applicationName) in AuditComponent interface and its implementation in AuditComponentImpl
   Add getAuditEntriesCountByApp(String applicationName) in AuditService interface and its implementation in AuditServiceImpl