### PR TITLE
Feature/repo 5369 acl resolution and paging inside db query engine

### DIFF
--- a/src/main/java/org/alfresco/ibatis/SqlSessionMetricsWrapper.java
+++ b/src/main/java/org/alfresco/ibatis/SqlSessionMetricsWrapper.java
@@ -217,7 +217,7 @@ public class SqlSessionMetricsWrapper implements SqlSession
         PassThroughMetricsResultsHandler passThroughHandler = new PassThroughMetricsResultsHandler(handler, startTime, statement);
         try
         {
-            this.select(statement, passThroughHandler);
+            this.sqlSession.select(statement, passThroughHandler);
         }
         finally
         {

--- a/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
+++ b/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
@@ -116,10 +116,10 @@ import org.springframework.util.Assert;
  */
 public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
 {
-    private static final String CACHE_REGION_ROOT_NODES = "N.RN";
-    private static final String CACHE_REGION_NODES = "N.N";
-    private static final String CACHE_REGION_ASPECTS = "N.A";
-    private static final String CACHE_REGION_PROPERTIES = "N.P";
+    public static final String CACHE_REGION_ROOT_NODES = "N.RN";
+    public static final String CACHE_REGION_NODES = "N.N";
+    public static final String CACHE_REGION_ASPECTS = "N.A";
+    public static final String CACHE_REGION_PROPERTIES = "N.P";
     
     private static final String KEY_LOST_NODE_PAIRS = AbstractNodeDAOImpl.class.getName() + ".lostNodePairs";
     private static final String KEY_DELETED_ASSOCS = AbstractNodeDAOImpl.class.getName() + ".deletedAssocs";

--- a/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
+++ b/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
@@ -427,7 +427,7 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
         NodeEntity node = new NodeEntity();
         node.setId(id);
         
-        logger.debug("+ Cache miss for node id: "+id);
+        logger.debug("+ Read node with id: "+id);
         return template.selectOne(SELECT_NODE_BY_ID, node);
     }
 
@@ -451,7 +451,7 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
         }
         node.setUuid(uuid);
         
-        logger.debug("+ Cache miss for node uuid: "+uuid);
+        logger.debug("+ Read node with uuid: "+uuid);
         return template.selectOne(SELECT_NODE_BY_NODEREF, node);
     }
 

--- a/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
+++ b/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
@@ -427,6 +427,7 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
         NodeEntity node = new NodeEntity();
         node.setId(id);
         
+        logger.debug("+ Cache miss for node id: "+id);
         return template.selectOne(SELECT_NODE_BY_ID, node);
     }
 
@@ -450,6 +451,7 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
         }
         node.setUuid(uuid);
         
+        logger.debug("+ Cache miss for node uuid: "+uuid);
         return template.selectOne(SELECT_NODE_BY_NODEREF, node);
     }
 

--- a/src/main/java/org/alfresco/repo/search/impl/lucene/PagingLuceneResultSet.java
+++ b/src/main/java/org/alfresco/repo/search/impl/lucene/PagingLuceneResultSet.java
@@ -52,6 +52,8 @@ public class PagingLuceneResultSet implements ResultSet, Serializable
     SearchParameters searchParameters;
     
     NodeService nodeService;
+
+    private boolean trimmedResultSet;
     
     public PagingLuceneResultSet(ResultSet wrapped, SearchParameters searchParameters, NodeService nodeService)
     {
@@ -116,15 +118,21 @@ public class PagingLuceneResultSet implements ResultSet, Serializable
 
         int max = searchParameters.getMaxItems();
         int skip = searchParameters.getSkipCount();
-        if ((max >= 0) && (max < (wrapped.length() - skip)))
+        int length = getWrappedResultSetLength();
+        if ((max >= 0) && (max < (length - skip)))
         {
             return searchParameters.getMaxItems();
         }
         else
         {
-            int lengthAfterSkipping = wrapped.length() - skip;
+            int lengthAfterSkipping = length - skip;
             return lengthAfterSkipping < 0 ? 0 : lengthAfterSkipping;
         }
+    }
+
+    private int getWrappedResultSetLength()
+    {
+        return trimmedResultSet ? Long.valueOf(wrapped.getNumberFound()).intValue() : wrapped.length();
     }
 
     /*
@@ -134,7 +142,14 @@ public class PagingLuceneResultSet implements ResultSet, Serializable
      */
     public int getStart()
     {
-        return searchParameters.getSkipCount();
+        if (trimmedResultSet)
+        {
+            return 0;
+        }
+        else
+        {
+            return searchParameters.getSkipCount();
+        }
     }
 
     /*
@@ -273,5 +288,10 @@ public class PagingLuceneResultSet implements ResultSet, Serializable
     public SpellCheckResult getSpellCheckResult()
     {
         return wrapped.getSpellCheckResult();
+    }
+
+    public void setTrimmedResultSet(boolean b)
+    {
+        this.trimmedResultSet = true;
     }
 }

--- a/src/main/java/org/alfresco/repo/search/impl/lucene/PagingLuceneResultSet.java
+++ b/src/main/java/org/alfresco/repo/search/impl/lucene/PagingLuceneResultSet.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.alfresco.repo.security.permissions.impl.acegi.FilteringResultSet;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
@@ -132,7 +133,7 @@ public class PagingLuceneResultSet implements ResultSet, Serializable
 
     private int getWrappedResultSetLength()
     {
-        return trimmedResultSet ? Long.valueOf(wrapped.getNumberFound()).intValue() : wrapped.length();
+        return trimmedResultSet ? wrapped.length() + searchParameters.getSkipCount() : wrapped.length();
     }
 
     /*
@@ -269,7 +270,14 @@ public class PagingLuceneResultSet implements ResultSet, Serializable
     @Override
     public long getNumberFound()
     {
-       return wrapped.getNumberFound();
+        if (trimmedResultSet && wrapped instanceof FilteringResultSet)
+        {
+            return ((FilteringResultSet) wrapped).getUnFilteredResultSet().getNumberFound();
+        }
+        else
+        {
+            return wrapped.getNumberFound();
+        }
     }
 
     @Override

--- a/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
+++ b/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
@@ -25,7 +25,12 @@
  */
 package org.alfresco.repo.search.impl.querymodel.impl.db;
 
+import static org.alfresco.repo.domain.node.AbstractNodeDAOImpl.CACHE_REGION_NODES;
+
+import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -33,11 +38,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.admin.patch.OptionalPatchApplicationCheckBootstrapBean;
+import org.alfresco.repo.cache.SimpleCache;
+import org.alfresco.repo.cache.lookup.EntityLookupCache;
+import org.alfresco.repo.cache.lookup.EntityLookupCache.EntityLookupCallbackDAOAdaptor;
 import org.alfresco.repo.domain.node.Node;
 import org.alfresco.repo.domain.node.NodeDAO;
