### PR TITLE
MNT-21879 : [Security] Multiple json-java vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20090211</version>
+            <version>20200518</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.icu</groupId>

--- a/src/main/java/org/alfresco/repo/preference/PreferenceServiceImpl.java
+++ b/src/main/java/org/alfresco/repo/preference/PreferenceServiceImpl.java
@@ -196,7 +196,7 @@ public class PreferenceServiceImpl implements PreferenceService, Extensible
             {
                 if(jsonPrefs.has(preferenceName))
                 {
-                    preferenceValue = jsonPrefs.getString(preferenceName);
+                    preferenceValue = String.valueOf(jsonPrefs.get(preferenceName));
                 }
             }
         }


### PR DESCRIPTION
json:json was upgraded to version 20200518 as per issue’s specifications (A/C).
Fix was introduced in the Repository considering the updated lib now converts the value put in the map. 

Resources below

Initial Core PR: https://github.com/Alfresco/alfresco-core/pull/165/
Core green build with released dev lib: https://travis-ci.com/github/Alfresco/alfresco-core/jobs/396299168

Initial Repository PR: https://github.com/Alfresco/alfresco-repository/pull/1245 
Repository green build with released dev lib: https://travis-ci.com/github/Alfresco/alfresco-repository/builds/188863082

Initial ACS-Packaging PR: https://github.com/Alfresco/acs-packaging/pull/1750
ACS-Packaging green build with the updated libs: https://travis-ci.com/github/Alfresco/acs-packaging/builds/188988355