+import org.alfresco.repo.domain.node.NodeVersionKey;
 import org.alfresco.repo.domain.qname.QNameDAO;
+import org.alfresco.repo.search.SimpleResultSetMetaData;
 import org.alfresco.repo.search.impl.lucene.PagingLuceneResultSet;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.Query;
@@ -46,22 +58,32 @@ import org.alfresco.repo.search.impl.querymodel.QueryEngineResults;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.QueryModelFactory;
 import org.alfresco.repo.search.impl.querymodel.QueryOptions;
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.repo.security.permissions.impl.acegi.FilteringResultSet;
 import org.alfresco.repo.tenant.TenantService;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
+import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
 import org.alfresco.service.cmr.repository.StoreRef;
+import org.alfresco.service.cmr.search.LimitBy;
+import org.alfresco.service.cmr.search.PermissionEvaluationMode;
 import org.alfresco.service.cmr.search.ResultSet;
+import org.alfresco.service.cmr.security.OwnableService;
+import org.alfresco.service.cmr.security.PermissionService;
 import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
+import org.alfresco.util.EqualsHelper;
 import org.alfresco.util.Pair;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.ibatis.session.ResultContext;
+import org.apache.ibatis.session.ResultHandler;
 import org.mybatis.spring.SqlSessionTemplate;
-import org.springframework.util.StopWatch;
 
 /**
  * @author Andy
  */
+@NotThreadSafe
 public class DBQueryEngine implements QueryEngine
 {
     protected static final Log logger = LogFactory.getLog(DBQueryEngine.class);
@@ -83,7 +105,45 @@ public class DBQueryEngine implements QueryEngine
     private TenantService tenantService;
     
     private OptionalPatchApplicationCheckBootstrapBean metadataIndexCheck2;
+    
+    private EntityLookupCache<Long, Node, NodeRef> nodesCache;
 
+    private PermissionService permissionService;
+
+    private OwnableService ownableService;
+    
+    private int maxPermissionChecks;
+    
+    private long maxPermissionCheckTimeMillis;
+
+    private SimpleCache<NodeVersionKey, Map<QName, Serializable>> propertiesCache;
+    
+    public void setMaxPermissionChecks(int maxPermissionChecks)
+    {
+        this.maxPermissionChecks = maxPermissionChecks;
+    }
+    
+    public void setMaxPermissionCheckTimeMillis(long maxPermissionCheckTimeMillis)
+    {
+        this.maxPermissionCheckTimeMillis = maxPermissionCheckTimeMillis;
+    }
+
+    public void setOwnableService(OwnableService ownableService)
+    {
+        this.ownableService = ownableService;
+    }
+
+    public void setTemplate(SqlSessionTemplate template)
+    {
+        this.template = template;
+    }
+
+    public void setPermissionService(PermissionService permissionService)
+    {
+        this.permissionService = permissionService;
+    }
+    
+    
     public void setMetadataIndexCheck2(OptionalPatchApplicationCheckBootstrapBean metadataIndexCheck2)
     {
         this.metadataIndexCheck2 = metadataIndexCheck2;
@@ -152,6 +212,8 @@ public class DBQueryEngine implements QueryEngine
     @Override
     public QueryEngineResults executeQuery(Query query, QueryOptions options, FunctionEvaluationContext functionContext)
     {
+        logger.debug("Query request received");
+        
         Set<String> selectorGroup = null;
         if (query.getSource() != null)
         {
@@ -205,47 +267,172 @@ public class DBQueryEngine implements QueryEngine
         }
         dbQuery.setSinceTxId(sinceTxId);
         
+        logger.debug("- query is being prepared");
         dbQuery.prepare(namespaceService, dictionaryService, qnameDAO, nodeDAO, tenantService, selectorGroup, null, functionContext, metadataIndexCheck2.getPatchApplied());
         
-        List<Node> nodes;
-        if (logger.isDebugEnabled()) 
+        ResultSet resultSet;
+        if (cleanCacheRequest(options)) {
+            nodesCache.clear();
+            propertiesCache.clear();
+            logger.info("Nodes cache cleared");
+            resultSet = new DBResultSet(options.getAsSearchParmeters(), Collections.emptyList(), nodeDAO, nodeService, tenantService, Integer.MAX_VALUE);
+        }
+        else if (resolvePermissionsNow(options))
         {
-            StopWatch stopWatch = new StopWatch("db query");
-            stopWatch.start();
-            nodes = selectNodes(options, dbQuery);
-            stopWatch.stop();
-            logger.debug("Selected " + nodes.size() + " nodes in " + stopWatch.getLastTaskTimeMillis() + "ms");
+            resultSet = selectNodesWithPermissions(options, dbQuery);
+            logger.info("Selected " +resultSet.length()+ " nodes with accelerated permission resolution");
         }
         else
         {
-            nodes = selectNodes(options, dbQuery);
+            resultSet = selectNodesStandard(options, dbQuery);
+            logger.info("Selected " +resultSet.length()+ " nodes with standard permission resolution");
         }
         
-        QueryEngineResults queryResults = createQueryResults(nodes, options);
-        return queryResults;
+        return asQueryEngineResults(resultSet);
+    }
+    
+    protected String pickQueryTemplate(QueryOptions options, DBQuery dbQuery)
+    {
+        logger.debug("- using standard table for the query");
+        return SELECT_BY_DYNAMIC_QUERY;
+    }
+    
+    private ResultSet selectNodesStandard(QueryOptions options, DBQuery dbQuery)
+    {
+        List<Node> nodes = removeDuplicates(template.selectList(pickQueryTemplate(options, dbQuery), dbQuery));
+        DBResultSet rs = new DBResultSet(options.getAsSearchParmeters(), nodes, nodeDAO, nodeService, tenantService, Integer.MAX_VALUE);
+        PagingLuceneResultSet plrs = new PagingLuceneResultSet(rs, options.getAsSearchParmeters(), nodeService);
+        return plrs;
+    }
+    
+    private ResultSet selectNodesWithPermissions(QueryOptions options, DBQuery dbQuery)
+    {
+        NodePermissionAssessor permissionAssessor = createAssessor(options);
+        
+        FilteringResultSet resultSet = acceleratedNodeSelection(options, dbQuery, permissionAssessor);
+        
+        PagingLuceneResultSet plrs = new PagingLuceneResultSet(resultSet, options.getAsSearchParmeters(), nodeService);
+        plrs.setTrimmedResultSet(true);
+        return plrs;
     }
 
-    protected QueryEngineResults createQueryResults(List<Node> nodes, QueryOptions options)
+    NodePermissionAssessor createAssessor(QueryOptions options)
     {
-        LinkedHashSet<Long> set = new LinkedHashSet<Long>(nodes.size());
-        for (Node node : nodes)
-        {
-            set.add(node.getId());
-        }
-        List<Long> nodeIds = new ArrayList<Long>(set);
-        ResultSet rs = new DBResultSet(options.getAsSearchParmeters(), nodeIds, nodeDAO, nodeService, tenantService, Integer.MAX_VALUE);
-        ResultSet paged = new PagingLuceneResultSet(rs, options.getAsSearchParmeters(), nodeService);
+        NodePermissionAssessor permissionAssessor = new NodePermissionAssessor();
+        int maxPermsChecks = options.getMaxPermissionChecks() < 0 ? maxPermissionChecks : options.getMaxPermissionChecks();
+        long maxPermCheckTimeMillis = options.getMaxPermissionCheckTimeMillis() < 0 ? maxPermissionCheckTimeMillis : options.getMaxPermissionCheckTimeMillis();
+        permissionAssessor.setMaxPermissionChecks(maxPermsChecks);
+        permissionAssessor.setMaxPermissionCheckTimeMillis(maxPermCheckTimeMillis);
+        return permissionAssessor;
+    }
 
-        Map<Set<String>, ResultSet> answer = new HashMap<Set<String>, ResultSet>();
+    FilteringResultSet acceleratedNodeSelection(QueryOptions options, DBQuery dbQuery, NodePermissionAssessor permissionAssessor)
+    {
+        List<Node> nodes = new ArrayList<>();
+        int requiredNodes = computeRequiredNodesCount(options);
+        
+        logger.debug("- query sent to the database");
+        template.select(pickQueryTemplate(options, dbQuery), dbQuery, new ResultHandler<Node>()
+        {
+            @Override
+            public void handleResult(ResultContext<? extends Node> context)
+            {
+                if (nodes.size() >= requiredNodes)
+                {
+                    context.stop();
+                    return;
+                }
+                
+                Node node = context.getResultObject();
+                
+                boolean shouldCache = nodes.size() >= options.getSkipCount();
+                if(shouldCache)
+                {
+                    logger.debug("- selected node "+nodes.size()+": "+node.getUuid()+" "+node.getId());
+                    nodesCache.setValue(node.getId(), node);
+                }
+                else
+                {
+                    logger.debug("- skipped node "+nodes.size()+": "+node.getUuid()+" "+node.getId());
+                }
+                
+                if (permissionAssessor.isIncluded(node))
+                {
+                    nodes.add(shouldCache ? node : null);
+                }
+                
+                if (permissionAssessor.shouldQuitChecks())
+                {
+                    context.stop();
+                    return;
+                }
+            }
+        });
+
+        int numberFound = nodes.size();
+        nodes.removeAll(Collections.singleton(null));
+        
+        DBResultSet rs =  createResultSet(options, nodes, numberFound);
+        FilteringResultSet frs = new FilteringResultSet(rs, formInclusionMask(nodes));
+        frs.setResultSetMetaData(new SimpleResultSetMetaData(LimitBy.UNLIMITED, PermissionEvaluationMode.EAGER, rs.getResultSetMetaData().getSearchParameters()));
+ 
+        logger.debug("- query is completed, "+nodes.size()+" nodes loaded");
+        return frs;
+    }
+
+    private DBResultSet createResultSet(QueryOptions options, List<Node> nodes, int numberFound)
+    {
+        DBResultSet dbResultSet = new DBResultSet(options.getAsSearchParmeters(), nodes, nodeDAO, nodeService, tenantService, Integer.MAX_VALUE);
+        dbResultSet.setNumberFound(numberFound);
+        return dbResultSet;
+    }
+
+    private int computeRequiredNodesCount(QueryOptions options)
+    {
+        if (options.getMaxItems() == -1)
+        {
+            return Integer.MAX_VALUE;
+        }
+        
+        return options.getMaxItems() + options.getSkipCount() + 1;
+    }
+
+    private BitSet formInclusionMask(List<Node> nodes)
+    {
+        BitSet inclusionMask = new BitSet(nodes.size());
+        for (int i=0; i < nodes.size(); i++)
+        {
+            inclusionMask.set(i, true);
+        }
+        return inclusionMask;
+    }
+
+    
+    private QueryEngineResults asQueryEngineResults(ResultSet paged)
+    {
         HashSet<String> key = new HashSet<String>();
         key.add("");
+        Map<Set<String>, ResultSet> answer = new HashMap<Set<String>, ResultSet>();
         answer.put(key, paged);
+
         return new QueryEngineResults(answer);
     }
-
-    protected List<Node> selectNodes(QueryOptions options, DBQuery dbQuery)
+    
+    private List<Node> removeDuplicates(List<Node> nodes)
     {
-        return template.selectList(SELECT_BY_DYNAMIC_QUERY, dbQuery);
+        LinkedHashSet<Node> uniqueNodes = new LinkedHashSet<>(nodes.size());
+        List<Long> checkedNodeIds = new ArrayList<>(nodes.size());
+
+        for (Node node : nodes)
+        {
+            if (!checkedNodeIds.contains(node.getId()))
+            {
+                checkedNodeIds.add(node.getId());
+                uniqueNodes.add(node);
+            }
+        }
+
+        return new ArrayList<Node>(uniqueNodes);
     }
 
     /*
@@ -258,4 +445,194 @@ public class DBQueryEngine implements QueryEngine
         return new DBQueryModelFactory();
     }
 
+    public class NodePermissionAssessor {
+        
+        private int maxPermissionChecks;
+        private int checksPerformed;
+        private long maxPermissionCheckTimeMillis;
+        private long timeCreated;
+        
+        public NodePermissionAssessor()
+        {
+           this.checksPerformed = 0;
+           this.maxPermissionChecks = Integer.MAX_VALUE;
+           this.maxPermissionCheckTimeMillis = Long.MAX_VALUE;
+        }
+        
+        public boolean isIncluded(Node node)
+        { 
+            if (isFirstRecord())
+            {
+                this.timeCreated = System.currentTimeMillis();
+            }
+            
+            if (shouldQuitChecks())
+            {
+                return false;
+            }
+            
+            checksPerformed++;
+            return isReallyIncluded(node);
+        }
+
+        public boolean isFirstRecord()
+        {
+            return checksPerformed == 0;
+        }
+
+        boolean isReallyIncluded(Node node)
+        {
+            return adminRead() || canRead(node.getAclId()) ||
+                    ownerRead(node.getNodeRef());
+        }
+
+        public void setMaxPermissionChecks(int maxPermissionChecks)
+        {
+            this.maxPermissionChecks = maxPermissionChecks;
+        }
+        
+        public boolean shouldQuitChecks()
+        {
+            boolean result = false;
+            
+            if (checksPerformed >= maxPermissionChecks)
+            {
+                result = true;
+            }
+            
+            if ((System.currentTimeMillis() - timeCreated) >= maxPermissionCheckTimeMillis)
+            {
+                result = true;
+            }
+            
+            return result;
+        }
+        
+        public int getMaxPermissionChecks()
+        {
+            return this.maxPermissionChecks;
+        }
+
+        public void setMaxPermissionCheckTimeMillis(long maxPermissionCheckTimeMillis)
+        {
+            this.maxPermissionCheckTimeMillis = maxPermissionCheckTimeMillis;
+        }
+        
+        public long getMaxPermissionCheckTimeMillis()
+        {
+            return this.maxPermissionCheckTimeMillis;
+        }
+    }
+    
+    private boolean ownerRead(NodeRef nodeRef)
+    {
+        String username = AuthenticationUtil.getRunAsUser();
+
+        String owner = ownableService.getOwner(nodeRef);
+        if (EqualsHelper.nullSafeEquals(username, owner))
+        {
+            return true;
+        } 
+        else 
+        {
+            return false;
+        }
+    }
+
+    private boolean adminRead()
+    {
+        Set<String> authorisations = permissionService.getAuthorisations();
+        return authorisations.contains(AuthenticationUtil.getAdminRoleName());
+    }
+    
+    private boolean canRead(Long aclId)
+    {
+        Set<String> authorities = permissionService.getAuthorisations();
+
+        Set<String> aclReadersDenied = permissionService.getReadersDenied(aclId);
+        for (String auth : aclReadersDenied)
+        {
+            if (authorities.contains(auth))
+            {
+                return false;
+            }
+        }
+
+        Set<String> aclReaders = permissionService.getReaders(aclId);
+        for (String auth : aclReaders)
+        {
+            if (authorities.contains(auth))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean cleanCacheRequest(QueryOptions options)
+    {
+        return "xxx".equals(getLocaleLanguage(options));
+    }
+    
+    char getMagicCharFromLocale(QueryOptions options, int index)
+    {
+        String lang = getLocaleLanguage(options);
+        return lang.length() > index ? lang.charAt(index) : ' ';
+    }
+    
+    private boolean resolvePermissionsNow(QueryOptions options)
+    {
+        return getMagicCharFromLocale(options, 2) == 'f';
+    }
+    
+    private String getLocaleLanguage(QueryOptions options)
+    {
+        return options.getLocales().size() == 1 ? options.getLocales().get(0).getLanguage() : "";
+    }
+    
+    /* 
+     * Injection of nodes cache for clean-up when required
+     */
+    public void setNodesCache(SimpleCache<Serializable, Serializable> cache)
+    {
+        this.nodesCache = new EntityLookupCache<Long, Node, NodeRef>(
+                cache,
+                CACHE_REGION_NODES,
+                new ReadonlyLocalCallbackDAO());
+    }
+
+    void setNodesCache(EntityLookupCache<Long, Node, NodeRef> nodesCache) 
+    {
+        this.nodesCache = nodesCache;
+    }
+    
+    private class ReadonlyLocalCallbackDAO extends EntityLookupCallbackDAOAdaptor<Long, Node, NodeRef>
+    {
+        @Override
+        public Pair<Long, Node> createValue(Node value)
+        {
+            throw new UnsupportedOperationException("Node creation is done externally: " + value);
+        }
+
+        @Override
+        public Pair<Long, Node> findByKey(Long nodeId)
+        {
+            return null;
+        }
+
+        @Override
+        public NodeRef getValueKey(Node value)
+        {
+            return value.getNodeRef();
+        }
+    }
+
+    /* 
+     * TEMPORARY - Injection of nodes cache for clean-up when required
+     */
+    public void setPropertiesCache(SimpleCache<NodeVersionKey, Map<QName, Serializable>> propertiesCache)
+    {
+        this.propertiesCache = propertiesCache;
+    }
 }

--- a/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
+++ b/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
@@ -143,7 +143,6 @@ public class DBQueryEngine implements QueryEngine
         this.permissionService = permissionService;
     }
     
-    
     public void setMetadataIndexCheck2(OptionalPatchApplicationCheckBootstrapBean metadataIndexCheck2)
     {
         this.metadataIndexCheck2 = metadataIndexCheck2;
@@ -302,8 +301,7 @@ public class DBQueryEngine implements QueryEngine
     {
         List<Node> nodes = removeDuplicates(template.selectList(pickQueryTemplate(options, dbQuery), dbQuery));
         DBResultSet rs = new DBResultSet(options.getAsSearchParmeters(), nodes, nodeDAO, nodeService, tenantService, Integer.MAX_VALUE);
-        PagingLuceneResultSet plrs = new PagingLuceneResultSet(rs, options.getAsSearchParmeters(), nodeService);
-        return plrs;
+        return new PagingLuceneResultSet(rs, options.getAsSearchParmeters(), nodeService);
     }
     
     private ResultSet selectNodesWithPermissions(QueryOptions options, DBQuery dbQuery)
@@ -365,7 +363,6 @@ public class DBQueryEngine implements QueryEngine
                 if (permissionAssessor.shouldQuitChecks())
                 {
                     context.stop();
-                    return;
                 }
             }
         });
@@ -411,9 +408,9 @@ public class DBQueryEngine implements QueryEngine
     
     private QueryEngineResults asQueryEngineResults(ResultSet paged)
     {
-        HashSet<String> key = new HashSet<String>();
+        HashSet<String> key = new HashSet<>();
         key.add("");
-        Map<Set<String>, ResultSet> answer = new HashMap<Set<String>, ResultSet>();
+        Map<Set<String>, ResultSet> answer = new HashMap<>();
         answer.put(key, paged);
 
         return new QueryEngineResults(answer);
@@ -528,16 +525,8 @@ public class DBQueryEngine implements QueryEngine
     private boolean ownerRead(NodeRef nodeRef)
     {
         String username = AuthenticationUtil.getRunAsUser();
-
         String owner = ownableService.getOwner(nodeRef);
-        if (EqualsHelper.nullSafeEquals(username, owner))
-        {
-            return true;
-        } 
-        else 
-        {
-            return false;
-        }
+        return EqualsHelper.nullSafeEquals(username, owner);
     }
 
     private boolean adminRead()
@@ -592,12 +581,13 @@ public class DBQueryEngine implements QueryEngine
         return options.getLocales().size() == 1 ? options.getLocales().get(0).getLanguage() : "";
     }
     
-    /* 
+    /**
      * Injection of nodes cache for clean-up and warm up when required
+     * @param cache The node cache to set
      */
     public void setNodesCache(SimpleCache<Serializable, Serializable> cache)
     {
-        this.nodesCache = new EntityLookupCache<Long, Node, NodeRef>(
+        this.nodesCache = new EntityLookupCache<>(
                 cache,
                 CACHE_REGION_NODES,
                 new ReadonlyLocalCallbackDAO());

--- a/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
+++ b/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
@@ -271,6 +271,7 @@ public class DBQueryEngine implements QueryEngine
         dbQuery.prepare(namespaceService, dictionaryService, qnameDAO, nodeDAO, tenantService, selectorGroup, null, functionContext, metadataIndexCheck2.getPatchApplied());
         
         ResultSet resultSet;
+        // TEMPORARY - this first branch of the if statement simply allows us to easily clear the caches for now; it will be removed afterwards
         if (cleanCacheRequest(options)) {
             nodesCache.clear();
             propertiesCache.clear();
@@ -280,12 +281,12 @@ public class DBQueryEngine implements QueryEngine
         else if (resolvePermissionsNow(options))
         {
             resultSet = selectNodesWithPermissions(options, dbQuery);
-            logger.info("Selected " +resultSet.length()+ " nodes with accelerated permission resolution");
+            logger.debug("Selected " +resultSet.length()+ " nodes with accelerated permission resolution");
         }
         else
         {
             resultSet = selectNodesStandard(options, dbQuery);
-            logger.info("Selected " +resultSet.length()+ " nodes with standard permission resolution");
+            logger.debug("Selected " +resultSet.length()+ " nodes with standard permission resolution");
         }
         
         return asQueryEngineResults(resultSet);
@@ -592,7 +593,7 @@ public class DBQueryEngine implements QueryEngine
     }
     
     /* 
-     * Injection of nodes cache for clean-up when required
+     * Injection of nodes cache for clean-up and warm up when required
      */
     public void setNodesCache(SimpleCache<Serializable, Serializable> cache)
     {

--- a/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBResultSet.java
+++ b/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBResultSet.java
@@ -25,14 +25,12 @@
  */
 package org.alfresco.repo.search.impl.querymodel.impl.db;
 
-import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Iterator;
 import java.util.List;
 
 import org.alfresco.repo.domain.node.Node;
 import org.alfresco.repo.domain.node.NodeDAO;
-import org.alfresco.repo.domain.node.NodeIdAndAclId;
 import org.alfresco.repo.search.AbstractResultSet;
 import org.alfresco.repo.search.SimpleResultSetMetaData;
 import org.alfresco.repo.tenant.TenantService;
@@ -44,7 +42,6 @@ import org.alfresco.service.cmr.search.PermissionEvaluationMode;
 import org.alfresco.service.cmr.search.ResultSetMetaData;
 import org.alfresco.service.cmr.search.ResultSetRow;
 import org.alfresco.service.cmr.search.SearchParameters;
-import org.alfresco.util.Pair;
 
 /**
  * @author Andy

--- a/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBResultSet.java
+++ b/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBResultSet.java
@@ -30,7 +30,9 @@ import java.util.BitSet;
 import java.util.Iterator;
 import java.util.List;
 
+import org.alfresco.repo.domain.node.Node;
 import org.alfresco.repo.domain.node.NodeDAO;
+import org.alfresco.repo.domain.node.NodeIdAndAclId;
 import org.alfresco.repo.search.AbstractResultSet;
 import org.alfresco.repo.search.SimpleResultSetMetaData;
 import org.alfresco.repo.tenant.TenantService;
@@ -50,9 +52,7 @@ import org.alfresco.util.Pair;
  */
 public class DBResultSet extends AbstractResultSet
 {
-    private List<Long> dbids;
-    
-    private NodeRef[] nodeRefs;
+    private List<Node> nodes;
     
     private NodeDAO nodeDao;
     
@@ -64,14 +64,16 @@ public class DBResultSet extends AbstractResultSet
     
     private BitSet prefetch;
     
-    public DBResultSet(SearchParameters searchParameters, List<Long> dbids, NodeDAO nodeDao,  NodeService nodeService, TenantService tenantService, int maximumResultsFromUnlimitedQuery)
+    private int numberFound;
+    
+    public DBResultSet(SearchParameters searchParameters, List<Node> nodes, NodeDAO nodeDao,  NodeService nodeService, TenantService tenantService, int maximumResultsFromUnlimitedQuery)
     {
         this.nodeDao = nodeDao;
-        this.dbids = dbids;
+        this.nodes = nodes;
         this.nodeService = nodeService;
         this.tenantService = tenantService;
-        this.prefetch = new BitSet(dbids.size());
-        nodeRefs= new NodeRef[(dbids.size())];
+        this.prefetch = new BitSet(nodes.size());
+        this.numberFound = nodes.size();
         
         final LimitBy limitBy;
         int maxResults = -1;
@@ -96,9 +98,10 @@ public class DBResultSet extends AbstractResultSet
         }
         
         this.resultSetMetaData = new SimpleResultSetMetaData(
-                maxResults > 0 && dbids.size() < maxResults ? LimitBy.UNLIMITED : limitBy,
+                maxResults > 0 && nodes.size() < maxResults ? LimitBy.UNLIMITED : limitBy,
                 PermissionEvaluationMode.EAGER, searchParameters);
     }
+    
 
     /* (non-Javadoc)
      * @see org.alfresco.service.cmr.search.ResultSetSPI#length()
@@ -106,7 +109,12 @@ public class DBResultSet extends AbstractResultSet
     @Override
     public int length()
     {
-        return dbids.size();
+        return nodes.size();
+    }
+    
+    public void setNumberFound(int numFound)
+    {
+        this.numberFound = numFound;
     }
 
     /* (non-Javadoc)
@@ -115,7 +123,7 @@ public class DBResultSet extends AbstractResultSet
     @Override
     public long getNumberFound()
     {
-        return dbids.size();
+        return numberFound;
     }
 
     /* (non-Javadoc)
@@ -124,8 +132,9 @@ public class DBResultSet extends AbstractResultSet
     @Override
     public NodeRef getNodeRef(int n)
     {
-        prefetch(n);
-        return nodeRefs[n];
+        NodeRef nodeRef = nodes.get(n).getNodeRef();
+        nodeRef = tenantService.getBaseName(nodeRef);
+        return nodeRef;
     }
 
     /* (non-Javadoc)
@@ -190,61 +199,13 @@ public class DBResultSet extends AbstractResultSet
         return new DBResultSetRowIterator(this);
     }
     
-    private void prefetch(int n)
-    {
-       
-        if (prefetch.get(n))
-        {
-            // The document was already processed
-            return;
-        }
-        // Start at 'n' and process the the next bulk set
-        int bulkFetchSize = getBulkFetchSize();
-        if (bulkFetchSize < 1)
-        {
-            Pair<Long, NodeRef> nodePair = nodeDao.getNodePair(dbids.get(n));
-            NodeRef nodeRef = nodePair == null ? null : nodePair.getSecond();
-            nodeRefs[n] = nodeRef == null ? null : tenantService.getBaseName(nodeRef);
-            return;
-        }
-        
-        List<Long> fetchList = new ArrayList<Long>(bulkFetchSize);
-        BitSet done = new BitSet(bulkFetchSize);
-        int totalHits = dbids.size();
-        for (int i = 0; i < bulkFetchSize; i++)
-        {
-            int next = n + i;
-            if (next >= totalHits)
-            {
-                // We've hit the end
-                break;
-            }
-            if (prefetch.get(next))
-            {
-                // This one is in there already
-                continue;
-            }
-            // We store the node and mark it as prefetched
-            prefetch.set(next);
-            
-            fetchList.add(dbids.get(next));
-            done.set(next);
-        }
-        // Now bulk fetch
-        if (fetchList.size() > 1)
-        {
-            nodeDao.cacheNodesById(fetchList);
-            for (int i = done.nextSetBit(0); i >= 0; i = done.nextSetBit(i+1)) 
-            {
-                NodeRef nodeRef = nodeDao.getNodePair(fetchList.get(i)).getSecond();
-                nodeRefs[n+1] = nodeRef == null ? null : tenantService.getBaseName(nodeRef);
-            }
-        }
-    }
-    
     public NodeService getNodeService()
     {
         return nodeService;
     }
-
+    
+    public Node getNode(int n)
+    {
+        return nodes.get(n);
+    }
 }

--- a/src/main/java/org/alfresco/repo/security/permissions/impl/acegi/FilteringResultSet.java
+++ b/src/main/java/org/alfresco/repo/security/permissions/impl/acegi/FilteringResultSet.java
@@ -357,7 +357,7 @@ public class FilteringResultSet extends ACLEntryAfterInvocationProvider implemen
     @Override
     public long getNumberFound()
     {
-        return this.unfiltered.getNumberFound();
+        return inclusionMask.cardinality();
     }
     
     @Override

--- a/src/main/java/org/alfresco/repo/security/permissions/impl/acegi/FilteringResultSet.java
+++ b/src/main/java/org/alfresco/repo/security/permissions/impl/acegi/FilteringResultSet.java
@@ -357,7 +357,7 @@ public class FilteringResultSet extends ACLEntryAfterInvocationProvider implemen
     @Override
     public long getNumberFound()
     {
-        return inclusionMask.cardinality();
+        return this.unfiltered.getNumberFound();
     }
     
     @Override

--- a/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/metadata-query-SqlMap.xml
+++ b/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/metadata-query-SqlMap.xml
@@ -4,7 +4,7 @@
 
 <mapper namespace="alfresco.metadata.query">
 
-  <select id="select_byDynamicQuery" fetchSize="200" parameterType="org.alfresco.repo.search.impl.querymodel.impl.db.DBQuery" resultMap="alfresco.node.result_NodeRef">
+  <select id="select_byDynamicQuery" fetchSize="200" parameterType="org.alfresco.repo.search.impl.querymodel.impl.db.DBQuery" resultMap="alfresco.node.result_Node">
       <include refid="sql_select_byDynamicQuery"/>   
   </select>
 

--- a/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/metadata-query-common-SqlMap.xml
+++ b/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/metadata-query-common-SqlMap.xml
@@ -6,9 +6,26 @@
 
    <sql id="sql_select_byDynamicQuery">
         select 
-            node.id             as id
+            node.id             as id,
+            node.version        as version,
+            store.id            as store_id,
+            store.protocol      as protocol,
+            store.identifier    as identifier,
+            node.uuid           as uuid,
+            node.type_qname_id  as type_qname_id,
+            node.locale_id      as locale_id,
+            node.acl_id         as acl_id,
+            txn.id              as txn_id,
+            txn.change_txn_id   as txn_change_id,
+            node.audit_creator  as audit_creator,
+            node.audit_created  as audit_created,
+            node.audit_modifier as audit_modifier,
+            node.audit_modified as audit_modified,
+            node.audit_accessed as audit_accessed
         from
             alf_node node
+            join alf_store store on (store.id = node.store_id)
+            join alf_transaction txn on (txn.id = node.transaction_id)
             <foreach item="item" index="index" collection="joins">
                 <choose>
                     <when test="item.type == 'PARENT'">

--- a/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/metadata-query-SqlMap.xml
+++ b/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/metadata-query-SqlMap.xml
@@ -4,7 +4,7 @@
 
 <mapper namespace="alfresco.metadata.query">
 
-  <select id="select_byDynamicQuery" fetchSize="-2147483648" parameterType="org.alfresco.repo.search.impl.querymodel.impl.db.DBQuery" resultMap="alfresco.node.result_NodeRef">
+  <select id="select_byDynamicQuery" fetchSize="-2147483648" parameterType="org.alfresco.repo.search.impl.querymodel.impl.db.DBQuery" resultMap="alfresco.node.result_Node">
       <include refid="sql_select_byDynamicQuery"/>   
   </select>
 

--- a/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
+++ b/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
@@ -107,6 +107,8 @@
     </bean>
     
     <bean id="search.dbQueryEngineImpl" class="org.alfresco.repo.search.impl.querymodel.impl.db.DBQueryEngine" >
+        <property name="permissionService" ref="permissionService"/>
+        <property name="ownableService" ref="ownableService"/>
         <property name="dictionaryService" ref="dictionaryService" />
         <property name="namespaceService" ref="namespaceService" />
         <property name="sqlSessionTemplate" ref="repoSqlSessionTemplate"/>
@@ -114,8 +116,16 @@
         <property name="nodeService" ref="nodeService"/>
         <property name="nodeDAO" ref="nodeDAO"/>
         <property name="tenantService" ref="tenantService"/>
+        <property name="nodesCache" ref="node.nodesCache"/>
+        <property name="propertiesCache" ref="node.propertiesCache"/>
         <property name="metadataIndexCheck2">
             <ref bean="metadataQueryIndexesCheck2" />
+        </property>
+        <property name="maxPermissionChecks">
+        	<value>${system.acl.maxPermissionChecks}</value>
+        </property>
+        <property name="maxPermissionCheckTimeMillis">
+        	<value>${system.acl.maxPermissionCheckTimeMillis}</value>
         </property>
     </bean>
    

--- a/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
+++ b/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
@@ -1,0 +1,248 @@
+package org.alfresco.repo.search.impl.querymodel.impl.db;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.alfresco.repo.cache.lookup.EntityLookupCache;
+import org.alfresco.repo.domain.node.Node;
+import org.alfresco.repo.domain.node.NodeEntity;
+import org.alfresco.repo.search.impl.querymodel.QueryOptions;
+import org.alfresco.repo.search.impl.querymodel.impl.db.DBQueryEngine.NodePermissionAssessor;
+import org.alfresco.repo.security.permissions.impl.acegi.FilteringResultSet;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.search.ResultSet;
+import org.alfresco.service.cmr.search.SearchParameters;
+import org.apache.ibatis.executor.result.DefaultResultContext;
+import org.apache.ibatis.session.ResultContext;
+import org.apache.ibatis.session.ResultHandler;
+import org.junit.Before;
+import org.junit.Test;
+import org.mybatis.spring.SqlSessionTemplate;
+
+public class DBQueryEngineTest
+{
+    private static final String SQL_TEMPLATE_PATH = "alfresco.metadata.query.select_byDynamicQuery";
+    
+    private DBQueryEngine engine;
+    private SqlSessionTemplate template;
+    private NodePermissionAssessor assessor;
+    private DBQuery dbQuery;
+    private ResultContext<Node> resultContext;
+    private QueryOptions options;
+    private EntityLookupCache<Long, Node, NodeRef> nodesCache;
+
+    @Before
+    public void setup()
+    {
+        template = mock(SqlSessionTemplate.class);
+        nodesCache = mock(EntityLookupCache.class);
+        engine = new DBQueryEngine();
+        engine.setSqlSessionTemplate(template);
+        engine.setNodesCache(nodesCache);
+        assessor = mock(NodePermissionAssessor.class);
+        dbQuery = mock(DBQuery.class);
+        resultContext = spy(new DefaultResultContext<>());
+        options = createQueryOptions();
+    }
+    
+    @Test
+    public void shoulGetAFilteringResultSetFromDenormalisedNodeSelection()
+    {
+        withMaxItems(10);
+
+        ResultSet result = engine.acceleratedNodeSelection(options, dbQuery, assessor);
+
+        assertTrue(result instanceof FilteringResultSet);
+    }
+
+    @Test
+    public void shouldResultSetHaveExpectedAmountOfRequiredNodesBasedOnMaxItems()
+    {
+        withMaxItems(5);
+        prepareTemplate(dbQuery, createNodes(20));
+        when(assessor.isIncluded(any(Node.class))).thenReturn(true);
+                
+        FilteringResultSet result = engine.acceleratedNodeSelection(options, dbQuery, assessor);
+        
+        assertEquals(6, result.length());
+        assertNodePresent(0, result);
+        assertNodePresent(1, result);
+        assertNodePresent(2, result);
+        assertNodePresent(3, result);
+        assertNodePresent(4, result);
+    }
+    
+    @Test
+    public void shouldResultContextBeClosedWhenMaxItemsReached()
+    {
+        withMaxItems(5);
+        prepareTemplate(dbQuery, createNodes(20));
+        when(assessor.isIncluded(any(Node.class))).thenReturn(true);
+                
+        FilteringResultSet result = engine.acceleratedNodeSelection(options, dbQuery, assessor);
+
+        verify(resultContext).stop();
+        assertEquals(6, result.length());
+    }
+
+    @Test
+    public void shouldResultSetHaveCorrectAmountOfRequiredNodesWhenSkipCountIsUsed()
+    {
+        withMaxItems(5);
+        withSkipCount(10);
+        prepareTemplate(dbQuery, createNodes(20));
+        when(assessor.isIncluded(any(Node.class))).thenReturn(true);
+                
+        FilteringResultSet result = engine.acceleratedNodeSelection(options, dbQuery, assessor);
+        
+        assertEquals(6, result.length());
+        assertNodePresent(10, result);
+        assertNodePresent(11, result);
+        assertNodePresent(12, result);
+        assertNodePresent(13, result);
+        assertNodePresent(14, result);
+    }
+    
+    @Test
+    public void shouldResultSetHaveCorrectAmountOfRequiredNodesWhenSomeAreExcludedDueToDeclinedPermission()
+    {
+        withMaxItems(5);
+        List<Node> nodes = createNodes(20);
+        when(assessor.isIncluded(any(Node.class))).thenReturn(true);
+        when(assessor.isIncluded(nodes.get(0))).thenReturn(false);
+        when(assessor.isIncluded(nodes.get(1))).thenReturn(false);
+        when(assessor.isIncluded(nodes.get(2))).thenReturn(false);
+        prepareTemplate(dbQuery, nodes);
+        
+        FilteringResultSet result = engine.acceleratedNodeSelection(options, dbQuery, assessor);
+        
+        assertEquals(6, result.length());
+        assertNodePresent(3, result);
+        assertNodePresent(4, result);
+        assertNodePresent(5, result);
+        assertNodePresent(6, result);
+        assertNodePresent(7, result);
+    }
+    
+    @Test
+    public void shouldAccessibleNodesBeSkippedWhenSkipCountIsUsed()
+    {
+        withMaxItems(2);
+        withSkipCount(2);
+        List<Node> nodes = createNodes(6);
+        when(assessor.isIncluded(any(Node.class))).thenReturn(true);
+        when(assessor.isIncluded(nodes.get(2))).thenReturn(false);
+        when(assessor.isIncluded(nodes.get(3))).thenReturn(false);
+        prepareTemplate(dbQuery, nodes);
+        
+        FilteringResultSet result = engine.acceleratedNodeSelection(options, dbQuery, assessor);
+        
+        assertEquals(2, result.length());
+        assertNodePresent(4, result);
+        assertNodePresent(5, result);
+    }
+    
+    @Test
+    public void shouldQuitCheckingNodePermissionsWhenImposedLimitsAreReached()
+    {
+        prepareTemplate(dbQuery, createNodes(20));
+        when(assessor.shouldQuitChecks()).thenReturn(true);
+        
+        FilteringResultSet result = engine.acceleratedNodeSelection(options, dbQuery, assessor);
+        
+        assertEquals(0, result.length());
+        verify(resultContext).stop();
+    }
+    
+    @Test
+    public void shouldNodePermissionAssessorLimitisBeOverridenWhenSetValuesAreProvidedInQueryOptions()
+    {
+        when(options.getMaxPermissionChecks()).thenReturn(2000);
+        when(options.getMaxPermissionCheckTimeMillis()).thenReturn(20000L);
+        
+        NodePermissionAssessor assessor = engine.createAssessor(options);
+        
+        assertEquals(assessor.getMaxPermissionChecks(), 2000);
+        assertEquals(assessor.getMaxPermissionCheckTimeMillis(), 20000L);
+    }
+        
+    private void prepareTemplate(DBQuery dbQuery, List<Node> nodes)
+    {
+        doAnswer(invocation -> {
+            ResultHandler<Node> handler = (ResultHandler<Node>)invocation.getArgument(2);
+            for (Node node: nodes)
+            {
+                if (!resultContext.isStopped())
+                {
+                    when(resultContext.getResultObject()).thenReturn(node);
+                    handler.handleResult(resultContext);
+                }
+            }
+            return null;
+            
+        }).when(template).select(eq(SQL_TEMPLATE_PATH), eq(dbQuery), any());
+    }
+    
+    private QueryOptions createQueryOptions()
+    {
+        QueryOptions options = mock(QueryOptions.class);
+        SearchParameters searchParams = mock(SearchParameters.class);
+        when(options.getAsSearchParmeters()).thenReturn(searchParams);
+        return options;
+    }
+    
+    private void assertNodePresent(long id, FilteringResultSet result)
+    {
+        DBResultSet rs = (DBResultSet)result.getUnFilteredResultSet();
+        for(int i = 0; i < rs.length(); i++)
+        {
+            if(rs.getNode(i).getId().equals(id))
+            {
+                return;
+            }
+        }
+        fail("Node with id " + id + " was not found in the result set");
+    }
+
+    private void withMaxItems(int maxItems)
+    {
+        when(options.getMaxItems()).thenReturn(maxItems);
+    }
+    
+    private void withSkipCount(int skipCount)
+    {
+        when(options.getSkipCount()).thenReturn(skipCount);
+    }
+    
+    private List<Node> createNodes(int amount)
+    {
+        List<Node> nodes = new ArrayList<>();
+        
+        for(int i = 0; i < amount; i++)
+        {
+            nodes.add(createNode(i));
+        }
+        
+        return nodes;
+    }
+    
+    private Node createNode(int id) 
+    {
+        Node node = spy(NodeEntity.class);
+        when(node.getId()).thenReturn((long)id);
+        return node;
+    }
+    
+}

--- a/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
+++ b/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
@@ -1,3 +1,28 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
+ * provided under the following open source license terms:
+ * 
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
 package org.alfresco.repo.search.impl.querymodel.impl.db;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
+++ b/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
@@ -83,7 +83,7 @@ public class DBQueryEngineTest
     }
     
     @Test
-    public void shoulGetAFilteringResultSetFromAcceleratedNodeSelection()
+    public void shouldGetAFilteringResultSetFromAcceleratedNodeSelection()
     {
         withMaxItems(10);
 

--- a/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
+++ b/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
@@ -58,7 +58,7 @@ public class DBQueryEngineTest
     }
     
     @Test
-    public void shoulGetAFilteringResultSetFromDenormalisedNodeSelection()
+    public void shoulGetAFilteringResultSetFromAcceleratedNodeSelection()
     {
         withMaxItems(10);
 
@@ -116,7 +116,7 @@ public class DBQueryEngineTest
     }
     
     @Test
-    public void shouldResultSetHaveCorrectAmountOfRequiredNodesWhenSomeAreExcludedDueToDeclinedPermission()
+    public void shouldNotConsiderInaccessibleNodesInResultSet()
     {
         withMaxItems(5);
         List<Node> nodes = createNodes(20);
@@ -137,7 +137,7 @@ public class DBQueryEngineTest
     }
     
     @Test
-    public void shouldAccessibleNodesBeSkippedWhenSkipCountIsUsed()
+    public void shouldNotConsiderInaccessibleNodesInResultSetWhenSkippingNodes()
     {
         withMaxItems(2);
         withSkipCount(2);

--- a/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/NodePermissionAssessorTest.java
+++ b/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/NodePermissionAssessorTest.java
@@ -1,3 +1,28 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
+ * provided under the following open source license terms:
+ * 
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
 package org.alfresco.repo.search.impl.querymodel.impl.db;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/NodePermissionAssessorTest.java
+++ b/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/NodePermissionAssessorTest.java
@@ -1,0 +1,86 @@
+package org.alfresco.repo.search.impl.querymodel.impl.db;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+import org.alfresco.repo.domain.node.Node;
+import org.alfresco.repo.search.impl.querymodel.impl.db.DBQueryEngine.NodePermissionAssessor;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NodePermissionAssessorTest
+{
+    private NodePermissionAssessor assessor;
+    private Node node;
+    
+    @Before
+    public void setup()
+    {
+        node = mock(Node.class);
+        assessor = createAssessor();
+    }
+    
+    @Test
+    public void shouldNotQuitAssessingPermissionsWhenMaxPermissionChecksLimitIsNotReached()
+    {
+        assessor.setMaxPermissionChecks(5);
+        
+        performChecks(3);
+        
+        assertFalse(assessor.shouldQuitChecks());
+        verify(assessor, times(3)).isReallyIncluded(node);
+    }
+    
+    @Test
+    public void shouldQuitAssessingPermissionsWhenMaxPermissionChecksLimitIsReached()
+    {
+        assessor.setMaxPermissionChecks(5);
+        
+        performChecks(20);
+        
+        assertTrue(assessor.shouldQuitChecks());
+        verify(assessor, times(5)).isReallyIncluded(node);
+    }
+    
+    @Test
+    public void shouldNotAssessPermissionsWhenMaxPermissionCheckTimeIsUp() throws Exception 
+    {
+        assessor.setMaxPermissionCheckTimeMillis(100);
+        
+        assessor.isIncluded(node);
+        Thread.sleep(200);
+        
+        assertTrue(assessor.shouldQuitChecks());
+        verify(assessor).isReallyIncluded(node);
+        
+    }
+    
+    @Test
+    public void shouldAssessPermissionsWhenMaxPermissionCheckTimeIsNotUp() throws Exception 
+    {
+        assessor.setMaxPermissionCheckTimeMillis(500);
+        Thread.sleep(200);
+        
+        assessor.isIncluded(node);
+        
+        assertFalse(assessor.shouldQuitChecks());
+        verify(assessor, atLeastOnce()).isReallyIncluded(node);
+        
+    }
+
+    private void performChecks(int checks)
+    {
+        for (int i=0; i < checks; i++)
+        {
+            assessor.isIncluded(node);
+        }
+    }
+    
+    private NodePermissionAssessor createAssessor()
+    {
+        NodePermissionAssessor assessor = spy(new DBQueryEngine().new NodePermissionAssessor());
+        doReturn(true).when(assessor).isReallyIncluded(any(Node.class));
+        return assessor;
+    }
+}


### PR DESCRIPTION
In this PR, ACLs resolution and paging are implemented inside the `DbQueryEngine` class allowing to achieve the latter faster than in the standard implementation and allowing to only load data that is necessary resolve the requested page. See also the [companion PR on enterprise](https://github.com/Alfresco/alfresco-enterprise-repository/pull/525).